### PR TITLE
[BugFix] Stop fetching after the plan receives an error

### DIFF
--- a/lib/blocs/home_page_cubit.dart
+++ b/lib/blocs/home_page_cubit.dart
@@ -148,6 +148,7 @@ class HomePageCubit extends Cubit<MapRouteState> {
         if (plan == null) {
           throw "Canceled by user";
         } else if (plan.hasError) {
+          updateMapRouteState(state.copyWith(isFetching: false));
           if (car) {
             showDialog(
               context: context,


### PR DESCRIPTION
After the error occurs, the fetching stops and the loading spinner is not visible anymore.

Resolves #425 

Currently, this part is not testable until we clean up the fetch function in the HomePageCubit.