### PR TITLE
fix show emptyMap

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -237,7 +237,7 @@ class HomePageState extends State<HomePage>
     final cfg = TrufiConfiguration();
     final homePageState = context.read<HomePageCubit>().state;
     final Widget body = Container(
-      child: homePageState.plan != null && homePageState.plan.error == null
+      child: !homePageState.isFetching && homePageState.plan != null && homePageState.plan.error == null
           ? PlanPage(
               homePageState.plan,
               homePageState.ad,


### PR DESCRIPTION
We need to show the EmptyMap, but the cubit state does not allow us to have the plan in null. 

Edit: The first time "Plan" is null, but once it is given a value, it can no longer be null