### PR TITLE
Fix/translations

### DIFF
--- a/lib/l10n/trufi_localization.dart
+++ b/lib/l10n/trufi_localization.dart
@@ -945,6 +945,12 @@ abstract class TrufiLocalization {
   /// **'Bike'**
   String get settingPanelMyModesTransportBike;
 
+  /// Bike and Ride configuration panel label
+  ///
+  /// In en, this message translates to:
+  /// **'Bike and Ride'**
+  String get settingPanelMyModesTransportBikeRide;
+
   /// Park and Ride configuration panel label
   ///
   /// In en, this message translates to:
@@ -1020,7 +1026,7 @@ abstract class TrufiLocalization {
   /// Average speed type
   ///
   /// In en, this message translates to:
-  /// **'Average'**
+  /// **'Normal'**
   String get typeSpeedAverage;
 
   /// Calm speed type

--- a/lib/l10n/trufi_localization_de.dart
+++ b/lib/l10n/trufi_localization_de.dart
@@ -447,7 +447,10 @@ class TrufiLocalizationDe extends TrufiLocalization {
   String get settingPanelMyModesTransportBike => 'Fahrrad';
 
   @override
-  String get settingPanelMyModesTransportParkRide => 'Park and Ride';
+  String get settingPanelMyModesTransportBikeRide => 'Bike & Ride';
+
+  @override
+  String get settingPanelMyModesTransportParkRide => 'Park & Ride';
 
   @override
   String get settingPanelTransportModes => 'Verkehrsmittel auswählen';
@@ -495,19 +498,19 @@ class TrufiLocalizationDe extends TrufiLocalization {
   String get title => 'Trufi App';
 
   @override
-  String get typeSpeedAverage => 'Standard';
+  String get typeSpeedAverage => 'Normal';
 
   @override
   String get typeSpeedCalm => 'Weniger';
 
   @override
-  String get typeSpeedFast => 'Am meisten';
+  String get typeSpeedFast => 'Schnell';
 
   @override
   String get typeSpeedPrompt => 'Mehr';
 
   @override
-  String get typeSpeedSlow => 'Am wenigsten';
+  String get typeSpeedSlow => 'Langsam';
 
   @override
   String version(Object version) {

--- a/lib/l10n/trufi_localization_ee.dart
+++ b/lib/l10n/trufi_localization_ee.dart
@@ -447,6 +447,9 @@ class TrufiLocalizationEe extends TrufiLocalization {
   String get settingPanelMyModesTransportBike => 'Bike';
 
   @override
+  String get settingPanelMyModesTransportBikeRide => 'Park and Ride';
+
+  @override
   String get settingPanelMyModesTransportParkRide => 'Park and Ride';
 
   @override

--- a/lib/l10n/trufi_localization_en.dart
+++ b/lib/l10n/trufi_localization_en.dart
@@ -447,6 +447,9 @@ class TrufiLocalizationEn extends TrufiLocalization {
   String get settingPanelMyModesTransportBike => 'Bike';
 
   @override
+  String get settingPanelMyModesTransportBikeRide => 'Bike and Ride';
+
+  @override
   String get settingPanelMyModesTransportParkRide => 'Park and Ride';
 
   @override
@@ -495,7 +498,7 @@ class TrufiLocalizationEn extends TrufiLocalization {
   String get title => 'Trufi App';
 
   @override
-  String get typeSpeedAverage => 'Average';
+  String get typeSpeedAverage => 'Normal';
 
   @override
   String get typeSpeedCalm => 'Calm';

--- a/lib/l10n/trufi_localization_es.dart
+++ b/lib/l10n/trufi_localization_es.dart
@@ -447,6 +447,9 @@ class TrufiLocalizationEs extends TrufiLocalization {
   String get settingPanelMyModesTransportBike => 'Bike';
 
   @override
+  String get settingPanelMyModesTransportBikeRide => 'Park and Ride';
+
+  @override
   String get settingPanelMyModesTransportParkRide => 'Park and Ride';
 
   @override

--- a/lib/l10n/trufi_localization_fr.dart
+++ b/lib/l10n/trufi_localization_fr.dart
@@ -447,6 +447,9 @@ class TrufiLocalizationFr extends TrufiLocalization {
   String get settingPanelMyModesTransportBike => 'Bike';
 
   @override
+  String get settingPanelMyModesTransportBikeRide => 'Park and Ride';
+
+  @override
   String get settingPanelMyModesTransportParkRide => 'Park and Ride';
 
   @override

--- a/lib/l10n/trufi_localization_it.dart
+++ b/lib/l10n/trufi_localization_it.dart
@@ -447,6 +447,9 @@ class TrufiLocalizationIt extends TrufiLocalization {
   String get settingPanelMyModesTransportBike => 'Bike';
 
   @override
+  String get settingPanelMyModesTransportBikeRide => 'Park and Ride';
+
+  @override
   String get settingPanelMyModesTransportParkRide => 'Park and Ride';
 
   @override

--- a/lib/l10n/trufi_localization_pt.dart
+++ b/lib/l10n/trufi_localization_pt.dart
@@ -447,6 +447,9 @@ class TrufiLocalizationPt extends TrufiLocalization {
   String get settingPanelMyModesTransportBike => 'Bike';
 
   @override
+  String get settingPanelMyModesTransportBikeRide => 'Park and Ride';
+
+  @override
   String get settingPanelMyModesTransportParkRide => 'Park and Ride';
 
   @override

--- a/lib/l10n/trufi_localization_qu.dart
+++ b/lib/l10n/trufi_localization_qu.dart
@@ -447,6 +447,9 @@ class TrufiLocalizationQu extends TrufiLocalization {
   String get settingPanelMyModesTransportBike => 'Bike';
 
   @override
+  String get settingPanelMyModesTransportBikeRide => 'Park and Ride';
+
+  @override
   String get settingPanelMyModesTransportParkRide => 'Park and Ride';
 
   @override

--- a/lib/models/enums/enums_plan/walking_speed.dart
+++ b/lib/models/enums/enums_plan/walking_speed.dart
@@ -1,6 +1,6 @@
 part of 'enums_plan.dart';
 
-enum WalkingSpeed { slow, calm, average, prompt, fast }
+enum WalkingSpeed { slow, average, fast }
 
 WalkingSpeed getWalkingSpeed(String key) {
   return WalkingSpeedExtension.names.keys.firstWhere(
@@ -11,34 +11,33 @@ WalkingSpeed getWalkingSpeed(String key) {
 
 extension WalkingSpeedExtension on WalkingSpeed {
   static const values = <WalkingSpeed, double>{
-    WalkingSpeed.slow: 0.69,
-    WalkingSpeed.calm: 0.97,
-    WalkingSpeed.average: 1.2,
-    WalkingSpeed.prompt: 1.67,
-    WalkingSpeed.fast: 2.22,
+    WalkingSpeed.slow: 0.83,
+    WalkingSpeed.average: 1.38,
+    WalkingSpeed.fast: 1.94444,
   };
   static const names = <WalkingSpeed, String>{
-    WalkingSpeed.slow: "slow",
-    WalkingSpeed.calm: "calm",
-    WalkingSpeed.average: "average",
-    WalkingSpeed.prompt: "prompt",
-    WalkingSpeed.fast: "fast",
+    WalkingSpeed.slow: 'slow',
+    WalkingSpeed.average: 'average',
+    WalkingSpeed.fast: 'fast',
   };
+
+  static const speeds = <WalkingSpeed, String>{
+    WalkingSpeed.slow: '3 km/h',
+    WalkingSpeed.average: '5 km/h',
+    WalkingSpeed.fast: '7 km/h',
+  };
+
+  String get name => names[this];
+  String get speed => speeds[this] ?? 'noSpeed';
   double get value => values[this] ?? 1.2;
-  String get name => names[this] ?? "slow";
+
   String translateValue(TrufiLocalization localization) {
     switch (this) {
       case WalkingSpeed.slow:
         return localization.typeSpeedSlow;
         break;
-      case WalkingSpeed.calm:
-        return localization.typeSpeedCalm;
-        break;
       case WalkingSpeed.average:
         return localization.typeSpeedAverage;
-        break;
-      case WalkingSpeed.prompt:
-        return localization.typeSpeedPrompt;
         break;
       case WalkingSpeed.fast:
         return localization.typeSpeedFast;

--- a/lib/pages/home/setting_payload/setting_panel/setting_panel.dart
+++ b/lib/pages/home/setting_payload/setting_panel/setting_panel.dart
@@ -4,8 +4,8 @@ import 'package:trufi_core/blocs/payload_data_plan/payload_data_plan_cubit.dart'
 import 'package:trufi_core/l10n/trufi_localization.dart';
 import 'package:trufi_core/models/enums/enums_plan/enums_plan.dart';
 import 'package:trufi_core/models/enums/enums_plan/icons/other_icons.dart';
-import 'package:trufi_core/widgets/custom_expanded_tile.dart';
 import 'package:trufi_core/widgets/custom_switch_tile.dart';
+import 'package:trufi_core/widgets/speed_expanded_tile.dart';
 
 class SettingPanel extends StatelessWidget {
   static const String route = "/setting-panel";
@@ -37,11 +37,12 @@ class SettingPanel extends StatelessWidget {
                 const SizedBox(
                   height: 10,
                 ),
-                CustomExpansionTile(
+                SpeedExpansionTile(
                   title: localization.settingPanelWalkingSpeed,
-                  options: WalkingSpeed.values
+                  dataSpeeds: WalkingSpeed.values
                       .map(
-                        (e) => e.translateValue(localization),
+                        (e) =>
+                            DataSpeed(e.translateValue(localization), e.speed),
                       )
                       .toList(),
                   textSelected:
@@ -231,11 +232,12 @@ class SettingPanel extends StatelessWidget {
                     margin: const EdgeInsets.only(
                       left: 55,
                     ),
-                    child: CustomExpansionTile(
+                    child: SpeedExpansionTile(
                       title: localization.settingPanelBikingSpeed,
-                      options: BikingSpeed.values
+                      dataSpeeds: BikingSpeed.values
                           .map(
-                            (e) => e.translateValue(localization),
+                            (e) =>
+                                DataSpeed(e.translateValue(localization), ''),
                           )
                           .toList(),
                       textSelected:

--- a/lib/pages/home/setting_payload/setting_panel/setting_panel.dart
+++ b/lib/pages/home/setting_payload/setting_panel/setting_panel.dart
@@ -32,47 +32,50 @@ class SettingPanel extends StatelessWidget {
       body: SafeArea(
         child: BlocBuilder<PayloadDataPlanCubit, PayloadDataPlanState>(
           builder: (blocContext, state) {
-            return ListView(
-              children: <Widget>[
-                const SizedBox(
-                  height: 10,
-                ),
-                SpeedExpansionTile(
-                  title: localization.settingPanelWalkingSpeed,
-                  dataSpeeds: WalkingSpeed.values
-                      .map(
-                        (e) =>
-                            DataSpeed(e.translateValue(localization), e.speed),
-                      )
-                      .toList(),
-                  textSelected:
-                      state.typeWalkingSpeed.translateValue(localization),
-                  onChanged: (value) {
-                    final WalkingSpeed selected = WalkingSpeed.values
-                        .firstWhere((element) =>
-                            element.translateValue(localization) == value);
-                    payloadDataPlanCubit.setWalkingSpeed(selected);
-                  },
-                ),
-                _divider,
-                CustomSwitchTile(
-                  title: localization.settingPanelAvoidWalking,
-                  value: state.avoidWalking,
-                  onChanged: (value) =>
-                      payloadDataPlanCubit.setAvoidWalking(avoidWalking: value),
-                ),
-                _dividerWeight,
-                Container(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Text(
-                    localization.settingPanelTransportModes,
-                    style: theme.textTheme.bodyText1,
+            return Scrollbar(
+              child: ListView(
+                children: <Widget>[
+                  const SizedBox(
+                    height: 10,
                   ),
-                  CustomExpansionTile(
+                  SpeedExpansionTile(
                     title: localization.settingPanelWalkingSpeed,
-                    options: WalkingSpeed.values
+                    dataSpeeds: WalkingSpeed.values
                         .map(
-                          (e) => e.translateValue(localization),
+                          (e) => DataSpeed(
+                              e.translateValue(localization), e.speed),
+                        )
+                        .toList(),
+                    textSelected:
+                        state.typeWalkingSpeed.translateValue(localization),
+                    onChanged: (value) {
+                      final WalkingSpeed selected = WalkingSpeed.values
+                          .firstWhere((element) =>
+                              element.translateValue(localization) == value);
+                      payloadDataPlanCubit.setWalkingSpeed(selected);
+                    },
+                  ),
+                  _divider,
+                  CustomSwitchTile(
+                    title: localization.settingPanelAvoidWalking,
+                    value: state.avoidWalking,
+                    onChanged: (value) => payloadDataPlanCubit.setAvoidWalking(
+                        avoidWalking: value),
+                  ),
+                  _dividerWeight,
+                  Container(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(
+                      localization.settingPanelTransportModes,
+                      style: theme.textTheme.bodyText1,
+                    ),
+                  ),
+                  SpeedExpansionTile(
+                    title: localization.settingPanelWalkingSpeed,
+                    dataSpeeds: WalkingSpeed.values
+                        .map(
+                          (e) => DataSpeed(
+                              e.translateValue(localization), e.speed),
                         )
                         .toList(),
                     textSelected:
@@ -256,26 +259,25 @@ class SettingPanel extends StatelessWidget {
                       width: 35,
                       child: bikeSvg(),
                     ),
-                    child: SpeedExpansionTile(
-                      title: localization.settingPanelBikingSpeed,
-                      dataSpeeds: BikingSpeed.values
-                          .map(
-                            (e) =>
-                                DataSpeed(e.translateValue(localization), ''),
-                          )
-                          .toList(),
-                      textSelected:
-                          state.typeBikingSpeed.translateValue(localization),
-                      onChanged: (value) {
-                        final BikingSpeed selected = BikingSpeed.values
-                            .firstWhere((element) =>
-                                element.translateValue(localization) == value);
-                        payloadDataPlanCubit.setBikingSpeed(selected);
-                      },
-                    ),
                     value: state.includeParkAndRideSuggestions,
                     onChanged: (value) =>
                         payloadDataPlanCubit.setParkRide(parkRide: value),
+                  ),
+                  SpeedExpansionTile(
+                    title: localization.settingPanelBikingSpeed,
+                    dataSpeeds: BikingSpeed.values
+                        .map(
+                          (e) => DataSpeed(e.translateValue(localization), ''),
+                        )
+                        .toList(),
+                    textSelected:
+                        state.typeBikingSpeed.translateValue(localization),
+                    onChanged: (value) {
+                      final BikingSpeed selected = BikingSpeed.values
+                          .firstWhere((element) =>
+                              element.translateValue(localization) == value);
+                      payloadDataPlanCubit.setBikingSpeed(selected);
+                    },
                   ),
                   CustomSwitchTile(
                     title: localization.instructionVehicleCar,

--- a/lib/pages/home/transport_selector/transport_selector.dart
+++ b/lib/pages/home/transport_selector/transport_selector.dart
@@ -64,7 +64,7 @@ class TransportSelector extends StatelessWidget {
               onTap: () async {
                 await Navigator.of(context).push(MaterialPageRoute(
                   builder: (BuildContext context) => ModeTransportScreen(
-                    title: localization.settingPanelMyModesTransportBike,
+                    title: localization.settingPanelMyModesTransportBikeRide,
                     plan: modesTransport.bikeAndVehicle,
                   ),
                 ));

--- a/lib/widgets/speed_expanded_tile.dart
+++ b/lib/widgets/speed_expanded_tile.dart
@@ -1,16 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
-class CustomExpansionTile extends StatelessWidget {
+class SpeedExpansionTile extends StatelessWidget {
   final String title;
-  final List<String> options;
+  final List<DataSpeed> dataSpeeds;
   final String textSelected;
   final Function(String) onChanged;
 
-  const CustomExpansionTile({
+  const SpeedExpansionTile({
     Key key,
     @required this.title,
-    @required this.options,
+    @required this.dataSpeeds,
     @required this.textSelected,
     @required this.onChanged,
   }) : super(key: key);
@@ -31,28 +31,44 @@ class CustomExpansionTile extends StatelessWidget {
           ),
         ],
       ),
-      children: options
+      children: dataSpeeds
           .map(
-            (option) => Container(
+            (dataSpeed) => Container(
               margin:
                   const EdgeInsets.symmetric(horizontal: 20.0, vertical: 4.0),
               child: ListTile(
                 tileColor: theme.textTheme.bodyText1.color.withOpacity(0.05),
                 visualDensity: VisualDensity.compact,
                 title: Text(
-                  option,
+                  dataSpeed.name,
                   style: TextStyle(
                     color: theme.primaryColor,
                   ),
                 ),
-                trailing: option.toLowerCase() == textSelected.toLowerCase()
-                    ? Icon(
-                        Icons.check,
-                        color: theme.accentColor,
-                      )
-                    : null,
+                trailing: SizedBox(
+                  width: 100,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        dataSpeed.speed,
+                        style: TextStyle(
+                          color: Colors.grey[600],
+                        ),
+                      ),
+                      if (dataSpeed.name.toLowerCase() ==
+                          textSelected.toLowerCase())
+                        Icon(
+                          Icons.check,
+                          color: theme.accentColor,
+                        )
+                      else
+                        Container(width: 15),
+                    ],
+                  ),
+                ),
                 onTap: () {
-                  onChanged(option);
+                  onChanged(dataSpeed.name);
                 },
               ),
             ),
@@ -60,4 +76,11 @@ class CustomExpansionTile extends StatelessWidget {
           .toList(),
     );
   }
+}
+
+class DataSpeed {
+  final String name;
+  final String speed;
+
+  DataSpeed(this.name, this.speed);
 }

--- a/translations/trufiapp_de.arb
+++ b/translations/trufiapp_de.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "de",
-    "@@last_modified": "2021-06-12T03:00:56+02:00",
+    "@@last_modified": "2021-06-15T13:19:49+02:00",
     "aboutContent": "Wir sind ein bolivianisches und internationales Team, das den öffentlichen Nahverkehr liebt und unterstützen möchte. Wir haben diese App entwickelt, um den Menschen die Verwendung des öffentlichen Nahverkehrs in Cochabamba und der näheren Umgebung zu erleichtern.",
     "@aboutContent": {
         "description": "Text displayed on the about page"
@@ -611,7 +611,11 @@
     "@settingPanelMyModesTransportBike": {
         "description": "Bike configuration panel label"
     },
-    "settingPanelMyModesTransportParkRide": "Park and Ride",
+    "settingPanelMyModesTransportBikeRide": "Bike & Ride",
+    "@settingPanelMyModesTransportBikeRide": {
+        "description": "Bike and Ride configuration panel label"
+    },
+    "settingPanelMyModesTransportParkRide": "Park & Ride",
     "@settingPanelMyModesTransportParkRide": {
         "description": "Park and Ride configuration panel label"
     },
@@ -698,7 +702,7 @@
     "@title": {
         "description": "The application's name"
     },
-    "typeSpeedAverage": "Standard",
+    "typeSpeedAverage": "Normal",
     "@typeSpeedAverage": {
         "description": "Average speed type"
     },
@@ -706,7 +710,7 @@
     "@typeSpeedCalm": {
         "description": "Calm speed type"
     },
-    "typeSpeedFast": "Am meisten",
+    "typeSpeedFast": "Schnell",
     "@typeSpeedFast": {
         "description": "Fast speed type"
     },
@@ -714,7 +718,7 @@
     "@typeSpeedPrompt": {
         "description": "Prompt speed type"
     },
-    "typeSpeedSlow": "Am wenigsten",
+    "typeSpeedSlow": "Langsam",
     "@typeSpeedSlow": {
         "description": "Slow speed type"
     },

--- a/translations/trufiapp_ee.arb
+++ b/translations/trufiapp_ee.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "ee",
-    "@@last_modified": "2021-06-12T03:00:56+02:00",
+    "@@last_modified": "2021-06-15T13:19:49+02:00",
     "aboutContent": "mitso Bolivia kple dukorvovome eye morlor hahomorzozor. mido dorworfea be morzorzor nanor  borboe na Cochabamba kple efe gologuiawo.",
     "@aboutContent": {
         "description": "Text displayed on the about page"
@@ -610,6 +610,10 @@
     "settingPanelMyModesTransportBike": "Bike",
     "@settingPanelMyModesTransportBike": {
         "description": "Bike configuration panel label"
+    },
+    "settingPanelMyModesTransportBikeRide": "Park and Ride",
+    "@settingPanelMyModesTransportBikeRide": {
+        "description": "Bike and Ride configuration panel label"
     },
     "settingPanelMyModesTransportParkRide": "Park and Ride",
     "@settingPanelMyModesTransportParkRide": {

--- a/translations/trufiapp_en.arb
+++ b/translations/trufiapp_en.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "en",
-    "@@last_modified": "2021-06-12T03:00:56+02:00",
+    "@@last_modified": "2021-06-15T13:19:49+02:00",
     "aboutContent": "We are a Bolivian and international team of people that love and support public transport. We have developed this app to make it easy for people to use the transport system in Cochabamba and the surrounding area.",
     "@aboutContent": {
         "description": "Text displayed on the about page"
@@ -611,6 +611,10 @@
     "@settingPanelMyModesTransportBike": {
         "description": "Bike configuration panel label"
     },
+    "settingPanelMyModesTransportBikeRide": "Bike and Ride",
+    "@settingPanelMyModesTransportBikeRide": {
+        "description": "Bike and Ride configuration panel label"
+    },
     "settingPanelMyModesTransportParkRide": "Park and Ride",
     "@settingPanelMyModesTransportParkRide": {
         "description": "Park and Ride configuration panel label"
@@ -698,7 +702,7 @@
     "@title": {
         "description": "The application's name"
     },
-    "typeSpeedAverage": "Average",
+    "typeSpeedAverage": "Normal",
     "@typeSpeedAverage": {
         "description": "Average speed type"
     },

--- a/translations/trufiapp_es.arb
+++ b/translations/trufiapp_es.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "es",
-    "@@last_modified": "2021-06-12T03:00:56+02:00",
+    "@@last_modified": "2021-06-15T13:19:49+02:00",
     "aboutContent": "Somos un equipo boliviano e internacional de personas que amamos y apoyamos el transporte público. Desarrollamos esta aplicación para facilitar el uso del transporte en la región de Cochabamba.",
     "@aboutContent": {
         "description": "Text displayed on the about page"
@@ -610,6 +610,10 @@
     "settingPanelMyModesTransportBike": "Bike",
     "@settingPanelMyModesTransportBike": {
         "description": "Bike configuration panel label"
+    },
+    "settingPanelMyModesTransportBikeRide": "Park and Ride",
+    "@settingPanelMyModesTransportBikeRide": {
+        "description": "Bike and Ride configuration panel label"
     },
     "settingPanelMyModesTransportParkRide": "Park and Ride",
     "@settingPanelMyModesTransportParkRide": {

--- a/translations/trufiapp_fr.arb
+++ b/translations/trufiapp_fr.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "fr",
-    "@@last_modified": "2021-06-12T03:00:56+02:00",
+    "@@last_modified": "2021-06-15T13:19:49+02:00",
     "aboutContent": "Nous sommes une équipe bolivienne et internationale de personnes qui aiment et soutiennent les transports en commun. Nous avons développé cette application pour faciliter l'utilisation du système de transport en commun à Cochabamba et dans les environs.",
     "@aboutContent": {
         "description": "Text displayed on the about page"
@@ -610,6 +610,10 @@
     "settingPanelMyModesTransportBike": "Bike",
     "@settingPanelMyModesTransportBike": {
         "description": "Bike configuration panel label"
+    },
+    "settingPanelMyModesTransportBikeRide": "Park and Ride",
+    "@settingPanelMyModesTransportBikeRide": {
+        "description": "Bike and Ride configuration panel label"
     },
     "settingPanelMyModesTransportParkRide": "Park and Ride",
     "@settingPanelMyModesTransportParkRide": {

--- a/translations/trufiapp_it.arb
+++ b/translations/trufiapp_it.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "it",
-    "@@last_modified": "2021-06-12T03:00:56+02:00",
+    "@@last_modified": "2021-06-15T13:19:49+02:00",
     "aboutContent": "Siamo un team boliviano e internazionale di persone che amano e supportano il trasporto pubblico. Abbiamo sviluppato questa app per semplificare l'uso dei trasporti pubblici a Cochabamba e nelle aree circostanti.",
     "@aboutContent": {
         "description": "Text displayed on the about page"
@@ -610,6 +610,10 @@
     "settingPanelMyModesTransportBike": "Bike",
     "@settingPanelMyModesTransportBike": {
         "description": "Bike configuration panel label"
+    },
+    "settingPanelMyModesTransportBikeRide": "Park and Ride",
+    "@settingPanelMyModesTransportBikeRide": {
+        "description": "Bike and Ride configuration panel label"
     },
     "settingPanelMyModesTransportParkRide": "Park and Ride",
     "@settingPanelMyModesTransportParkRide": {

--- a/translations/trufiapp_pt.arb
+++ b/translations/trufiapp_pt.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "pt",
-    "@@last_modified": "2021-06-12T03:00:56+02:00",
+    "@@last_modified": "2021-06-15T13:19:49+02:00",
     "aboutContent": "Somos uma equipe boliviana e internacional de pessoas que amam e apoiam o transporte público.\n\nNós desenvolvemos este aplicativo para facilitar o uso do sistema de transporte em Cochabamba e arredores.",
     "@aboutContent": {
         "description": "Text displayed on the about page"
@@ -610,6 +610,10 @@
     "settingPanelMyModesTransportBike": "Bike",
     "@settingPanelMyModesTransportBike": {
         "description": "Bike configuration panel label"
+    },
+    "settingPanelMyModesTransportBikeRide": "Park and Ride",
+    "@settingPanelMyModesTransportBikeRide": {
+        "description": "Bike and Ride configuration panel label"
     },
     "settingPanelMyModesTransportParkRide": "Park and Ride",
     "@settingPanelMyModesTransportParkRide": {

--- a/translations/trufiapp_qu.arb
+++ b/translations/trufiapp_qu.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "qu",
-    "@@last_modified": "2021-06-12T03:00:56+02:00",
+    "@@last_modified": "2021-06-15T13:19:49+02:00",
     "aboutContent": "Bolivia suyumantapacha waq jawa suyukunawan jukchasqa kayku, munayku chanta kallpanchayku ima transporte publico ñisqata. Kay thatkichiy ruwasqa kachkan Qhuchapampa jap’iypi, ukhupi jawaman ima, aswan sasata ch’usanaykipaq.",
     "@aboutContent": {
         "description": "Text displayed on the about page"
@@ -610,6 +610,10 @@
     "settingPanelMyModesTransportBike": "Bike",
     "@settingPanelMyModesTransportBike": {
         "description": "Bike configuration panel label"
+    },
+    "settingPanelMyModesTransportBikeRide": "Park and Ride",
+    "@settingPanelMyModesTransportBikeRide": {
+        "description": "Bike and Ride configuration panel label"
     },
     "settingPanelMyModesTransportParkRide": "Park and Ride",
     "@settingPanelMyModesTransportParkRide": {


### PR DESCRIPTION
Resolve:

- Change the wording of the walking speeds in the itinerary settings #164
![Simulator Screen Shot - iPhone 11 Pro Max - 2021-06-15 at 13 43 14](https://user-images.githubusercontent.com/42806689/122047708-bbad5780-cde0-11eb-9aa0-0ac3c9d10bee.png)

- Bike & Ride Mode window is named "Fahrrad" #172
![Simulator Screen Shot - iPhone 11 Pro Max - 2021-06-15 at 13 52 18](https://user-images.githubusercontent.com/42806689/122047917-f7482180-cde0-11eb-985c-8c5c9b0dc75d.png)


- Translations in Park & Ride mode are missing #170

![Simulator Screen Shot - iPhone 11 Pro Max - 2021-06-15 at 13 53 05](https://user-images.githubusercontent.com/42806689/122047981-07f89780-cde1-11eb-83e9-ed50e7b8957e.png)
