### PR TITLE
Fix/walk stop separator

### DIFF
--- a/lib/blocs/home_page_cubit.dart
+++ b/lib/blocs/home_page_cubit.dart
@@ -229,6 +229,7 @@ class HomePageCubit extends Cubit<MapRouteState> {
                     correlationId: correlationId,
                     advancedOptions: advancedOptions
                         .copyWith(transportModes: [TransportMode.car]),
+                    localeName: localization.localeName,
                   )
                 : requestManager.fetchCarPlan(
                     state.fromPlace,
@@ -239,10 +240,12 @@ class HomePageCubit extends Cubit<MapRouteState> {
         : CancelableOperation.fromFuture(
             () {
               return requestManager.fetchAdvancedPlan(
-                  from: state.fromPlace,
-                  to: state.toPlace,
-                  correlationId: correlationId,
-                  advancedOptions: advancedOptions);
+                from: state.fromPlace,
+                to: state.toPlace,
+                correlationId: correlationId,
+                advancedOptions: advancedOptions,
+                localeName: localization.localeName,
+              );
             }(),
           );
     final PlanEntity plan = await currentFetchPlanOperation.valueOrCancellation(
@@ -278,7 +281,8 @@ class HomePageCubit extends Cubit<MapRouteState> {
             from: state.fromPlace,
             to: state.toPlace,
             correlationId: correlationId,
-            advancedOptions: advancedOptions);
+            advancedOptions: advancedOptions,
+            localeName: localization.localeName);
       }(),
     );
     final ModesTransportEntity plan =

--- a/lib/pages/home/plan_map/plan_itinerary_tabs/itinerary_details_expanded/leg_overview_advanced/leg_overview_advanced.dart
+++ b/lib/pages/home/plan_map/plan_itinerary_tabs/itinerary_details_expanded/leg_overview_advanced/leg_overview_advanced.dart
@@ -159,6 +159,7 @@ class _LegOverviewAdvancedState extends State<LegOverviewAdvanced> {
                       children: [
                         WalkDash(
                           leg: itineraryLeg,
+                          legBefore: compresedLegs[index - 1],
                         ),
                         if (itineraryLeg.endTime.millisecondsSinceEpoch <
                             compresedLegs[index + 1]

--- a/lib/pages/home/plan_map/plan_itinerary_tabs/itinerary_details_expanded/leg_overview_advanced/line_dash_components.dart
+++ b/lib/pages/home/plan_map/plan_itinerary_tabs/itinerary_details_expanded/leg_overview_advanced/line_dash_components.dart
@@ -104,16 +104,24 @@ class TransportDash extends StatelessWidget {
 
 class WalkDash extends StatelessWidget {
   final PlanItineraryLeg leg;
+  final PlanItineraryLeg legBefore;
   const WalkDash({
     Key key,
     @required this.leg,
+    this.legBefore,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     final localization = TrufiLocalization.of(context);
-    return Row(
+    return Column(
       children: [
+        if (legBefore != null && legBefore.transportMode == TransportMode.walk)
+          DashLinePlace(
+            date: leg.startTimeString.toString(),
+            location: leg.fromPlace.name,
+            color: Colors.grey,
+          ),
         SeparatorPlace(
           color: leg?.route?.color != null
               ? Color(int.tryParse("0xFF${leg.route.color}"))

--- a/lib/services/plan_request/online_graphql_repository/graphql_plan_repository.dart
+++ b/lib/services/plan_request/online_graphql_repository/graphql_plan_repository.dart
@@ -55,7 +55,7 @@ class GraphQLPlanRepository {
     @required TrufiLocation fromLocation,
     @required TrufiLocation toLocation,
     @required PayloadDataPlanState advancedOptions,
-    String locale,
+    @required String locale,
     bool defaultFecth = false,
   }) async {
     final transportsMode =
@@ -133,7 +133,7 @@ class GraphQLPlanRepository {
     @required TrufiLocation fromLocation,
     @required TrufiLocation toLocation,
     @required PayloadDataPlanState advancedOptions,
-    String locale,
+    @required String locale,
   }) async {
     final linearDistance =
         estimateDistance(fromLocation.latLng, toLocation.latLng);

--- a/lib/services/plan_request/online_graphql_repository/online_graphql_repository.dart
+++ b/lib/services/plan_request/online_graphql_repository/online_graphql_repository.dart
@@ -28,15 +28,16 @@ class OnlineGraphQLRepository implements RequestManager {
     @required TrufiLocation to,
     @required String correlationId,
     PayloadDataPlanState advancedOptions,
+    String localeName,
   }) async {
     if (advancedOptions == null) {
       return _fetchPlan(from, to, [TransportMode.transit, TransportMode.walk]);
     } else {
       return _fetchPlanAdvanced(
-        from: from,
-        to: to,
-        advancedOptions: advancedOptions,
-      );
+          from: from,
+          to: to,
+          advancedOptions: advancedOptions,
+          locale: localeName);
     }
   }
 
@@ -46,11 +47,13 @@ class OnlineGraphQLRepository implements RequestManager {
     TrufiLocation to,
     String correlationId,
     PayloadDataPlanState advancedOptions,
+    String localeName,
   }) {
     return _fetchTransportModePlan(
       from: from,
       to: to,
       advancedOptions: advancedOptions,
+      locale: localeName,
     );
   }
 
@@ -86,11 +89,13 @@ class OnlineGraphQLRepository implements RequestManager {
     @required TrufiLocation from,
     @required TrufiLocation to,
     @required PayloadDataPlanState advancedOptions,
+    @required String locale,
   }) async {
     Plan planData = await _graphQLPlanRepository.fetchPlanAdvanced(
       fromLocation: from,
       toLocation: to,
       advancedOptions: advancedOptions,
+      locale: locale,
     );
     planData = planData.copyWith(
       itineraries: planData.itineraries
@@ -106,6 +111,7 @@ class OnlineGraphQLRepository implements RequestManager {
         fromLocation: from,
         toLocation: to,
         advancedOptions: advancedOptions,
+        locale: locale,
         defaultFecth: true,
       );
     }
@@ -140,13 +146,14 @@ class OnlineGraphQLRepository implements RequestManager {
     @required TrufiLocation from,
     @required TrufiLocation to,
     @required PayloadDataPlanState advancedOptions,
+    @required String locale,
   }) async {
     final ModesTransport planEntityData =
         await _graphQLPlanRepository.fetchWalkBikePlanQuery(
-      fromLocation: from,
-      toLocation: to,
-      advancedOptions: advancedOptions,
-    );
+            fromLocation: from,
+            toLocation: to,
+            advancedOptions: advancedOptions,
+            locale: locale);
     return planEntityData.toModesTransport();
   }
 }

--- a/lib/services/plan_request/online_repository.dart
+++ b/lib/services/plan_request/online_repository.dart
@@ -28,6 +28,7 @@ class OnlineRepository implements RequestManager {
     @required TrufiLocation to,
     @required String correlationId,
     PayloadDataPlanState advancedOptions,
+    String localeName,
   }) {
     if (advancedOptions == null) {
       return _fetchPlan(from, to, "TRANSIT,WALK", correlationId);
@@ -171,6 +172,7 @@ class OnlineRepository implements RequestManager {
     TrufiLocation to,
     String correlationId,
     PayloadDataPlanState advancedOptions,
+    String localeName,
   }) {
     // TODO: implement fetchMytransportModePlan
     throw UnimplementedError();

--- a/lib/services/plan_request/request_manager.dart
+++ b/lib/services/plan_request/request_manager.dart
@@ -11,6 +11,7 @@ abstract class RequestManager {
     @required TrufiLocation to,
     @required String correlationId,
     PayloadDataPlanState advancedOptions,
+    String localeName,
   });
 
   Future<ModesTransportEntity> fetchTransportModePlan({
@@ -18,6 +19,7 @@ abstract class RequestManager {
     @required TrufiLocation to,
     @required String correlationId,
     PayloadDataPlanState advancedOptions,
+    String localeName,
   });
 
   Future<PlanEntity> fetchCarPlan(


### PR DESCRIPTION
@ahmed-nawar, resolved in https://github.com/trufi-association/trufi-core/pull/546

1) The P&R mode returns different result between IOS and Android: This point is explained in the https://github.com/stadtnavi/stadtnavi_app/issues/246

2) The first itinerary for Android P&R for this route returns multiple walking legs: The backend sends us the travel plan, so they send us multiple walks, but now we can show the separation of the multiple walks (as in the webApp)

![Simulator Screen Shot - iPhone 11 Pro Max - 2021-06-28 at 16 04 04](https://user-images.githubusercontent.com/42806689/123650802-350a6880-d82b-11eb-91d1-9532dddc144f.png)

![Screen Shot 2021-06-28 at 16 04 00](https://user-images.githubusercontent.com/42806689/123650812-376cc280-d82b-11eb-9215-804f14b1639d.png)