### PR TITLE
#604 Ensure Compatibility with Flutter v3 (TrufiMenuItem, Bump share_plus

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   async_executor:
     dependency: transitive
     description:
@@ -63,28 +63,21 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   crypto:
     dependency: transitive
     description:
@@ -161,7 +154,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -377,7 +370,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   latlong2:
     dependency: transitive
     description:
@@ -405,14 +398,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -496,7 +496,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   path_drawing:
     dependency: transitive
     description:
@@ -643,42 +643,42 @@ packages:
       name: share_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "4.0.10+1"
   share_plus_linux:
     dependency: transitive
     description:
       name: share_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "3.0.0"
   share_plus_macos:
     dependency: transitive
     description:
       name: share_plus_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.3"
   share_plus_web:
     dependency: transitive
     description:
       name: share_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "3.0.1"
   share_plus_windows:
     dependency: transitive
     description:
       name: share_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "3.0.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -690,7 +690,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   sqflite:
     dependency: transitive
     description:
@@ -725,7 +725,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   synchronized:
     dependency: transitive
     description:
@@ -739,14 +739,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.12"
   transparent_image:
     dependency: transitive
     description:
@@ -872,7 +872,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   web_socket_channel:
     dependency: transitive
     description:
@@ -909,5 +909,5 @@ packages:
     source: hosted
     version: "5.3.1"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.8.1"

--- a/lib/base/widgets/drawer/menu/default_item_menu.dart
+++ b/lib/base/widgets/drawer/menu/default_item_menu.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:trufi_core/base/blocs/localization/trufi_localization_cubit.dart';
 import 'package:trufi_core/base/blocs/theme/theme_cubit.dart';
 import 'package:trufi_core/base/translations/trufi_base_localizations.dart';
-import 'package:trufi_core/base/widgets/drawer/menu/menu_item.dart';
+import 'package:trufi_core/base/widgets/drawer/menu/trufi_menu_item.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class SimpleMenuItem extends MenuItem {
+class SimpleMenuItem extends TrufiMenuItem {
   SimpleMenuItem({
     required WidgetBuilder buildIcon,
     required WidgetBuilder name,

--- a/lib/base/widgets/drawer/menu/default_pages_menu.dart
+++ b/lib/base/widgets/drawer/menu/default_pages_menu.dart
@@ -9,9 +9,9 @@ import 'package:trufi_core/base/pages/saved_places/saved_places.dart';
 import 'package:trufi_core/base/pages/transport_list/transport_list.dart';
 import 'package:trufi_core/base/pages/saved_places/translations/saved_places_localizations.dart';
 import 'package:trufi_core/base/translations/trufi_base_localizations.dart';
-import 'package:trufi_core/base/widgets/drawer/menu/menu_item.dart';
+import 'package:trufi_core/base/widgets/drawer/menu/trufi_menu_item.dart';
 
-class MenuPageItem extends MenuItem {
+class MenuPageItem extends TrufiMenuItem {
   MenuPageItem({
     required String id,
     required WidgetBuilder selectedIcon,
@@ -23,7 +23,7 @@ class MenuPageItem extends MenuItem {
           selectedIcon: selectedIcon,
           notSelectedIcon: notSelectedIcon,
           name: (context) {
-            return MenuItem.buildName(
+            return TrufiMenuItem.buildName(
               context,
               name(context),
               color: nameColor,

--- a/lib/base/widgets/drawer/menu/social_media_item.dart
+++ b/lib/base/widgets/drawer/menu/social_media_item.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:trufi_core/base/translations/trufi_base_localizations.dart';
 import 'package:trufi_core/base/utils/util_icons/custom_icons.dart';
 import 'package:trufi_core/base/widgets/drawer/menu/default_item_menu.dart';
-import 'package:trufi_core/base/widgets/drawer/menu/menu_item.dart';
+import 'package:trufi_core/base/widgets/drawer/menu/trufi_menu_item.dart' ;
 import 'package:url_launcher/url_launcher.dart';
 
-abstract class SocialMediaItem extends MenuItem {
+abstract class SocialMediaItem extends TrufiMenuItem {
   final String url;
   SocialMediaItem({
     required this.url,
@@ -16,7 +16,7 @@ abstract class SocialMediaItem extends MenuItem {
           notSelectedIcon: buildIcon,
           name: (context) => Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: MenuItem.buildName(context, name(context)),
+            child: TrufiMenuItem.buildName(context, name(context)),
           ),
           onClick: (context, isSelected) {
             // ignore: deprecated_member_use
@@ -125,7 +125,7 @@ class UrlSocialMedia {
       urlYoutube != null;
 }
 
-MenuItem defaultSocialMedia(UrlSocialMedia defaultUrls) {
+TrufiMenuItem defaultSocialMedia(UrlSocialMedia defaultUrls) {
   return SimpleMenuItem(
       buildIcon: (context) => const Icon(Icons.share),
       name: (context) {

--- a/lib/base/widgets/drawer/menu/trufi_menu_item.dart
+++ b/lib/base/widgets/drawer/menu/trufi_menu_item.dart
@@ -4,14 +4,14 @@ import 'package:trufi_core/base/widgets/drawer/menu/default_item_menu.dart';
 import 'package:trufi_core/base/widgets/drawer/menu/default_pages_menu.dart';
 import 'package:trufi_core/base/widgets/drawer/menu/social_media_item.dart';
 
-abstract class MenuItem {
+abstract class TrufiMenuItem {
   final String? id;
   final WidgetBuilder selectedIcon;
   final WidgetBuilder notSelectedIcon;
   final WidgetBuilder name;
   final void Function(BuildContext, bool isSelected) onClick;
 
-  MenuItem({
+  TrufiMenuItem({
     this.id,
     required this.selectedIcon,
     required this.notSelectedIcon,
@@ -44,7 +44,7 @@ abstract class MenuItem {
   }
 }
 
-List<List<MenuItem>> defaultMenuItems({
+List<List<TrufiMenuItem>> defaultMenuItems({
   required UrlSocialMedia? defaultUrls,
 }) {
   return [

--- a/lib/base/widgets/drawer/trufi_drawer.dart
+++ b/lib/base/widgets/drawer/trufi_drawer.dart
@@ -5,7 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:trufi_core/base/translations/trufi_base_localizations.dart';
-import 'package:trufi_core/base/widgets/drawer/menu/menu_item.dart';
+import 'package:trufi_core/base/widgets/drawer/menu/trufi_menu_item.dart';
 import 'package:share_plus/share_plus.dart';
 
 class TrufiDrawer extends StatelessWidget {
@@ -25,7 +25,7 @@ class TrufiDrawer extends StatelessWidget {
   final String countryName;
   final String urlShareApp;
   final String currentRoute;
-  final List<List<MenuItem>> menuItems;
+  final List<List<TrufiMenuItem>> menuItems;
   final WidgetBuilder? backgroundImageBuilder;
 
   @override

--- a/lib/default_values.dart
+++ b/lib/default_values.dart
@@ -16,7 +16,7 @@ import 'package:trufi_core/base/pages/home/home.dart';
 import 'package:trufi_core/base/pages/saved_places/saved_places.dart';
 import 'package:trufi_core/base/pages/saved_places/translations/saved_places_localizations.dart';
 import 'package:trufi_core/base/pages/transport_list/transport_list.dart';
-import 'package:trufi_core/base/widgets/drawer/menu/menu_item.dart';
+import 'package:trufi_core/base/widgets/drawer/menu/trufi_menu_item.dart';
 import 'package:trufi_core/base/widgets/drawer/menu/social_media_item.dart';
 import 'package:trufi_core/base/widgets/drawer/trufi_drawer.dart';
 import 'package:trufi_core/base/widgets/screen/screen_helpers.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   provider: ^6.0.1
   package_info_plus: ^1.3.0
   rxdart: ^0.27.3
-  share_plus: ^3.0.4
+  share_plus: ^4.0.10+1
   synchronized: ^3.0.0
   cached_network_image: ^3.2.0
   uni_links: ^0.5.1


### PR DESCRIPTION
* menu_item.dart was renamed to trufi_menu_item.dart as well as the contained class (MenuItem->TrufiMenuItem).

* import last recent version of share_plus to fix build errors

The example now builds with Flutter 3