### PR TITLE
fix: prevent WSoD when selecting Your Location on desktop browsers

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -496,22 +496,44 @@ class _HomeScreenState extends State<HomeScreen>
           ),
           onYourLocation: () async {
             // Try to get GPS location
-            var status = await _locationService.checkPermission();
+            try {
+              if (kIsWeb) {
+                // On web, getCurrentLocation() calls the browser's
+                // geolocation API directly, which handles its own
+                // permission dialog. No need for separate permission checks.
+                final location =
+                    await _locationService.getCurrentLocation();
+                if (location != null) {
+                  return SearchLocation(
+                    id: 'current_location',
+                    displayName: l10n.yourLocation,
+                    latitude: location.latitude,
+                    longitude: location.longitude,
+                  );
+                }
+              } else {
+                // On mobile, check and request permissions explicitly
+                var status = await _locationService.checkPermission();
 
-            if (status == LocationPermissionStatus.denied) {
-              status = await _locationService.requestPermission();
-            }
+                if (status == LocationPermissionStatus.denied) {
+                  status = await _locationService.requestPermission();
+                }
 
-            if (status == LocationPermissionStatus.granted) {
-              final location = await _locationService.getCurrentLocation();
-              if (location != null) {
-                return SearchLocation(
-                  id: 'current_location',
-                  displayName: l10n.yourLocation,
-                  latitude: location.latitude,
-                  longitude: location.longitude,
-                );
+                if (status == LocationPermissionStatus.granted) {
+                  final location =
+                      await _locationService.getCurrentLocation();
+                  if (location != null) {
+                    return SearchLocation(
+                      id: 'current_location',
+                      displayName: l10n.yourLocation,
+                      latitude: location.latitude,
+                      longitude: location.longitude,
+                    );
+                  }
+                }
               }
+            } catch (e) {
+              debugPrint('Failed to get user location: $e');
             }
 
             // Fallback to default center if GPS not available

--- a/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
+++ b/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
@@ -270,9 +270,15 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
                         onYourLocation: widget.onYourLocation != null
                             ? () async {
                                 HapticFeedback.lightImpact();
-                                final location = await widget.onYourLocation!();
-                                if (location != null && context.mounted) {
-                                  Navigator.pop(context, location);
+                                try {
+                                  final location =
+                                      await widget.onYourLocation!();
+                                  if (location != null && context.mounted) {
+                                    Navigator.pop(context, location);
+                                  }
+                                } catch (e) {
+                                  debugPrint(
+                                      'Error getting your location: $e');
                                 }
                               }
                             : null,

--- a/packages/trufi_core_utils/lib/src/location_service.dart
+++ b/packages/trufi_core_utils/lib/src/location_service.dart
@@ -85,11 +85,17 @@ class LocationService extends ChangeNotifier {
 
   /// Checks the current permission status without requesting.
   Future<LocationPermissionStatus> checkPermission() async {
-    final serviceEnabled = await isLocationServiceEnabled();
-    if (!serviceEnabled) {
-      _lastPermissionStatus = LocationPermissionStatus.serviceDisabled;
-      _safeNotifyListeners();
-      return LocationPermissionStatus.serviceDisabled;
+    // On web, isLocationServiceEnabled() is not a meaningful concept
+    // (browsers don't have a "location services" toggle like mobile).
+    // Skipping this check on web allows the browser to handle geolocation
+    // permissions natively.
+    if (!kIsWeb) {
+      final serviceEnabled = await isLocationServiceEnabled();
+      if (!serviceEnabled) {
+        _lastPermissionStatus = LocationPermissionStatus.serviceDisabled;
+        _safeNotifyListeners();
+        return LocationPermissionStatus.serviceDisabled;
+      }
     }
 
     final permission = await Geolocator.checkPermission();
@@ -102,11 +108,13 @@ class LocationService extends ChangeNotifier {
   ///
   /// Returns the new permission status after the request.
   Future<LocationPermissionStatus> requestPermission() async {
-    final serviceEnabled = await isLocationServiceEnabled();
-    if (!serviceEnabled) {
-      _lastPermissionStatus = LocationPermissionStatus.serviceDisabled;
-      _safeNotifyListeners();
-      return LocationPermissionStatus.serviceDisabled;
+    if (!kIsWeb) {
+      final serviceEnabled = await isLocationServiceEnabled();
+      if (!serviceEnabled) {
+        _lastPermissionStatus = LocationPermissionStatus.serviceDisabled;
+        _safeNotifyListeners();
+        return LocationPermissionStatus.serviceDisabled;
+      }
     }
 
     final permission = await Geolocator.requestPermission();
@@ -119,22 +127,53 @@ class LocationService extends ChangeNotifier {
   ///
   /// Returns null if permission is not granted or location services are disabled.
   /// Throws [LocationServiceException] if an error occurs.
+  ///
+  /// On web, the browser handles permissions natively through the
+  /// geolocation API prompt, so we skip the permission pre-check and
+  /// call getCurrentPosition() directly.
   Future<LocationResult?> getCurrentLocation({
     LocationAccuracy accuracy = LocationAccuracy.high,
     Duration? timeout,
   }) async {
-    final status = await checkPermission();
-    if (status != LocationPermissionStatus.granted) {
-      return null;
+    // On mobile, check permission first to avoid unnecessary API calls.
+    // On web, skip this — the browser will show its own permission dialog
+    // when getCurrentPosition() is called, and the Permissions API state
+    // may not accurately reflect whether access will be granted.
+    if (!kIsWeb) {
+      final status = await checkPermission();
+      if (status != LocationPermissionStatus.granted) {
+        return null;
+      }
     }
 
     try {
-      final position = await Geolocator.getCurrentPosition(
-        locationSettings: LocationSettings(
-          accuracy: accuracy,
-          timeLimit: timeout ?? const Duration(seconds: 15),
-        ),
-      );
+      // On web/desktop, high accuracy may fail because there's no GPS hardware.
+      // Try with the requested accuracy first, then fall back to low accuracy
+      // (IP-based geolocation) which is more reliable on desktop browsers.
+      final effectiveTimeout = timeout ?? const Duration(seconds: 15);
+      Position? position;
+
+      try {
+        position = await Geolocator.getCurrentPosition(
+          locationSettings: LocationSettings(
+            accuracy: accuracy,
+            timeLimit: effectiveTimeout,
+          ),
+        );
+      } catch (e) {
+        // On web/desktop, high accuracy often fails because there's no GPS
+        // hardware. Retry with low accuracy (IP-based geolocation).
+        if (kIsWeb && accuracy != LocationAccuracy.low) {
+          position = await Geolocator.getCurrentPosition(
+            locationSettings: LocationSettings(
+              accuracy: LocationAccuracy.low,
+              timeLimit: effectiveTimeout,
+            ),
+          );
+        } else {
+          rethrow;
+        }
+      }
 
       _lastKnownPosition = position;
       _safeNotifyListeners();


### PR DESCRIPTION
## Summary
- Fixes #857 — White Screen of Death when selecting "Your Location" on desktop browsers
- On web, skips `isLocationServiceEnabled()` and permission pre-checks that don't apply to browsers, calling the browser's geolocation API directly which handles its own permission dialog
- If high accuracy geolocation fails (common on desktop without GPS hardware), automatically retries with low accuracy (IP-based)
- Adds error handling at multiple levels to prevent unhandled exceptions from crashing the UI, falling back to default center coordinates gracefully

## Files changed
- `packages/trufi_core_utils/lib/src/location_service.dart` — Web-aware permission checks and geolocation with accuracy fallback
- `packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart` — Separate web/mobile flows with error handling
- `packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart` — Defensive try-catch in UI callback

## Test plan
- [ ] On desktop browser (Windows/Edge): click "Your Location" → browser shows permission dialog → coordinates are fetched and populated
- [ ] On desktop browser with geolocation denied: app falls back to default center without crashing
- [ ] On mobile: existing permission flow continues to work as before
- [ ] No White Screen of Death in any scenario