### PR TITLE
fix: bottom panel gets stuck due to Android navigation gesture conflict

### DIFF
--- a/packages/trufi_core_base_widgets/lib/trufi_bottom_sheet.dart
+++ b/packages/trufi_core_base_widgets/lib/trufi_bottom_sheet.dart
@@ -85,7 +85,6 @@ class _TrufiBottomSheetState extends State<TrufiBottomSheet> {
     final theme = Theme.of(context);
 
     return SafeArea(
-      bottom: false,
       child: DraggableScrollableSheet(
         controller: widget.controller,
         initialChildSize: widget.initialChildSize,


### PR DESCRIPTION
## Summary
- Fixes #858 — Bottom sliding panel cannot be dragged up after dragging down on Android
- The `SafeArea` in `TrufiBottomSheet` had `bottom: false`, allowing the minimized panel to overlap with Android's system navigation zone (gesture bar / buttons)
- Android intercepted the upward swipe as a system navigation gesture instead of passing it to the app
- Removing `bottom: false` makes the sheet respect the system navigation area, keeping the draggable grabber in the app's touch zone

## Test plan
- [ ] On Android with gesture navigation: drag panel to minimum → swipe up still works
- [ ] On Android with 3-button navigation: panel doesn't overlap with system buttons
- [ ] Toggle button still works correctly
- [ ] No layout issues on iOS or web