### PR TITLE
Fix UI issues for Trujillo app deployment

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/routing_settings_sheet.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/routing_settings_sheet.dart
@@ -113,7 +113,7 @@ class RoutingSettingsSheet extends StatelessWidget {
           ),
           // Apply button
           Padding(
-            padding: const EdgeInsets.fromLTRB(20, 8, 20, 24),
+            padding: EdgeInsets.fromLTRB(20, 8, 20, 24 + MediaQuery.of(context).padding.bottom),
             child: SizedBox(
               width: double.infinity,
               child: FilledButton.icon(

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_de.arb
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_de.arb
@@ -12,7 +12,7 @@
   "onboardingRoutingTitle": "Wähle deine Routenplanung",
   "onboardingComplete": "Los geht's",
 
-  "privacyConsentTitle": "Hilf uns, Trufi zu verbessern",
+  "privacyConsentTitle": "Hilf uns, die App zu verbessern",
   "privacyConsentSubtitle": "Hilf uns, die App zu verbessern, indem du anonyme Nutzungsdaten teilst",
   "privacyConsentInfoTitle": "Was wir sammeln",
   "privacyConsentInfoLogs": "Fehlerprotokolle, um Abstürze und Bugs zu beheben",

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_en.arb
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_en.arb
@@ -51,7 +51,7 @@
     "description": "Button to complete onboarding"
   },
 
-  "privacyConsentTitle": "Help Improve Trufi",
+  "privacyConsentTitle": "Help Improve the App",
   "@privacyConsentTitle": {
     "description": "Privacy consent dialog title"
   },

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_es.arb
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_es.arb
@@ -12,7 +12,7 @@
   "onboardingRoutingTitle": "Elige tu motor de enrutamiento",
   "onboardingComplete": "Comenzar",
 
-  "privacyConsentTitle": "Ayuda a mejorar Trufi",
+  "privacyConsentTitle": "Ayuda a mejorar la app",
   "privacyConsentSubtitle": "Ayúdanos a mejorar la app compartiendo datos de uso anónimos",
   "privacyConsentInfoTitle": "Qué recopilamos",
   "privacyConsentInfoLogs": "Registros de errores para ayudarnos a corregir fallos",

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_localizations.dart
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_localizations.dart
@@ -166,7 +166,7 @@ abstract class SettingsLocalizations {
   /// Privacy consent dialog title
   ///
   /// In en, this message translates to:
-  /// **'Help Improve Trufi'**
+  /// **'Help Improve the App'**
   String get privacyConsentTitle;
 
   /// Privacy consent dialog subtitle

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_de.dart
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_de.dart
@@ -39,7 +39,7 @@ class SettingsLocalizationsDe extends SettingsLocalizations {
   String get onboardingComplete => 'Los geht\'s';
 
   @override
-  String get privacyConsentTitle => 'Hilf uns, Trufi zu verbessern';
+  String get privacyConsentTitle => 'Hilf uns, die App zu verbessern';
 
   @override
   String get privacyConsentSubtitle =>

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_en.dart
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_en.dart
@@ -39,7 +39,7 @@ class SettingsLocalizationsEn extends SettingsLocalizations {
   String get onboardingComplete => 'Get Started';
 
   @override
-  String get privacyConsentTitle => 'Help Improve Trufi';
+  String get privacyConsentTitle => 'Help Improve the App';
 
   @override
   String get privacyConsentSubtitle =>

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_es.dart
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_es.dart
@@ -39,7 +39,7 @@ class SettingsLocalizationsEs extends SettingsLocalizations {
   String get onboardingComplete => 'Comenzar';
 
   @override
-  String get privacyConsentTitle => 'Ayuda a mejorar Trufi';
+  String get privacyConsentTitle => 'Ayuda a mejorar la app';
 
   @override
   String get privacyConsentSubtitle =>


### PR DESCRIPTION
## Summary
- Remove "Trufi" branding from privacy consent title in settings (use generic "Help Improve the App" instead)
- Add bottom safe area padding to route settings "Apply" button so it doesn't overlap the system navigation bar

## Context
These fixes address UI issues found during Trujillo app QA (issues TB-08 and T-48).