### PR TITLE
Add flag for showWheelchair for OTP1.5

### DIFF
--- a/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_preferences.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_preferences.dart
@@ -185,8 +185,9 @@ class Otp15PreferencesState extends ChangeNotifier {
 /// Complete preferences UI for OTP 1.5 provider.
 class Otp15Preferences extends StatelessWidget {
   final Otp15PreferencesState state;
+  final bool showWheelchair;
 
-  const Otp15Preferences({super.key, required this.state});
+  const Otp15Preferences({super.key, required this.state, this.showWheelchair = true});
 
   @override
   Widget build(BuildContext context) {
@@ -197,8 +198,10 @@ class Otp15Preferences extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            _AccessibilitySection(state: state),
-            const SizedBox(height: 24),
+            if (showWheelchair) ...[
+              _AccessibilitySection(state: state),
+              const SizedBox(height: 24),
+            ],
             _WalkSpeedSection(state: state),
             const SizedBox(height: 24),
             _MaxWalkDistanceSection(state: state),

--- a/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
@@ -50,11 +50,15 @@ class Otp15RoutingProvider implements IRoutingProvider {
   /// Optional HTTP client, primarily for testing.
   final http.Client? _injectedHttpClient;
 
+  /// Whether to show the wheelchair accessibility toggle in preferences UI.
+  final bool showWheelchairOption;
+
   Otp15RoutingProvider({
     required this.endpoint,
     this.displayName,
     this.displayDescription,
     this.planHeaderProvider,
+    this.showWheelchairOption = true,
     http.Client? httpClient,
   }) : _injectedHttpClient = httpClient;
 
@@ -78,7 +82,7 @@ class Otp15RoutingProvider implements IRoutingProvider {
 
   @override
   Widget? buildPreferencesUI(BuildContext context) =>
-      Otp15Preferences(state: _prefs);
+      Otp15Preferences(state: _prefs, showWheelchair: showWheelchairOption);
 
   @override
   void resetPreferences() => _prefs.reset();


### PR DESCRIPTION
A flag has been added to the OTP 1.5 provider for showWheelchair to hide the wheelchair accessibility toggle.

The default value is showWheelchairOption = true

#861 