### PR TITLE
fix: import localization delegate of widget used in the home screen

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/src/home_screen_trufi_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/home_screen_trufi_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/single_child_widget.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:trufi_core_poi_layers/trufi_core_poi_layers.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart' as routing;
+import 'package:trufi_core_navigation/trufi_core_navigation.dart';
 import 'package:trufi_core_utils/trufi_core_utils.dart';
 
 import '../l10n/home_screen_localizations.dart';
@@ -84,6 +85,8 @@ class HomeScreenTrufiScreen extends TrufiScreen {
     ...HomeScreenLocalizations.localizationsDelegates,
     // Include POI layers localizations if POI layers are configured
     if (config.poiLayersManager != null) POILayersLocalizations.delegate,
+    routing.RoutingLocalizations.delegate,
+    NavigationLocalizations.delegate,
   ];
 
   @override


### PR DESCRIPTION
Opening the OTP 2.8 settings or starting the navigation was leading to a blank widget because of error "Null check operator used on a null value".

This error occured in localisation component when calling "Localizations.of(....)!"


<img width="316" height="220" alt="Screenshot 2026-04-12 at 13-24-59 Trufi App" src="https://github.com/user-attachments/assets/de361022-0e98-4451-ad2e-4fae0e357f43" /><img width="339" height="292" alt="Screenshot 2026-04-12 at 13-21-28 Trufi App" src="https://github.com/user-attachments/assets/f3a86486-579d-40de-91b4-5b43daf658aa" />
