### PR TITLE
Add DeviceIdProvider and send X-Device-Id header on every trufi-core HTTP request

### DIFF
--- a/packages/trufi_core_interfaces/lib/src/device/device_id_service.dart
+++ b/packages/trufi_core_interfaces/lib/src/device/device_id_service.dart
@@ -1,0 +1,10 @@
+/// Abstract interface for obtaining a stable per-install device identifier.
+///
+/// Implementations typically generate a UUID on first access, persist it, and
+/// return the same value for the lifetime of the install. The value is sent as
+/// the `X-Device-Id` HTTP header on every outgoing request to correlate
+/// backend analytics.
+abstract class DeviceIdService {
+  /// Returns the stable device id, generating and persisting one on first call.
+  Future<String> getDeviceId();
+}

--- a/packages/trufi_core_interfaces/lib/trufi_core_interfaces.dart
+++ b/packages/trufi_core_interfaces/lib/trufi_core_interfaces.dart
@@ -27,6 +27,9 @@ export './src/places/my_places_provider.dart';
 // Storage interfaces
 export './src/storage/storage_service.dart';
 
+// Device interfaces
+export './src/device/device_id_service.dart';
+
 // Overlay interfaces
 export './src/overlay/overlay_service.dart';
 

--- a/packages/trufi_core_maps/lib/src/data/tile/cached_fetch.dart
+++ b/packages/trufi_core_maps/lib/src/data/tile/cached_fetch.dart
@@ -1,22 +1,19 @@
 import 'dart:typed_data';
 import 'package:dio/dio.dart';
-
-/// Shared configuration for the tile fetcher.
-///
-/// Set [deviceIdProvider] once at app startup to include the `X-Device-Id`
-/// header on every tile request.
-class CachedFetchConfig {
-  CachedFetchConfig._();
-
-  static Future<String?> Function()? deviceIdProvider;
-}
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 
 final Dio _dio = Dio();
 final Map<String, CancelToken> _activeRequests = {};
 
 int? _lastZ, _lastX, _lastY;
 
-Future<Uint8List> cachedFirstFetch(Uri uri, int z, int x, int y) async {
+Future<Uint8List> cachedFirstFetch(
+  Uri uri,
+  int z,
+  int x,
+  int y, {
+  DeviceIdService? deviceIdService,
+}) async {
   final key = uri.toString();
 
   if (_lastZ != null) {
@@ -34,21 +31,20 @@ Future<Uint8List> cachedFirstFetch(Uri uri, int z, int x, int y) async {
   final cancelToken = CancelToken();
   _activeRequests[key] = cancelToken;
 
-  final headers = <String, dynamic>{};
-  final provider = CachedFetchConfig.deviceIdProvider;
-  if (provider != null) {
-    final deviceId = await provider();
-    if (deviceId != null && deviceId.isNotEmpty) {
-      headers['X-Device-Id'] = deviceId;
-    }
+  String? deviceId;
+  if (deviceIdService != null) {
+    deviceId = await deviceIdService.getDeviceId();
   }
+  final headers = (deviceId == null || deviceId.isEmpty)
+      ? null
+      : {'X-Device-Id': deviceId};
 
   try {
     final response = await _dio.get<List<int>>(
       key,
       options: Options(
         responseType: ResponseType.bytes,
-        headers: headers.isEmpty ? null : headers,
+        headers: headers,
       ),
       cancelToken: cancelToken,
     );

--- a/packages/trufi_core_maps/lib/src/data/tile/cached_fetch.dart
+++ b/packages/trufi_core_maps/lib/src/data/tile/cached_fetch.dart
@@ -1,6 +1,16 @@
 import 'dart:typed_data';
 import 'package:dio/dio.dart';
 
+/// Shared configuration for the tile fetcher.
+///
+/// Set [deviceIdProvider] once at app startup to include the `X-Device-Id`
+/// header on every tile request.
+class CachedFetchConfig {
+  CachedFetchConfig._();
+
+  static Future<String?> Function()? deviceIdProvider;
+}
+
 final Dio _dio = Dio();
 final Map<String, CancelToken> _activeRequests = {};
 
@@ -24,10 +34,22 @@ Future<Uint8List> cachedFirstFetch(Uri uri, int z, int x, int y) async {
   final cancelToken = CancelToken();
   _activeRequests[key] = cancelToken;
 
+  final headers = <String, dynamic>{};
+  final provider = CachedFetchConfig.deviceIdProvider;
+  if (provider != null) {
+    final deviceId = await provider();
+    if (deviceId != null && deviceId.isNotEmpty) {
+      headers['X-Device-Id'] = deviceId;
+    }
+  }
+
   try {
     final response = await _dio.get<List<int>>(
       key,
-      options: Options(responseType: ResponseType.bytes),
+      options: Options(
+        responseType: ResponseType.bytes,
+        headers: headers.isEmpty ? null : headers,
+      ),
       cancelToken: cancelToken,
     );
 

--- a/packages/trufi_core_maps/lib/src/data/tile/tile_grid_layer.dart
+++ b/packages/trufi_core_maps/lib/src/data/tile/tile_grid_layer.dart
@@ -1,6 +1,8 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
+import 'package:trufi_core_utils/trufi_core_utils.dart';
 import 'package:vector_tile/vector_tile.dart';
 
 import '../../domain/entities/camera.dart';
@@ -32,13 +34,19 @@ class TileGrid<T> {
     this.granularityLevels = 0,
     this.showGrid = false,
     this.gridColor = Colors.blue,
-  });
+    DeviceIdService? deviceIdService,
+  }) : _deviceIdService =
+           deviceIdService ?? SharedPreferencesDeviceIdService();
 
   final String uriTemplate;
   final T? Function(GeoJsonPoint) fromGeoJsonPoint;
   final int granularityLevels;
   final bool showGrid;
   final Color gridColor;
+
+  /// Service used to inject the `X-Device-Id` header on every tile fetch.
+  /// Defaults to [SharedPreferencesDeviceIdService].
+  final DeviceIdService _deviceIdService;
 
   final Set<String> _drawnBoxes = <String>{};
 
@@ -95,7 +103,13 @@ class TileGrid<T> {
           .replaceAll('{y}', '$y');
       final uri = Uri.parse(replaced);
 
-      final Uint8List bodyByte = await cachedFirstFetch(uri, z, x, y);
+      final Uint8List bodyByte = await cachedFirstFetch(
+        uri,
+        z,
+        x,
+        y,
+        deviceIdService: _deviceIdService,
+      );
       final tile = VectorTile.fromBytes(bytes: bodyByte);
 
       final markersToAdd = <T>[];

--- a/packages/trufi_core_notifications/lib/src/services/http_notification_service.dart
+++ b/packages/trufi_core_notifications/lib/src/services/http_notification_service.dart
@@ -29,6 +29,13 @@ class HttpNotificationService implements NotificationService {
       }
     }
 
+    if (config.getDeviceId != null) {
+      final deviceId = await config.getDeviceId!();
+      if (deviceId.isNotEmpty) {
+        headers['X-Device-Id'] = deviceId;
+      }
+    }
+
     return headers;
   }
 

--- a/packages/trufi_core_notifications/lib/src/services/http_notification_service.dart
+++ b/packages/trufi_core_notifications/lib/src/services/http_notification_service.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
+import 'package:trufi_core_utils/trufi_core_utils.dart';
 
 import '../models/notification.dart';
 import 'notification_service.dart';
@@ -11,10 +13,18 @@ class HttpNotificationService implements NotificationService {
   final NotificationServiceConfig config;
   final http.Client _client;
 
+  /// Service used to inject the `X-Device-Id` header on every outgoing
+  /// request. Defaults to [SharedPreferencesDeviceIdService].
+  final DeviceIdService _deviceIdService;
+
   bool _isDisposed = false;
 
-  HttpNotificationService({required this.config, http.Client? client})
-    : _client = client ?? http.Client();
+  HttpNotificationService({
+    required this.config,
+    http.Client? client,
+    DeviceIdService? deviceIdService,
+  }) : _client = client ?? http.Client(),
+       _deviceIdService = deviceIdService ?? SharedPreferencesDeviceIdService();
 
   Future<Map<String, String>> _getHeaders() async {
     final headers = <String, String>{
@@ -29,11 +39,9 @@ class HttpNotificationService implements NotificationService {
       }
     }
 
-    if (config.getDeviceId != null) {
-      final deviceId = await config.getDeviceId!();
-      if (deviceId.isNotEmpty) {
-        headers['X-Device-Id'] = deviceId;
-      }
+    final deviceId = await _deviceIdService.getDeviceId();
+    if (deviceId.isNotEmpty) {
+      headers['X-Device-Id'] = deviceId;
     }
 
     return headers;

--- a/packages/trufi_core_planner/lib/src/client/remote_planner_client.dart
+++ b/packages/trufi_core_planner/lib/src/client/remote_planner_client.dart
@@ -14,11 +14,27 @@ import 'planner_routing_client.dart';
 /// Used on web platforms where GTFS data is processed server-side.
 class RemotePlannerClient implements PlannerRoutingClient {
   final String serverUrl;
+  final Future<String?> Function()? deviceIdProvider;
   final http.Client _httpClient;
   bool _isReady = false;
 
-  RemotePlannerClient({required this.serverUrl, http.Client? httpClient})
-    : _httpClient = httpClient ?? http.Client();
+  RemotePlannerClient({
+    required this.serverUrl,
+    this.deviceIdProvider,
+    http.Client? httpClient,
+  }) : _httpClient = httpClient ?? http.Client();
+
+  Future<Map<String, String>> _buildHeaders([Map<String, String>? base]) async {
+    final headers = <String, String>{...?base};
+    final provider = deviceIdProvider;
+    if (provider != null) {
+      final deviceId = await provider();
+      if (deviceId != null && deviceId.isNotEmpty) {
+        headers['X-Device-Id'] = deviceId;
+      }
+    }
+    return headers;
+  }
 
   String get _baseUrl => serverUrl.endsWith('/')
       ? serverUrl.substring(0, serverUrl.length - 1)
@@ -29,7 +45,10 @@ class RemotePlannerClient implements PlannerRoutingClient {
 
   @override
   Future<void> initialize() async {
-    final response = await _httpClient.get(Uri.parse('$_baseUrl/health'));
+    final response = await _httpClient.get(
+      Uri.parse('$_baseUrl/health'),
+      headers: await _buildHeaders(),
+    );
     if (response.statusCode == 200) {
       _isReady = true;
     } else {
@@ -46,7 +65,7 @@ class RemotePlannerClient implements PlannerRoutingClient {
   }) async {
     final response = await _httpClient.post(
       Uri.parse('$_baseUrl/plan'),
-      headers: {'Content-Type': 'application/json'},
+      headers: await _buildHeaders({'Content-Type': 'application/json'}),
       body: jsonEncode({
         'from': {'lat': origin.latitude, 'lon': origin.longitude},
         'to': {'lat': destination.latitude, 'lon': destination.longitude},
@@ -70,7 +89,10 @@ class RemotePlannerClient implements PlannerRoutingClient {
 
   @override
   Future<List<GtfsRoute>> getRoutes() async {
-    final response = await _httpClient.get(Uri.parse('$_baseUrl/routes'));
+    final response = await _httpClient.get(
+      Uri.parse('$_baseUrl/routes'),
+      headers: await _buildHeaders(),
+    );
     if (response.statusCode != 200) return [];
 
     final data = jsonDecode(response.body) as Map<String, dynamic>;
@@ -85,7 +107,10 @@ class RemotePlannerClient implements PlannerRoutingClient {
     final uri = limit != null
         ? Uri.parse('$_baseUrl/stops?limit=$limit')
         : Uri.parse('$_baseUrl/stops');
-    final response = await _httpClient.get(uri);
+    final response = await _httpClient.get(
+      uri,
+      headers: await _buildHeaders(),
+    );
     if (response.statusCode != 200) return [];
 
     final data = jsonDecode(response.body) as Map<String, dynamic>;
@@ -109,6 +134,7 @@ class RemotePlannerClient implements PlannerRoutingClient {
         '&maxDistance=$maxDistance'
         '&maxResults=$maxResults',
       ),
+      headers: await _buildHeaders(),
     );
     if (response.statusCode != 200) return [];
 
@@ -129,6 +155,7 @@ class RemotePlannerClient implements PlannerRoutingClient {
   Future<RouteDetail?> getRouteDetail(String routeId) async {
     final response = await _httpClient.get(
       Uri.parse('$_baseUrl/routes/$routeId'),
+      headers: await _buildHeaders(),
     );
     if (response.statusCode != 200) return null;
 

--- a/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
@@ -47,6 +47,10 @@ class Otp15RoutingProvider implements IRoutingProvider {
   /// Optional callback to provide extra HTTP headers per plan request.
   final PlanHeaderProvider? planHeaderProvider;
 
+  /// Optional callback to provide a stable device id, sent as `X-Device-Id`
+  /// on every outgoing request.
+  final Future<String?> Function()? deviceIdProvider;
+
   /// Optional HTTP client, primarily for testing.
   final http.Client? _injectedHttpClient;
 
@@ -55,6 +59,7 @@ class Otp15RoutingProvider implements IRoutingProvider {
     this.displayName,
     this.displayDescription,
     this.planHeaderProvider,
+    this.deviceIdProvider,
     http.Client? httpClient,
   }) : _injectedHttpClient = httpClient;
 
@@ -141,6 +146,7 @@ class Otp15RoutingProvider implements IRoutingProvider {
       if (planHeaderProvider != null) {
         headers.addAll(await planHeaderProvider!(from, to));
       }
+      await _applyDeviceId(headers);
 
       final response = await _httpClient
           .get(uri, headers: headers)
@@ -311,8 +317,11 @@ class Otp15RoutingProvider implements IRoutingProvider {
   }
 
   Future<dynamic> _getJson(String url) async {
+    final headers = <String, String>{'Accept': 'application/json'};
+    await _applyDeviceId(headers);
+
     final response = await _httpClient
-        .get(Uri.parse(url), headers: {'Accept': 'application/json'})
+        .get(Uri.parse(url), headers: headers)
         .timeout(const Duration(seconds: 30));
 
     if (response.statusCode != 200) {
@@ -320,6 +329,15 @@ class Otp15RoutingProvider implements IRoutingProvider {
     }
 
     return jsonDecode(response.body);
+  }
+
+  Future<void> _applyDeviceId(Map<String, String> headers) async {
+    final provider = deviceIdProvider;
+    if (provider == null) return;
+    final deviceId = await provider();
+    if (deviceId != null && deviceId.isNotEmpty) {
+      headers['X-Device-Id'] = deviceId;
+    }
   }
 
   // --- Endpoint helpers ---

--- a/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import 'package:flutter/widgets.dart';
 import 'package:http/http.dart' as http;
 import 'package:latlong2/latlong.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
+import 'package:trufi_core_utils/trufi_core_utils.dart';
 
 import '../../utils/polyline_decoder.dart';
 import '../../models/plan.dart';
@@ -47,21 +49,22 @@ class Otp15RoutingProvider implements IRoutingProvider {
   /// Optional callback to provide extra HTTP headers per plan request.
   final PlanHeaderProvider? planHeaderProvider;
 
-  /// Optional callback to provide a stable device id, sent as `X-Device-Id`
-  /// on every outgoing request.
-  final Future<String?> Function()? deviceIdProvider;
-
   /// Optional HTTP client, primarily for testing.
   final http.Client? _injectedHttpClient;
+
+  /// Service used to inject the `X-Device-Id` header on every outgoing
+  /// request. Defaults to [SharedPreferencesDeviceIdService].
+  final DeviceIdService _deviceIdService;
 
   Otp15RoutingProvider({
     required this.endpoint,
     this.displayName,
     this.displayDescription,
     this.planHeaderProvider,
-    this.deviceIdProvider,
     http.Client? httpClient,
-  }) : _injectedHttpClient = httpClient;
+    DeviceIdService? deviceIdService,
+  }) : _injectedHttpClient = httpClient,
+       _deviceIdService = deviceIdService ?? SharedPreferencesDeviceIdService();
 
   late final _prefs = Otp15PreferencesState();
 
@@ -332,10 +335,8 @@ class Otp15RoutingProvider implements IRoutingProvider {
   }
 
   Future<void> _applyDeviceId(Map<String, String> headers) async {
-    final provider = deviceIdProvider;
-    if (provider == null) return;
-    final deviceId = await provider();
-    if (deviceId != null && deviceId.isNotEmpty) {
+    final deviceId = await _deviceIdService.getDeviceId();
+    if (deviceId.isNotEmpty) {
       headers['X-Device-Id'] = deviceId;
     }
   }

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_4/graphql_client_factory.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_4/graphql_client_factory.dart
@@ -1,5 +1,7 @@
 import 'package:graphql/client.dart';
 import 'package:http/http.dart' as http;
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
+import 'package:trufi_core_utils/trufi_core_utils.dart';
 
 /// Factory for creating GraphQL clients.
 class GraphQLClientFactory {
@@ -11,15 +13,17 @@ class GraphQLClientFactory {
   /// Creates a GraphQL client for the given endpoint.
   ///
   /// [timeout] defaults to 60 seconds.
+  /// [deviceIdService] defaults to [SharedPreferencesDeviceIdService] and is
+  /// used to inject the `X-Device-Id` header on every outgoing request.
   static GraphQLClient create(
     String endpoint, {
     Duration timeout = defaultTimeout,
-    Future<String?> Function()? deviceIdProvider,
+    DeviceIdService? deviceIdService,
   }) {
     final httpClient = _OtpHttpClient(
       http.Client(),
       timeout,
-      deviceIdProvider,
+      deviceIdService ?? SharedPreferencesDeviceIdService(),
     );
 
     final httpLink = HttpLink(
@@ -39,23 +43,20 @@ class GraphQLClientFactory {
   }
 }
 
-/// HTTP client wrapper that adds a timeout and optionally injects the
-/// `X-Device-Id` header into every outgoing request.
+/// HTTP client wrapper that adds a timeout and injects the `X-Device-Id`
+/// header read from a [DeviceIdService] on every outgoing request.
 class _OtpHttpClient extends http.BaseClient {
-  _OtpHttpClient(this._inner, this._timeout, this._deviceIdProvider);
+  _OtpHttpClient(this._inner, this._timeout, this._deviceIdService);
 
   final http.Client _inner;
   final Duration _timeout;
-  final Future<String?> Function()? _deviceIdProvider;
+  final DeviceIdService _deviceIdService;
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
-    final provider = _deviceIdProvider;
-    if (provider != null) {
-      final deviceId = await provider();
-      if (deviceId != null && deviceId.isNotEmpty) {
-        request.headers['X-Device-Id'] = deviceId;
-      }
+    final deviceId = await _deviceIdService.getDeviceId();
+    if (deviceId.isNotEmpty) {
+      request.headers['X-Device-Id'] = deviceId;
     }
     return _inner.send(request).timeout(_timeout);
   }

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_4/graphql_client_factory.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_4/graphql_client_factory.dart
@@ -14,9 +14,13 @@ class GraphQLClientFactory {
   static GraphQLClient create(
     String endpoint, {
     Duration timeout = defaultTimeout,
+    Future<String?> Function()? deviceIdProvider,
   }) {
-    // Create HTTP client with timeout
-    final httpClient = _TimeoutHttpClient(http.Client(), timeout);
+    final httpClient = _OtpHttpClient(
+      http.Client(),
+      timeout,
+      deviceIdProvider,
+    );
 
     final httpLink = HttpLink(
       endpoint,
@@ -35,15 +39,24 @@ class GraphQLClientFactory {
   }
 }
 
-/// HTTP client wrapper that adds timeout to all requests.
-class _TimeoutHttpClient extends http.BaseClient {
-  _TimeoutHttpClient(this._inner, this._timeout);
+/// HTTP client wrapper that adds a timeout and optionally injects the
+/// `X-Device-Id` header into every outgoing request.
+class _OtpHttpClient extends http.BaseClient {
+  _OtpHttpClient(this._inner, this._timeout, this._deviceIdProvider);
 
   final http.Client _inner;
   final Duration _timeout;
+  final Future<String?> Function()? _deviceIdProvider;
 
   @override
-  Future<http.StreamedResponse> send(http.BaseRequest request) {
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final provider = _deviceIdProvider;
+    if (provider != null) {
+      final deviceId = await provider();
+      if (deviceId != null && deviceId.isNotEmpty) {
+        request.headers['X-Device-Id'] = deviceId;
+      }
+    }
     return _inner.send(request).timeout(_timeout);
   }
 

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_routing_provider.dart
@@ -46,12 +46,17 @@ class Otp24RoutingProvider implements IRoutingProvider {
   /// Optional callback to provide extra HTTP headers per plan request.
   final PlanHeaderProvider? planHeaderProvider;
 
+  /// Optional callback to provide a stable device id, sent as `X-Device-Id`
+  /// on every outgoing request (plan, transit routes, pattern lookups).
+  final Future<String?> Function()? deviceIdProvider;
+
   Otp24RoutingProvider({
     required this.endpoint,
     this.useSimpleQuery = false,
     this.displayName,
     this.displayDescription,
     this.planHeaderProvider,
+    this.deviceIdProvider,
   });
 
   late final _prefs = Otp24PreferencesState();
@@ -86,6 +91,7 @@ class Otp24RoutingProvider implements IRoutingProvider {
 
   late final GraphQLClient _client = GraphQLClientFactory.create(
     _graphqlEndpoint,
+    deviceIdProvider: deviceIdProvider,
   );
 
   // --- Plan ---

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_routing_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 // ignore: depend_on_referenced_packages
 import 'package:gql/language.dart';
 import 'package:graphql/client.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 
 import 'graphql_client_factory.dart';
 import '../../models/plan.dart';
@@ -46,9 +47,9 @@ class Otp24RoutingProvider implements IRoutingProvider {
   /// Optional callback to provide extra HTTP headers per plan request.
   final PlanHeaderProvider? planHeaderProvider;
 
-  /// Optional callback to provide a stable device id, sent as `X-Device-Id`
-  /// on every outgoing request (plan, transit routes, pattern lookups).
-  final Future<String?> Function()? deviceIdProvider;
+  /// Service used to inject the `X-Device-Id` header on every outgoing
+  /// request. Defaults to [SharedPreferencesDeviceIdService].
+  final DeviceIdService? deviceIdService;
 
   Otp24RoutingProvider({
     required this.endpoint,
@@ -56,7 +57,7 @@ class Otp24RoutingProvider implements IRoutingProvider {
     this.displayName,
     this.displayDescription,
     this.planHeaderProvider,
-    this.deviceIdProvider,
+    this.deviceIdService,
   });
 
   late final _prefs = Otp24PreferencesState();
@@ -91,7 +92,7 @@ class Otp24RoutingProvider implements IRoutingProvider {
 
   late final GraphQLClient _client = GraphQLClientFactory.create(
     _graphqlEndpoint,
-    deviceIdProvider: deviceIdProvider,
+    deviceIdService: deviceIdService,
   );
 
   // --- Plan ---

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 // ignore: depend_on_referenced_packages
 import 'package:gql/language.dart';
 import 'package:graphql/client.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 
 import '../otp_2_4/graphql_client_factory.dart';
 import '../../models/plan.dart';
@@ -46,9 +47,9 @@ class Otp28RoutingProvider implements IRoutingProvider {
   /// Optional callback to provide extra HTTP headers per plan request.
   final PlanHeaderProvider? planHeaderProvider;
 
-  /// Optional callback to provide a stable device id, sent as `X-Device-Id`
-  /// on every outgoing request.
-  final Future<String?> Function()? deviceIdProvider;
+  /// Service used to inject the `X-Device-Id` header on every outgoing
+  /// request. Defaults to [SharedPreferencesDeviceIdService].
+  final DeviceIdService? deviceIdService;
 
   /// Whether to show the wheelchair accessibility option in preferences UI.
   final bool showWheelchairOption;
@@ -62,7 +63,7 @@ class Otp28RoutingProvider implements IRoutingProvider {
     this.displayName,
     this.displayDescription,
     this.planHeaderProvider,
-    this.deviceIdProvider,
+    this.deviceIdService,
     this.showWheelchairOption = true,
     this.showBicycleOption = true,
   });
@@ -99,7 +100,7 @@ class Otp28RoutingProvider implements IRoutingProvider {
 
   late final GraphQLClient _client = GraphQLClientFactory.create(
     _graphqlEndpoint,
-    deviceIdProvider: deviceIdProvider,
+    deviceIdService: deviceIdService,
   );
 
   // --- Plan ---

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
@@ -46,6 +46,10 @@ class Otp28RoutingProvider implements IRoutingProvider {
   /// Optional callback to provide extra HTTP headers per plan request.
   final PlanHeaderProvider? planHeaderProvider;
 
+  /// Optional callback to provide a stable device id, sent as `X-Device-Id`
+  /// on every outgoing request.
+  final Future<String?> Function()? deviceIdProvider;
+
   /// Whether to show the wheelchair accessibility option in preferences UI.
   final bool showWheelchairOption;
 
@@ -58,6 +62,7 @@ class Otp28RoutingProvider implements IRoutingProvider {
     this.displayName,
     this.displayDescription,
     this.planHeaderProvider,
+    this.deviceIdProvider,
     this.showWheelchairOption = true,
     this.showBicycleOption = true,
   });
@@ -94,6 +99,7 @@ class Otp28RoutingProvider implements IRoutingProvider {
 
   late final GraphQLClient _client = GraphQLClientFactory.create(
     _graphqlEndpoint,
+    deviceIdProvider: deviceIdProvider,
   );
 
   // --- Plan ---

--- a/packages/trufi_core_routing/pubspec.yaml
+++ b/packages/trufi_core_routing/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   trufi_core_planner: ^1.0.0
+  trufi_core_utils: ^1.0.0
+  trufi_core_interfaces: ^1.0.0
   equatable: ^2.0.8
   flutter_bloc: ^9.1.1
   graphql: ^5.2.3

--- a/packages/trufi_core_search_locations/lib/src/services/nominatim_search_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/nominatim_search_service.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
+import 'package:trufi_core_utils/trufi_core_utils.dart';
 
 import '../models/search_location.dart';
 import 'search_location_service.dart';
@@ -40,12 +42,12 @@ class NominatimSearchService implements SearchLocationService {
   /// Radius in degrees for the viewbox around bias point.
   final double biasRadius;
 
-  /// Optional callback to provide a stable device id, sent as `X-Device-Id`
-  /// on every outgoing request.
-  final Future<String?> Function()? deviceIdProvider;
-
   /// HTTP client for making requests.
   final http.Client _client;
+
+  /// Service used to inject the `X-Device-Id` header on every outgoing
+  /// request. Defaults to [SharedPreferencesDeviceIdService].
+  final DeviceIdService _deviceIdService;
 
   NominatimSearchService({
     required this.baseUrl,
@@ -57,18 +59,16 @@ class NominatimSearchService implements SearchLocationService {
     this.biasLatitude,
     this.biasLongitude,
     this.biasRadius = 0.5,
-    this.deviceIdProvider,
     http.Client? client,
-  }) : _client = client ?? http.Client();
+    DeviceIdService? deviceIdService,
+  }) : _client = client ?? http.Client(),
+       _deviceIdService = deviceIdService ?? SharedPreferencesDeviceIdService();
 
   Future<Map<String, String>> _buildHeaders() async {
     final headers = <String, String>{'User-Agent': userAgent};
-    final provider = deviceIdProvider;
-    if (provider != null) {
-      final deviceId = await provider();
-      if (deviceId != null && deviceId.isNotEmpty) {
-        headers['X-Device-Id'] = deviceId;
-      }
+    final deviceId = await _deviceIdService.getDeviceId();
+    if (deviceId.isNotEmpty) {
+      headers['X-Device-Id'] = deviceId;
     }
     return headers;
   }

--- a/packages/trufi_core_search_locations/lib/src/services/nominatim_search_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/nominatim_search_service.dart
@@ -40,6 +40,10 @@ class NominatimSearchService implements SearchLocationService {
   /// Radius in degrees for the viewbox around bias point.
   final double biasRadius;
 
+  /// Optional callback to provide a stable device id, sent as `X-Device-Id`
+  /// on every outgoing request.
+  final Future<String?> Function()? deviceIdProvider;
+
   /// HTTP client for making requests.
   final http.Client _client;
 
@@ -53,8 +57,21 @@ class NominatimSearchService implements SearchLocationService {
     this.biasLatitude,
     this.biasLongitude,
     this.biasRadius = 0.5,
+    this.deviceIdProvider,
     http.Client? client,
   }) : _client = client ?? http.Client();
+
+  Future<Map<String, String>> _buildHeaders() async {
+    final headers = <String, String>{'User-Agent': userAgent};
+    final provider = deviceIdProvider;
+    if (provider != null) {
+      final deviceId = await provider();
+      if (deviceId != null && deviceId.isNotEmpty) {
+        headers['X-Device-Id'] = deviceId;
+      }
+    }
+    return headers;
+  }
 
   @override
   Future<List<SearchLocation>> search(String query) async {
@@ -96,10 +113,7 @@ class NominatimSearchService implements SearchLocationService {
     ).replace(queryParameters: queryParams);
 
     try {
-      final response = await _client.get(
-        uri,
-        headers: {'User-Agent': userAgent},
-      );
+      final response = await _client.get(uri, headers: await _buildHeaders());
 
       if (response.statusCode != 200) {
         throw SearchLocationException(
@@ -138,10 +152,7 @@ class NominatimSearchService implements SearchLocationService {
     ).replace(queryParameters: queryParams);
 
     try {
-      final response = await _client.get(
-        uri,
-        headers: {'User-Agent': userAgent},
-      );
+      final response = await _client.get(uri, headers: await _buildHeaders());
 
       if (response.statusCode != 200) {
         return null;

--- a/packages/trufi_core_search_locations/lib/src/services/photon_search_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/photon_search_service.dart
@@ -28,6 +28,10 @@ class PhotonSearchService implements SearchLocationService {
   /// Optional bounding box to limit results [minLon, minLat, maxLon, maxLat].
   final List<double>? boundingBox;
 
+  /// Optional callback to provide a stable device id, sent as `X-Device-Id`
+  /// on every outgoing request.
+  final Future<String?> Function()? deviceIdProvider;
+
   /// HTTP client for making requests.
   final http.Client _client;
 
@@ -38,8 +42,17 @@ class PhotonSearchService implements SearchLocationService {
     this.biasLongitude,
     this.limit = 10,
     this.boundingBox,
+    this.deviceIdProvider,
     http.Client? client,
   }) : _client = client ?? http.Client();
+
+  Future<Map<String, String>?> _buildHeaders() async {
+    final provider = deviceIdProvider;
+    if (provider == null) return null;
+    final deviceId = await provider();
+    if (deviceId == null || deviceId.isEmpty) return null;
+    return {'X-Device-Id': deviceId};
+  }
 
   @override
   Future<List<SearchLocation>> search(String query) async {
@@ -68,7 +81,7 @@ class PhotonSearchService implements SearchLocationService {
     ).replace(queryParameters: queryParams);
 
     try {
-      final response = await _client.get(uri);
+      final response = await _client.get(uri, headers: await _buildHeaders());
 
       if (response.statusCode != 200) {
         throw SearchLocationException(
@@ -106,7 +119,7 @@ class PhotonSearchService implements SearchLocationService {
     ).replace(queryParameters: queryParams);
 
     try {
-      final response = await _client.get(uri);
+      final response = await _client.get(uri, headers: await _buildHeaders());
 
       if (response.statusCode != 200) {
         return null;

--- a/packages/trufi_core_search_locations/lib/src/services/photon_search_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/photon_search_service.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
+import 'package:trufi_core_utils/trufi_core_utils.dart';
 
 import '../models/search_location.dart';
 import 'search_location_service.dart';
@@ -28,12 +30,12 @@ class PhotonSearchService implements SearchLocationService {
   /// Optional bounding box to limit results [minLon, minLat, maxLon, maxLat].
   final List<double>? boundingBox;
 
-  /// Optional callback to provide a stable device id, sent as `X-Device-Id`
-  /// on every outgoing request.
-  final Future<String?> Function()? deviceIdProvider;
-
   /// HTTP client for making requests.
   final http.Client _client;
+
+  /// Service used to inject the `X-Device-Id` header on every outgoing
+  /// request. Defaults to [SharedPreferencesDeviceIdService].
+  final DeviceIdService _deviceIdService;
 
   PhotonSearchService({
     required this.baseUrl,
@@ -42,15 +44,14 @@ class PhotonSearchService implements SearchLocationService {
     this.biasLongitude,
     this.limit = 10,
     this.boundingBox,
-    this.deviceIdProvider,
     http.Client? client,
-  }) : _client = client ?? http.Client();
+    DeviceIdService? deviceIdService,
+  }) : _client = client ?? http.Client(),
+       _deviceIdService = deviceIdService ?? SharedPreferencesDeviceIdService();
 
   Future<Map<String, String>?> _buildHeaders() async {
-    final provider = deviceIdProvider;
-    if (provider == null) return null;
-    final deviceId = await provider();
-    if (deviceId == null || deviceId.isEmpty) return null;
+    final deviceId = await _deviceIdService.getDeviceId();
+    if (deviceId.isEmpty) return null;
     return {'X-Device-Id': deviceId};
   }
 

--- a/packages/trufi_core_utils/lib/src/device/device_id_provider.dart
+++ b/packages/trufi_core_utils/lib/src/device/device_id_provider.dart
@@ -1,0 +1,45 @@
+import 'dart:math';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+class DeviceIdProvider {
+  DeviceIdProvider._();
+
+  static final DeviceIdProvider instance = DeviceIdProvider._();
+
+  static const String _prefsKey = 'trufi.device_id';
+
+  String? _cached;
+  Future<String>? _pending;
+
+  Future<String> getDeviceId() {
+    if (_cached != null) return Future.value(_cached);
+    return _pending ??= _load();
+  }
+
+  Future<String> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    var id = prefs.getString(_prefsKey);
+    if (id == null || id.isEmpty) {
+      id = _generateUuidV4();
+      await prefs.setString(_prefsKey, id);
+    }
+    _cached = id;
+    _pending = null;
+    return id;
+  }
+
+  static String _generateUuidV4() {
+    final rnd = Random.secure();
+    final bytes = List<int>.generate(16, (_) => rnd.nextInt(256));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    String hex(int b) => b.toRadixString(16).padLeft(2, '0');
+    final h = bytes.map(hex).toList();
+    return '${h[0]}${h[1]}${h[2]}${h[3]}-'
+        '${h[4]}${h[5]}-'
+        '${h[6]}${h[7]}-'
+        '${h[8]}${h[9]}-'
+        '${h[10]}${h[11]}${h[12]}${h[13]}${h[14]}${h[15]}';
+  }
+}

--- a/packages/trufi_core_utils/lib/src/device/shared_preferences_device_id_service.dart
+++ b/packages/trufi_core_utils/lib/src/device/shared_preferences_device_id_service.dart
@@ -1,17 +1,22 @@
 import 'dart:math';
 
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 
-class DeviceIdProvider {
-  DeviceIdProvider._();
-
-  static final DeviceIdProvider instance = DeviceIdProvider._();
+/// SharedPreferences implementation of [DeviceIdService].
+///
+/// Generates a UUID v4 on first call, persists it under the
+/// `trufi.device_id` key, caches it in memory for subsequent calls within the
+/// same instance, and returns the same value for the lifetime of the install.
+class SharedPreferencesDeviceIdService implements DeviceIdService {
+  SharedPreferencesDeviceIdService();
 
   static const String _prefsKey = 'trufi.device_id';
 
   String? _cached;
   Future<String>? _pending;
 
+  @override
   Future<String> getDeviceId() {
     if (_cached != null) return Future.value(_cached);
     return _pending ??= _load();

--- a/packages/trufi_core_utils/lib/trufi_core_utils.dart
+++ b/packages/trufi_core_utils/lib/trufi_core_utils.dart
@@ -10,4 +10,4 @@ export './src/storage/shared_preferences_storage.dart';
 export './src/location_service.dart';
 
 // Device
-export './src/device/device_id_provider.dart';
+export './src/device/shared_preferences_device_id_service.dart';

--- a/packages/trufi_core_utils/lib/trufi_core_utils.dart
+++ b/packages/trufi_core_utils/lib/trufi_core_utils.dart
@@ -8,3 +8,6 @@ export './src/storage/shared_preferences_storage.dart';
 
 // Location
 export './src/location_service.dart';
+
+// Device
+export './src/device/device_id_provider.dart';


### PR DESCRIPTION
Add DeviceIdProvider utility in trufi_core_utils that generates a UUID v4 on first use and persists it in SharedPreferences. Wire an optional deviceIdProvider callback into every HTTP-producing package (routing OTP 1.5/2.4/2.8, planner, search locations, notifications, maps tiles) so that X-Device-Id is attached to all outgoing requests when configured.