### PR TITLE
Add live GTFS-RT vehicle positions support

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_de.arb
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_de.arb
@@ -115,5 +115,11 @@
   "limitationRequiresInternet": "Erfordert Internet",
   "limitationSlower": "Langsamere Antwort",
   "limitationNoWalkingRoute": "Keine Fußweg-Route auf Karte",
-  "estimatedTimesDisclaimer": "Reisezeiten sind geschätzt und können je nach Verkehr variieren"
+  "estimatedTimesDisclaimer": "Reisezeiten sind geschätzt und können je nach Verkehr variieren",
+
+  "liveVehiclesTitle": "Live-Busse",
+  "liveVehiclesSubtitle": "Zeige die Live-Position der Busse auf der Karte",
+  "liveVehiclesEnable": "Aktivieren",
+  "liveVehiclesStateOn": "Ein",
+  "liveVehiclesStateOff": "Aus"
 }

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_en.arb
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_en.arb
@@ -603,5 +603,26 @@
   "estimatedTimesDisclaimer": "Travel times are estimated and may vary due to traffic",
   "@estimatedTimesDisclaimer": {
     "description": "Disclaimer shown above route results about estimated times"
+  },
+
+  "liveVehiclesTitle": "Live buses",
+  "@liveVehiclesTitle": {
+    "description": "Title of the live vehicles section in the map settings sheet"
+  },
+  "liveVehiclesSubtitle": "Show the live position of buses on the map",
+  "@liveVehiclesSubtitle": {
+    "description": "Subtitle describing what the live vehicles toggle does"
+  },
+  "liveVehiclesEnable": "Enable",
+  "@liveVehiclesEnable": {
+    "description": "Label for the toggle row of the live vehicles section"
+  },
+  "liveVehiclesStateOn": "On",
+  "@liveVehiclesStateOn": {
+    "description": "Secondary label when the live vehicles toggle is enabled"
+  },
+  "liveVehiclesStateOff": "Off",
+  "@liveVehiclesStateOff": {
+    "description": "Secondary label when the live vehicles toggle is disabled"
   }
 }

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_es.arb
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_es.arb
@@ -115,5 +115,11 @@
   "limitationRequiresInternet": "Requiere internet",
   "limitationSlower": "Respuesta más lenta",
   "limitationNoWalkingRoute": "Sin ruta de caminata en mapa",
-  "estimatedTimesDisclaimer": "Los tiempos son estimados y pueden variar según el tráfico"
+  "estimatedTimesDisclaimer": "Los tiempos son estimados y pueden variar según el tráfico",
+
+  "liveVehiclesTitle": "Buses en tiempo real",
+  "liveVehiclesSubtitle": "Mostrar la posición en vivo de los buses sobre el mapa",
+  "liveVehiclesEnable": "Activar",
+  "liveVehiclesStateOn": "Encendido",
+  "liveVehiclesStateOff": "Apagado"
 }

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations.dart
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations.dart
@@ -798,6 +798,36 @@ abstract class HomeScreenLocalizations {
   /// In en, this message translates to:
   /// **'Travel times are estimated and may vary due to traffic'**
   String get estimatedTimesDisclaimer;
+
+  /// Title of the live vehicles section in the map settings sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Live buses'**
+  String get liveVehiclesTitle;
+
+  /// Subtitle describing what the live vehicles toggle does
+  ///
+  /// In en, this message translates to:
+  /// **'Show the live position of buses on the map'**
+  String get liveVehiclesSubtitle;
+
+  /// Label for the toggle row of the live vehicles section
+  ///
+  /// In en, this message translates to:
+  /// **'Enable'**
+  String get liveVehiclesEnable;
+
+  /// Secondary label when the live vehicles toggle is enabled
+  ///
+  /// In en, this message translates to:
+  /// **'On'**
+  String get liveVehiclesStateOn;
+
+  /// Secondary label when the live vehicles toggle is disabled
+  ///
+  /// In en, this message translates to:
+  /// **'Off'**
+  String get liveVehiclesStateOff;
 }
 
 class _HomeScreenLocalizationsDelegate

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_de.dart
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_de.dart
@@ -422,4 +422,20 @@ class HomeScreenLocalizationsDe extends HomeScreenLocalizations {
   @override
   String get estimatedTimesDisclaimer =>
       'Reisezeiten sind geschätzt und können je nach Verkehr variieren';
+
+  @override
+  String get liveVehiclesTitle => 'Live-Busse';
+
+  @override
+  String get liveVehiclesSubtitle =>
+      'Zeige die Live-Position der Busse auf der Karte';
+
+  @override
+  String get liveVehiclesEnable => 'Aktivieren';
+
+  @override
+  String get liveVehiclesStateOn => 'Ein';
+
+  @override
+  String get liveVehiclesStateOff => 'Aus';
 }

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_en.dart
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_en.dart
@@ -421,4 +421,20 @@ class HomeScreenLocalizationsEn extends HomeScreenLocalizations {
   @override
   String get estimatedTimesDisclaimer =>
       'Travel times are estimated and may vary due to traffic';
+
+  @override
+  String get liveVehiclesTitle => 'Live buses';
+
+  @override
+  String get liveVehiclesSubtitle =>
+      'Show the live position of buses on the map';
+
+  @override
+  String get liveVehiclesEnable => 'Enable';
+
+  @override
+  String get liveVehiclesStateOn => 'On';
+
+  @override
+  String get liveVehiclesStateOff => 'Off';
 }

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_es.dart
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_es.dart
@@ -422,4 +422,20 @@ class HomeScreenLocalizationsEs extends HomeScreenLocalizations {
   @override
   String get estimatedTimesDisclaimer =>
       'Los tiempos son estimados y pueden variar según el tráfico';
+
+  @override
+  String get liveVehiclesTitle => 'Buses en tiempo real';
+
+  @override
+  String get liveVehiclesSubtitle =>
+      'Mostrar la posición en vivo de los buses sobre el mapa';
+
+  @override
+  String get liveVehiclesEnable => 'Activar';
+
+  @override
+  String get liveVehiclesStateOn => 'Encendido';
+
+  @override
+  String get liveVehiclesStateOff => 'Apagado';
 }

--- a/packages/screens/trufi_core_home_screen/lib/src/config/home_screen_config.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/config/home_screen_config.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:trufi_core_maps/trufi_core_maps.dart';
 import 'package:trufi_core_poi_layers/trufi_core_poi_layers.dart';
 import 'package:trufi_core_search_locations/trufi_core_search_locations.dart';
@@ -31,36 +32,19 @@ class HomeScreenConfig {
   final String? shareBaseUrl;
 
   /// Optional custom map layers to display on the home screen map.
-  ///
-  /// Use this to add POI layers or other custom map layers.
-  /// Each layer will be automatically added to the map controller.
-  ///
-  /// Example:
-  /// ```dart
-  /// customMapLayers: [
-  ///   POITrufiLayerAdapter(poiLayersCubit),
-  /// ]
-  /// ```
   final List<TrufiLayer> Function(TrufiMapController controller)?
   customMapLayers;
 
   /// Optional POI layers manager for displaying points of interest on the map.
-  ///
-  /// When provided, the HomeScreen will:
-  /// 1. Initialize the layers when the map is ready
-  /// 2. Register the provider in the widget tree for child widgets to access
-  /// 3. Show POI settings in the map type button automatically
-  ///
-  /// Default enabled subcategories are determined by `defaultActive: true`
-  /// in the metadata.json file for each subcategory.
-  ///
-  /// Example:
-  /// ```dart
-  /// poiLayersManager: POILayersManager(
-  ///   assetsBasePath: 'assets/pois',
-  /// ),
-  /// ```
   final POILayersManager? poiLayersManager;
+
+  /// Optional extra section appended under the built-in sections in the map
+  /// settings bottom sheet. Use this for deploy-specific overlays beyond POIs
+  /// and live vehicles.
+  ///
+  /// Note: live vehicle support is wired automatically via the currently-active
+  /// [IRoutingProvider.realtimeVehiclesProvider] — no config needed here.
+  final Widget? extraMapLayerSettings;
 
   const HomeScreenConfig({
     this.chooseLocationZoom = 16.0,
@@ -71,5 +55,6 @@ class HomeScreenConfig {
     this.shareBaseUrl,
     this.customMapLayers,
     this.poiLayersManager,
+    this.extraMapLayerSettings,
   });
 }

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
@@ -6,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:provider/provider.dart';
 import 'package:trufi_core_base_widgets/trufi_core_base_widgets.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart'
     hide ITrufiMapEngine;
@@ -18,6 +20,7 @@ import 'package:trufi_core_utils/trufi_core_utils.dart';
 
 import '../../l10n/home_screen_localizations.dart';
 import '../config/home_screen_config.dart';
+import 'live_vehicles_settings_section.dart';
 import '../cubit/route_planner_cubit.dart';
 import '../models/route_planner_state.dart';
 import '../services/share_route_service.dart';
@@ -97,6 +100,20 @@ class _HomeScreenState extends State<HomeScreen>
   // Deep link handling
   SharedRouteNotifier? _sharedRouteNotifier;
 
+  // Live vehicles (GTFS-RT). These are fully owned by HomeScreen so any deploy
+  // that provides a `realtimeVehiclesProvider` in its config gets the toggle UI
+  // and map rendering "for free" — no controller/notifier plumbing required in
+  // the consuming app.
+  static const _liveVehiclesStorageKey = 'trufi_live_vehicles_enabled';
+  final ValueNotifier<bool> _liveVehiclesEnabled = ValueNotifier<bool>(false);
+  final StorageService _liveVehiclesStorage = SharedPreferencesStorage();
+  List<VehiclePosition> _liveVehicles = const [];
+  Set<String> _selectedTransitRouteIds = const {};
+  StreamSubscription<List<VehiclePosition>>? _liveVehiclesSub;
+
+  routing.RoutingEngineManager? _routingEngineManager;
+  RealtimeVehiclesProvider? _realtimeVehiclesProvider;
+
   @override
   void initState() {
     super.initState();
@@ -104,9 +121,76 @@ class _HomeScreenState extends State<HomeScreen>
     _locationService.addListener(_onLocationUpdate);
     // Listen to POI selection changes
     widget.config.poiLayersManager?.addListener(_onPOISelectionChanged);
+    _liveVehiclesEnabled.addListener(_onLiveVehiclesEnabledChanged);
+    _restoreLiveVehiclesToggle();
+  }
+
+  Future<void> _restoreLiveVehiclesToggle() async {
+    try {
+      await _liveVehiclesStorage.initialize();
+      final saved = await _liveVehiclesStorage.readBool(
+        _liveVehiclesStorageKey,
+      );
+      if (!mounted || saved == null) return;
+      if (_liveVehiclesEnabled.value != saved) {
+        _liveVehiclesEnabled.value = saved;
+      }
+    } catch (_) {
+      // Best-effort: if storage fails, just use the default (off).
+    }
   }
 
   void _onPOISelectionChanged() {
+    if (mounted) setState(() {});
+  }
+
+  /// Rebuilds the live-vehicles wiring when the currently-selected routing
+  /// engine changes. Cancels any previous subscription and, if the new engine
+  /// exposes a [RealtimeVehiclesProvider], subscribes to its stream.
+  void _rewireRealtimeVehicles(RealtimeVehiclesProvider? provider) {
+    if (identical(provider, _realtimeVehiclesProvider)) return;
+
+    _liveVehiclesSub?.cancel();
+    _liveVehiclesSub = null;
+    _realtimeVehiclesProvider?.stop();
+    _liveVehicles = const [];
+
+    _realtimeVehiclesProvider = provider;
+    if (provider == null) {
+      if (mounted) setState(() {});
+      return;
+    }
+
+    _liveVehicles = provider.latest;
+    _liveVehiclesSub = provider.positionsStream.listen((positions) {
+      if (!mounted) return;
+      setState(() => _liveVehicles = positions);
+    });
+    if (_liveVehiclesEnabled.value) {
+      provider.start();
+    }
+    if (mounted) setState(() {});
+  }
+
+  void _onRoutingEngineChanged() {
+    _rewireRealtimeVehicles(
+      _routingEngineManager?.currentEngine.realtimeVehiclesProvider,
+    );
+  }
+
+  void _onLiveVehiclesEnabledChanged() {
+    _liveVehiclesStorage.writeBool(
+      _liveVehiclesStorageKey,
+      _liveVehiclesEnabled.value,
+    );
+    final realtime = _realtimeVehiclesProvider;
+    if (realtime == null) return;
+    if (_liveVehiclesEnabled.value) {
+      realtime.start();
+    } else {
+      realtime.stop();
+      _liveVehicles = const [];
+    }
     if (mounted) setState(() {});
   }
 
@@ -117,6 +201,15 @@ class _HomeScreenState extends State<HomeScreen>
     _setupSharedRouteListener();
     // Parse URL parameters on first load (web only)
     _parseUrlAndSetPlaces();
+    // Wire the realtime-vehicles provider from the currently-active routing
+    // engine. Re-wires automatically when the user switches engines.
+    final manager = context.read<routing.RoutingEngineManager?>();
+    if (_routingEngineManager != manager) {
+      _routingEngineManager?.removeListener(_onRoutingEngineChanged);
+      _routingEngineManager = manager;
+      _routingEngineManager?.addListener(_onRoutingEngineChanged);
+      _rewireRealtimeVehicles(manager?.currentEngine.realtimeVehiclesProvider);
+    }
   }
 
   @override
@@ -393,6 +486,11 @@ class _HomeScreenState extends State<HomeScreen>
     _sharedRouteNotifier?.removeListener(_onSharedRouteChanged);
     _locationService.removeListener(_onLocationUpdate);
     widget.config.poiLayersManager?.removeListener(_onPOISelectionChanged);
+    _routingEngineManager?.removeListener(_onRoutingEngineChanged);
+    _liveVehiclesEnabled.removeListener(_onLiveVehiclesEnabledChanged);
+    _liveVehiclesSub?.cancel();
+    _realtimeVehiclesProvider?.stop();
+    _liveVehiclesEnabled.dispose();
     _locationService.dispose();
     _sheetController.dispose();
     super.dispose();
@@ -609,6 +707,7 @@ class _HomeScreenState extends State<HomeScreen>
     setState(() {
       _routeMarkers = const [];
       _routeLines = const [];
+      _selectedTransitRouteIds = const {};
     });
   }
 
@@ -811,9 +910,17 @@ class _HomeScreenState extends State<HomeScreen>
       );
     }
 
+    final routeIds = <String>{};
+    for (final leg in itinerary.legs) {
+      if (!leg.transitLeg) continue;
+      final id = leg.route?.gtfsId;
+      if (id != null && id.isNotEmpty) routeIds.add(id);
+    }
+
     setState(() {
       _routeMarkers = markers;
       _routeLines = lines;
+      _selectedTransitRouteIds = routeIds;
     });
   }
 
@@ -1196,6 +1303,36 @@ class _HomeScreenState extends State<HomeScreen>
     }
   }
 
+  Widget? _buildMapLayerExtras() {
+    final sections = <Widget>[];
+    if (widget.config.poiLayersManager != null) {
+      sections.add(const POILayersSettingsSection());
+    }
+    if (_realtimeVehiclesProvider != null) {
+      sections.add(
+        LiveVehiclesSettingsSection(
+          enabled: _liveVehiclesEnabled,
+          onChanged: (v) => _liveVehiclesEnabled.value = v,
+        ),
+      );
+    }
+    if (widget.config.extraMapLayerSettings != null) {
+      sections.add(widget.config.extraMapLayerSettings!);
+    }
+    if (sections.isEmpty) return null;
+    if (sections.length == 1) return sections.first;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (int i = 0; i < sections.length; i++) ...[
+          if (i > 0) const SizedBox(height: 16),
+          sections[i],
+        ],
+      ],
+    );
+  }
+
   /// Build the list of TrufiLayer data objects from current state.
   List<TrufiLayer> _buildLayers() {
     final layers = <TrufiLayer>[];
@@ -1218,11 +1355,11 @@ class _HomeScreenState extends State<HomeScreen>
       ));
     }
 
-    // Route layer
-    if (_routeMarkers.isNotEmpty || _routeLines.isNotEmpty) {
+    // Route lines (polylines) sit below live/realtime layers so vehicles
+    // render on top of them.
+    if (_routeLines.isNotEmpty) {
       layers.add(TrufiLayer(
-        id: 'route-layer',
-        markers: _routeMarkers,
+        id: 'route-lines-layer',
         lines: _routeLines,
         layerLevel: 1000,
       ));
@@ -1232,6 +1369,36 @@ class _HomeScreenState extends State<HomeScreen>
     final poiManager = widget.config.poiLayersManager;
     if (poiManager != null) {
       layers.addAll(poiManager.buildLayers());
+    }
+
+    // Live vehicles layer (GTFS-RT) — between route lines and route markers
+    // (origin/destination/transit labels). Rendered only when a provider is
+    // wired and the runtime toggle is on.
+    if (_realtimeVehiclesProvider != null &&
+        _liveVehiclesEnabled.value &&
+        _liveVehicles.isNotEmpty) {
+      final toShow = _selectedTransitRouteIds.isEmpty
+          ? _liveVehicles
+          : _liveVehicles
+                .where(
+                  (v) =>
+                      v.routeId != null &&
+                      _selectedTransitRouteIds.contains(v.routeId),
+                )
+                .toList(growable: false);
+      if (toShow.isNotEmpty) {
+        layers.add(buildVehiclePositionsLayer(vehicles: toShow));
+      }
+    }
+
+    // Route markers (origin/destination/boarding/transit labels) stay on top
+    // so they aren't hidden by live vehicle markers.
+    if (_routeMarkers.isNotEmpty) {
+      layers.add(TrufiLayer(
+        id: 'route-markers-layer',
+        markers: _routeMarkers,
+        layerLevel: 2000,
+      ));
     }
 
     return layers;
@@ -1256,7 +1423,9 @@ class _HomeScreenState extends State<HomeScreen>
     final l10n = HomeScreenLocalizations.of(context);
     final theme = Theme.of(context);
 
-    return Scaffold(
+    return Provider<RealtimeVehiclesProvider?>.value(
+      value: _realtimeVehiclesProvider,
+      child: Scaffold(
       body: BlocConsumer<RoutePlannerCubit, RoutePlannerState>(
         listener: (context, state) {
           _updateLocationMarkers(state);
@@ -1463,6 +1632,7 @@ class _HomeScreenState extends State<HomeScreen>
           );
         },
       ),
+      ),
     );
   }
 
@@ -1492,9 +1662,7 @@ class _HomeScreenState extends State<HomeScreen>
                   onEngineChanged: (engine) {
                     mapEngineManager.setEngine(engine);
                   },
-                  additionalSettings: widget.config.poiLayersManager != null
-                      ? const POILayersSettingsSection()
-                      : null,
+                  additionalSettings: _buildMapLayerExtras(),
                 ),
                 const SizedBox(height: 8),
               ],

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_card.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_card.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart' as routing;
+import 'package:trufi_core_routing_ui/trufi_core_routing_ui.dart';
 
 import '../../l10n/home_screen_localizations.dart';
 
@@ -318,6 +321,7 @@ class _LegChip extends StatelessWidget {
         ? Colors.black87
         : Colors.white;
     final routeName = leg.shortName ?? leg.route?.shortName ?? '';
+    final realtime = context.watch<RealtimeVehiclesProvider?>();
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -338,6 +342,15 @@ class _LegChip extends StatelessWidget {
                 fontWeight: FontWeight.bold,
                 fontSize: 12,
               ),
+            ),
+          ],
+          if (realtime != null) ...[
+            const SizedBox(width: 6),
+            LiveBusBadge.whenLive(
+              provider: realtime,
+              leg: leg,
+              color: textColor,
+              size: 10,
             ),
           ],
         ],

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_detail_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_detail_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart' as routing;
+import 'package:trufi_core_routing_ui/trufi_core_routing_ui.dart';
 
 import '../../l10n/home_screen_localizations.dart';
 
@@ -709,6 +712,23 @@ class _LegItemState extends State<_LegItem> {
                   );
                 },
               ),
+            ),
+            // Live indicator: pulses when a live vehicle is reported for this
+            // leg's route. Only visible if a RealtimeVehiclesProvider is wired.
+            Builder(
+              builder: (context) {
+                final realtime = context.watch<RealtimeVehiclesProvider?>();
+                if (realtime == null) return const SizedBox.shrink();
+                return Padding(
+                  padding: const EdgeInsets.only(left: 6),
+                  child: LiveBusBadge.whenLive(
+                    provider: realtime,
+                    leg: leg,
+                    color: widget.lineColor,
+                    size: 12,
+                  ),
+                );
+              },
             ),
             const SizedBox(width: 8),
             // Duration and distance

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/live_vehicles_settings_section.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/live_vehicles_settings_section.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../../l10n/home_screen_localizations.dart';
+
+/// Section rendered inside the map settings bottom sheet when the screen is
+/// wired with a `RealtimeVehiclesProvider`. Paddings and container styling
+/// match `POILayersSettingsSection` so both read uniformly.
+class LiveVehiclesSettingsSection extends StatelessWidget {
+  const LiveVehiclesSettingsSection({
+    super.key,
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  final ValueListenable<bool> enabled;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final l10n = HomeScreenLocalizations.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                l10n.liveVehiclesTitle,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                l10n.liveVehiclesSubtitle,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+        Container(
+          margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          decoration: BoxDecoration(
+            color: colorScheme.surface,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: colorScheme.outlineVariant.withValues(alpha: 0.5),
+            ),
+          ),
+          child: ValueListenableBuilder<bool>(
+            valueListenable: enabled,
+            builder: (context, isOn, _) {
+              return Material(
+                color: Colors.transparent,
+                borderRadius: BorderRadius.circular(12),
+                child: InkWell(
+                  borderRadius: BorderRadius.circular(12),
+                  onTap: () => onChanged(!isOn),
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 40,
+                          height: 40,
+                          decoration: BoxDecoration(
+                            color: colorScheme.primary.withValues(alpha: 0.12),
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          child: Icon(
+                            Icons.directions_bus_rounded,
+                            size: 22,
+                            color: colorScheme.primary,
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                l10n.liveVehiclesEnable,
+                                style: theme.textTheme.bodyLarge?.copyWith(
+                                  fontWeight: FontWeight.w500,
+                                  color: colorScheme.onSurface,
+                                ),
+                              ),
+                              const SizedBox(height: 1),
+                              Text(
+                                isOn
+                                    ? l10n.liveVehiclesStateOn
+                                    : l10n.liveVehiclesStateOff,
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: colorScheme.onSurfaceVariant,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        Switch(value: isOn, onChanged: onChanged),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/trufi_core_interfaces/lib/src/models/realtime_vehicles_provider.dart
+++ b/packages/trufi_core_interfaces/lib/src/models/realtime_vehicles_provider.dart
@@ -1,0 +1,37 @@
+import 'vehicle_position.dart';
+
+/// Contract for any source of live vehicle positions (GTFS-Realtime via OTP,
+/// direct GTFS-RT, SIRI, custom, etc.).
+///
+/// This interface is intentionally minimal — just enough for UIs to subscribe
+/// to updates and query the current snapshot. Convenience queries like
+/// "vehicles for a given route" live in the [RealtimeVehiclesProviderQueries]
+/// extension below so the contract stays small.
+abstract class RealtimeVehiclesProvider {
+  /// Stream of vehicle position snapshots. Emits the full current fleet on
+  /// every tick.
+  Stream<List<VehiclePosition>> get positionsStream;
+
+  /// Latest snapshot (may be empty before the first tick or after [stop]).
+  List<VehiclePosition> get latest;
+
+  /// Start polling / subscribing. Idempotent.
+  Future<void> start();
+
+  /// Stop polling. Idempotent. The latest snapshot stays available.
+  void stop();
+}
+
+/// Convenience queries computed on top of [RealtimeVehiclesProvider.latest].
+extension RealtimeVehiclesProviderQueries on RealtimeVehiclesProvider {
+  List<VehiclePosition> vehiclesForRoute(String routeGtfsId) => latest
+      .where((v) => v.routeId == routeGtfsId)
+      .toList(growable: false);
+
+  List<VehiclePosition> vehiclesForRoutes(Set<String> routeGtfsIds) => latest
+      .where((v) => v.routeId != null && routeGtfsIds.contains(v.routeId))
+      .toList(growable: false);
+
+  bool hasDataForRoute(String routeGtfsId) =>
+      latest.any((v) => v.routeId == routeGtfsId);
+}

--- a/packages/trufi_core_interfaces/lib/src/models/vehicle_position.dart
+++ b/packages/trufi_core_interfaces/lib/src/models/vehicle_position.dart
@@ -1,0 +1,70 @@
+import 'package:equatable/equatable.dart';
+
+import 'trufi_latlng.dart';
+
+/// Real-time position of a transit vehicle as published by a GTFS-Realtime feed
+/// and exposed through OTP's `vehiclePositions` GraphQL field.
+class VehiclePosition extends Equatable {
+  final String vehicleId;
+  final TrufiLatLng position;
+  final double? heading;
+  final double? speed;
+  final String? label;
+  final String? routeId;
+  final String? routeColor;
+  final String? tripId;
+  final DateTime? timestamp;
+
+  const VehiclePosition({
+    required this.vehicleId,
+    required this.position,
+    this.heading,
+    this.speed,
+    this.label,
+    this.routeId,
+    this.routeColor,
+    this.tripId,
+    this.timestamp,
+  });
+
+  VehiclePosition copyWith({
+    String? vehicleId,
+    TrufiLatLng? position,
+    double? heading,
+    double? speed,
+    String? label,
+    String? routeId,
+    String? routeColor,
+    String? tripId,
+    DateTime? timestamp,
+  }) {
+    return VehiclePosition(
+      vehicleId: vehicleId ?? this.vehicleId,
+      position: position ?? this.position,
+      heading: heading ?? this.heading,
+      speed: speed ?? this.speed,
+      label: label ?? this.label,
+      routeId: routeId ?? this.routeId,
+      routeColor: routeColor ?? this.routeColor,
+      tripId: tripId ?? this.tripId,
+      timestamp: timestamp ?? this.timestamp,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    vehicleId,
+    position,
+    heading,
+    speed,
+    label,
+    routeId,
+    routeColor,
+    tripId,
+    timestamp,
+  ];
+
+  @override
+  String toString() =>
+      'VehiclePosition($vehicleId, $position, heading=$heading, route=$routeId)';
+}

--- a/packages/trufi_core_interfaces/lib/trufi_core_interfaces.dart
+++ b/packages/trufi_core_interfaces/lib/trufi_core_interfaces.dart
@@ -16,6 +16,8 @@ export './src/models/trufi_latlng.dart';
 export './src/models/trufi_location.dart';
 export './src/models/trufi_place.dart';
 export './src/models/journey_plan.dart';
+export './src/models/vehicle_position.dart';
+export './src/models/realtime_vehicles_provider.dart';
 
 // Map interfaces
 export './src/map/map_engine.dart';

--- a/packages/trufi_core_maps/lib/src/configuration/markers/vehicle_position_marker.dart
+++ b/packages/trufi_core_maps/lib/src/configuration/markers/vehicle_position_marker.dart
@@ -1,0 +1,113 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// Live vehicle marker: a circular badge with an upright bus icon plus a small
+/// rotating arrow that indicates heading.
+///
+/// Keeping the bus icon upright (and rotating only the arrow) ensures the
+/// icon is always readable regardless of direction of travel.
+class VehiclePositionMarker extends StatelessWidget {
+  const VehiclePositionMarker({
+    super.key,
+    this.color = const Color(0xFF1E88E5),
+    this.size = 28,
+    this.heading = 0,
+    this.icon = Icons.directions_bus_rounded,
+  });
+
+  final Color color;
+  final double size;
+  final double heading;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final total = size * 1.55;
+    final arrowSize = size * 0.55;
+    final arrowOffset = size * 0.5;
+
+    return SizedBox(
+      width: total,
+      height: total,
+      child: Stack(
+        alignment: Alignment.center,
+        clipBehavior: Clip.none,
+        children: [
+          Transform.rotate(
+            angle: heading * math.pi / 180,
+            child: Transform.translate(
+              offset: Offset(0, -arrowOffset),
+              child: _HeadingChevron(size: arrowSize, color: color),
+            ),
+          ),
+          Container(
+            width: size,
+            height: size,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+              border: Border.all(color: Colors.white, width: 2.5),
+              boxShadow: const [
+                BoxShadow(
+                  color: Colors.black38,
+                  blurRadius: 4,
+                  offset: Offset(0, 1),
+                ),
+              ],
+            ),
+            child: Icon(
+              icon,
+              size: size * 0.6,
+              color: Colors.white,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeadingChevron extends StatelessWidget {
+  const _HeadingChevron({required this.size, required this.color});
+
+  final double size;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      size: Size(size, size),
+      painter: _ChevronPainter(color: color),
+    );
+  }
+}
+
+class _ChevronPainter extends CustomPainter {
+  _ChevronPainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final fill = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill;
+    final stroke = Paint()
+      ..color = Colors.white
+      ..strokeWidth = 1.5
+      ..style = PaintingStyle.stroke;
+
+    final path = Path()
+      ..moveTo(size.width / 2, 0)
+      ..lineTo(size.width, size.height)
+      ..lineTo(0, size.height)
+      ..close();
+
+    canvas.drawPath(path, fill);
+    canvas.drawPath(path, stroke);
+  }
+
+  @override
+  bool shouldRepaint(covariant _ChevronPainter old) => old.color != color;
+}

--- a/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
@@ -103,6 +103,7 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
 
   // Source tracking
   final Set<String> _initializedSources = {};
+  final Map<String, int> _initializedLayerLevels = {};
   final Map<String, Future<void>> _sourceInit = {};
 
   // Spatial indices for marker picking
@@ -332,6 +333,7 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
       await ctl.removeSource(sourceId);
     } catch (_) {}
     _initializedSources.remove(sourceId);
+    _initializedLayerLevels.remove(sourceId);
     _markerIndices.remove(sourceId);
   }
 
@@ -346,6 +348,21 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
     if (inFlight != null) {
       await inFlight;
       return;
+    }
+
+    // MapLibre z-order is determined by layer addition order, not by any
+    // native "level" concept. To render this TrufiLayer between existing
+    // ones, find the lowest-layerLevel layer already initialized whose level
+    // is higher than ours and insert this one below its sublayers.
+    String? belowLayerId;
+    int? lowestHigherLevel;
+    for (final entry in _initializedLayerLevels.entries) {
+      if (entry.value > layer.layerLevel) {
+        if (lowestHigherLevel == null || entry.value < lowestHigherLevel) {
+          lowestHigherLevel = entry.value;
+          belowLayerId = '${entry.key}_dotted';
+        }
+      }
     }
 
     final future = () async {
@@ -364,6 +381,7 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
           lineDasharray: [2, 1],
           lineJoin: "round",
         ),
+        belowLayerId: belowLayerId,
         filter: [
           "==",
           ["get", "dotted"],
@@ -382,6 +400,7 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
           lineJoin: "round",
           lineCap: "round",
         ),
+        belowLayerId: belowLayerId,
         filter: [
           "==",
           ["get", "dotted"],
@@ -401,6 +420,7 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
           iconRotate: ["get", "rotate"],
           symbolSortKey: ["get", "layerLevel"],
         ),
+        belowLayerId: belowLayerId,
         filter: [
           "==",
           ["get", "allowOverlap"],
@@ -420,6 +440,7 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
           iconRotate: ["get", "rotate"],
           symbolSortKey: ["get", "layerLevel"],
         ),
+        belowLayerId: belowLayerId,
         filter: [
           "==",
           ["get", "allowOverlap"],
@@ -429,6 +450,7 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
       );
 
       _initializedSources.add(sourceId);
+      _initializedLayerLevels[sourceId] = layer.layerLevel;
     }();
 
     _sourceInit[sourceId] = future;
@@ -620,6 +642,7 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
       onStyleLoadedCallback: () async {
         _mapReady = true;
         _initializedSources.clear();
+        _initializedLayerLevels.clear();
         _imageLoaders.clear();
         _loadedImages.clear();
         _sourceInit.clear();

--- a/packages/trufi_core_maps/lib/src/presentation/vehicles/vehicle_positions_layer.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/vehicles/vehicle_positions_layer.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
+
+import '../../configuration/markers/vehicle_position_marker.dart';
+import '../../domain/entities/marker.dart';
+import '../../domain/layers/trufi_layer.dart';
+
+typedef VehicleColorResolver = Color Function(VehiclePosition vehicle);
+
+/// Builds a [TrufiLayer] from a list of [VehiclePosition]s.
+///
+/// By default, each vehicle is colored using its own [VehiclePosition.routeColor]
+/// when present (parsed as a 6-digit hex string without the `#`). Pass a custom
+/// [colorResolver] to override. Falls back to a neutral blue.
+TrufiLayer buildVehiclePositionsLayer({
+  required List<VehiclePosition> vehicles,
+  String layerId = 'realtime-vehicles',
+  int layerLevel = 1500,
+  VehicleColorResolver? colorResolver,
+  Color fallbackColor = const Color(0xFF1E88E5),
+  double markerSize = 28,
+}) {
+  final markers = <TrufiMarker>[];
+
+  for (final v in vehicles) {
+    final color = colorResolver?.call(v) ?? _colorFromHex(v.routeColor) ?? fallbackColor;
+    final heading = v.heading ?? 0;
+    final headingBucket = (heading / 15).round();
+    final total = markerSize * 1.55;
+    markers.add(
+      TrufiMarker(
+        id: 'vehicle-${v.vehicleId}',
+        position: LatLng(v.position.latitude, v.position.longitude),
+        widget: VehiclePositionMarker(
+          color: color,
+          size: markerSize,
+          heading: heading,
+        ),
+        size: Size(total, total),
+        allowOverlap: true,
+        layerLevel: layerLevel,
+        imageCacheKey:
+            'vehicle_${color.toARGB32()}_${headingBucket}_${markerSize.toInt()}',
+      ),
+    );
+  }
+
+  return TrufiLayer(id: layerId, markers: markers, layerLevel: layerLevel);
+}
+
+Color? _colorFromHex(String? hex) {
+  if (hex == null || hex.isEmpty) return null;
+  final clean = hex.startsWith('#') ? hex.substring(1) : hex;
+  if (clean.length != 6 && clean.length != 8) return null;
+  final parsed = int.tryParse(clean, radix: 16);
+  if (parsed == null) return null;
+  return clean.length == 6 ? Color(0xFF000000 | parsed) : Color(parsed);
+}

--- a/packages/trufi_core_maps/lib/trufi_core_maps.dart
+++ b/packages/trufi_core_maps/lib/trufi_core_maps.dart
@@ -27,6 +27,7 @@ export 'src/configuration/map_layer/map_layer_storage_impl.dart';
 export 'src/configuration/markers/from_marker.dart';
 export 'src/configuration/markers/to_marker.dart';
 export 'src/configuration/markers/my_location_marker.dart';
+export 'src/configuration/markers/vehicle_position_marker.dart';
 export 'src/configuration/map_engine/trufi_map_engine.dart';
 export 'src/configuration/map_engine/maplibre_engine.dart';
 export 'src/configuration/map_engine/map_engine_manager.dart';
@@ -58,6 +59,11 @@ export 'src/domain/layers/fit_camera_layer.dart';
 // PRESENTATION LAYER - Map Widget
 // ============================================
 export 'src/presentation/map/trufi_map.dart';
+
+// ============================================
+// PRESENTATION LAYER - Vehicles
+// ============================================
+export 'src/presentation/vehicles/vehicle_positions_layer.dart';
 
 // ============================================
 // PRESENTATION LAYER - Utils

--- a/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
@@ -31,7 +31,7 @@ import 'otp_1_5_response_parser.dart';
 ///   endpoint: 'https://otp.example.com',
 /// );
 /// ```
-class Otp15RoutingProvider implements IRoutingProvider {
+class Otp15RoutingProvider extends IRoutingProvider {
   /// The OTP endpoint URL.
   ///
   /// Can be the base URL (e.g., "https://example.com/otp") or

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_routing_provider.dart
@@ -27,7 +27,7 @@ import 'otp_2_4_response_parser.dart';
 ///   endpoint: 'https://otp.example.com',
 /// );
 /// ```
-class Otp24RoutingProvider implements IRoutingProvider {
+class Otp24RoutingProvider extends IRoutingProvider {
   /// The OTP endpoint URL.
   ///
   /// Can be the base URL (e.g., "https://example.com/otp") or

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
@@ -2,12 +2,14 @@ import 'package:flutter/widgets.dart';
 // ignore: depend_on_referenced_packages
 import 'package:gql/language.dart';
 import 'package:graphql/client.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 
 import '../otp_2_4/graphql_client_factory.dart';
 import '../../models/plan.dart';
 import '../../models/routing_location.dart';
 import '../../models/stop.dart';
 import '../../models/transit_route.dart';
+import '../../services/vehicle_positions_service.dart';
 import '../otp_2_4/otp_2_4_pattern_queries.dart' as pattern_queries;
 import '../routing_provider.dart';
 import 'otp_28_preferences.dart';
@@ -27,7 +29,7 @@ import 'otp_2_8_response_parser.dart';
 ///   endpoint: 'https://otp.trufi.app',
 /// );
 /// ```
-class Otp28RoutingProvider implements IRoutingProvider {
+class Otp28RoutingProvider extends IRoutingProvider {
   /// The OTP endpoint URL.
   ///
   /// Can be the base URL (e.g., "https://example.com/otp") or
@@ -52,6 +54,15 @@ class Otp28RoutingProvider implements IRoutingProvider {
   /// Whether to show the bicycle transport mode option in preferences UI.
   final bool showBicycleOption;
 
+  /// Whether this provider exposes a companion GTFS-Realtime vehicle positions
+  /// source. When true, [realtimeVehiclesProvider] returns a lazily-created
+  /// [OtpVehiclePositionsProvider] bound to the same [endpoint].
+  final bool liveVehiclesEnabled;
+
+  /// Poll interval for the live vehicle positions stream. Ignored when
+  /// [liveVehiclesEnabled] is false.
+  final Duration liveVehiclesPollInterval;
+
   Otp28RoutingProvider({
     required this.endpoint,
     this.useSimpleQuery = false,
@@ -60,7 +71,20 @@ class Otp28RoutingProvider implements IRoutingProvider {
     this.planHeaderProvider,
     this.showWheelchairOption = true,
     this.showBicycleOption = true,
+    this.liveVehiclesEnabled = false,
+    this.liveVehiclesPollInterval = const Duration(seconds: 10),
   });
+
+  OtpVehiclePositionsProvider? _realtimeVehiclesProvider;
+
+  @override
+  RealtimeVehiclesProvider? get realtimeVehiclesProvider {
+    if (!liveVehiclesEnabled) return null;
+    return _realtimeVehiclesProvider ??= OtpVehiclePositionsProvider(
+      endpoint: endpoint,
+      pollInterval: liveVehiclesPollInterval,
+    );
+  }
 
   late final _prefs = Otp28PreferencesState();
 

--- a/packages/trufi_core_routing/lib/src/providers/routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/routing_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/widgets.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 
 import '../models/plan.dart';
 import '../models/routing_location.dart';
@@ -106,6 +107,19 @@ abstract class IRoutingProvider {
 
   /// Resets provider-specific preferences to defaults.
   void resetPreferences() {}
+
+  /// Optional companion provider of live (GTFS-Realtime) vehicle positions.
+  ///
+  /// Return non-null when this routing engine has a paired source of live
+  /// vehicle data (e.g. OTP 2.x with GTFS-RT vehiclePositions). When set,
+  /// `trufi_core_home_screen` automatically:
+  /// - Shows a "Live buses" toggle in the map settings sheet.
+  /// - Renders interpolated bus markers on the map filtered by the selected
+  ///   itinerary's routes.
+  /// - Lets itinerary tiles render a "live" badge on matching routes.
+  ///
+  /// Default: null (no live vehicles).
+  RealtimeVehiclesProvider? get realtimeVehiclesProvider => null;
 }
 
 /// Option for routing provider selection UI.

--- a/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_provider.dart
@@ -41,7 +41,7 @@ import 'trufi_planner_preferences.dart';
 ///   ),
 /// )
 /// ```
-class TrufiPlannerProvider implements IRoutingProvider {
+class TrufiPlannerProvider extends IRoutingProvider {
   final TrufiPlannerConfig config;
   late final TrufiPlannerDataSource _dataSource;
 

--- a/packages/trufi_core_routing/lib/src/services/vehicle_positions_service.dart
+++ b/packages/trufi_core_routing/lib/src/services/vehicle_positions_service.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+// ignore: depend_on_referenced_packages
+import 'package:gql/language.dart';
+import 'package:graphql/client.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
+
+import '../providers/otp_2_4/graphql_client_factory.dart';
+
+const _query = '''
+{
+  routes {
+    gtfsId
+    color
+    patterns {
+      code
+      vehiclePositions {
+        vehicleId
+        label
+        lat
+        lon
+        heading
+        speed
+        trip { gtfsId }
+      }
+    }
+  }
+}
+''';
+
+/// OTP-backed implementation of [RealtimeVehiclesProvider]. Polls the OTP
+/// GraphQL endpoint periodically for GTFS-Realtime vehicle positions.
+///
+/// ```dart
+/// final provider = OtpVehiclePositionsProvider(
+///   endpoint: 'https://otp.example.com',
+///   pollInterval: Duration(seconds: 10),
+/// );
+/// await provider.start();
+/// ```
+class OtpVehiclePositionsProvider implements RealtimeVehiclesProvider {
+  OtpVehiclePositionsProvider({
+    required this.endpoint,
+    this.pollInterval = const Duration(seconds: 10),
+    this.requestTimeout = const Duration(seconds: 10),
+  });
+
+  final String endpoint;
+  final Duration pollInterval;
+  final Duration requestTimeout;
+
+  final _controller = StreamController<List<VehiclePosition>>.broadcast();
+  Timer? _timer;
+  GraphQLClient? _client;
+  List<VehiclePosition> _latest = const [];
+
+  @override
+  Stream<List<VehiclePosition>> get positionsStream => _controller.stream;
+
+  @override
+  List<VehiclePosition> get latest => _latest;
+
+  bool get isRunning => _timer != null;
+
+  @override
+  Future<void> start() async {
+    if (_timer != null) return;
+    debugPrint(
+      '[RealtimeVehicles] polling $_graphqlEndpoint every $pollInterval',
+    );
+    _client = GraphQLClientFactory.create(_graphqlEndpoint, timeout: requestTimeout);
+    await _tick();
+    _timer = Timer.periodic(pollInterval, (_) => _tick());
+  }
+
+  @override
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  Future<void> dispose() async {
+    stop();
+    await _controller.close();
+  }
+
+  Future<void> _tick() async {
+    final client = _client;
+    if (client == null) return;
+    try {
+      final result = await client.query(
+        WatchQueryOptions(
+          document: parseString(_query),
+          fetchResults: true,
+          fetchPolicy: FetchPolicy.networkOnly,
+        ),
+      );
+
+      if (result.hasException) {
+        debugPrint('[RealtimeVehicles] query exception: ${result.exception}');
+        return;
+      }
+      if (result.data == null) {
+        debugPrint('[RealtimeVehicles] query returned null data');
+        return;
+      }
+
+      final routes = result.data!['routes'] as List<dynamic>? ?? const [];
+      final positions = <VehiclePosition>[];
+
+      for (final route in routes) {
+        final routeMap = route as Map<String, dynamic>;
+        final routeId = routeMap['gtfsId'] as String?;
+        final routeColor = routeMap['color'] as String?;
+        final patterns = routeMap['patterns'] as List<dynamic>? ?? const [];
+        for (final pattern in patterns) {
+          final patternMap = pattern as Map<String, dynamic>;
+          final vehicles =
+              patternMap['vehiclePositions'] as List<dynamic>? ?? const [];
+          for (final v in vehicles) {
+            final position = _parseVehicle(
+              v as Map<String, dynamic>,
+              routeId,
+              routeColor,
+            );
+            if (position != null) positions.add(position);
+          }
+        }
+      }
+
+      _latest = positions;
+      _controller.add(positions);
+      debugPrint('[RealtimeVehicles] tick: ${positions.length} vehicles');
+    } catch (e, st) {
+      debugPrint('[RealtimeVehicles] tick error: $e\n$st');
+    }
+  }
+
+  VehiclePosition? _parseVehicle(
+    Map<String, dynamic> json,
+    String? routeId,
+    String? routeColor,
+  ) {
+    final lat = (json['lat'] as num?)?.toDouble();
+    final lon = (json['lon'] as num?)?.toDouble();
+    final vehicleId = json['vehicleId'] as String?;
+    if (lat == null || lon == null || vehicleId == null) return null;
+
+    final trip = json['trip'] as Map<String, dynamic>?;
+    return VehiclePosition(
+      vehicleId: vehicleId,
+      position: TrufiLatLng(lat, lon),
+      heading: (json['heading'] as num?)?.toDouble(),
+      speed: (json['speed'] as num?)?.toDouble(),
+      label: json['label'] as String?,
+      routeId: routeId,
+      routeColor: routeColor,
+      tripId: trip?['gtfsId'] as String?,
+      timestamp: DateTime.now(),
+    );
+  }
+
+  String get _graphqlEndpoint {
+    if (endpoint.contains('/graphql') || endpoint.contains('/gtfs/v1')) {
+      return endpoint;
+    }
+    final base = endpoint.endsWith('/')
+        ? endpoint.substring(0, endpoint.length - 1)
+        : endpoint;
+    return '$base/otp/gtfs/v1';
+  }
+}
+
+/// Deprecated alias kept for callers that haven't migrated yet.
+@Deprecated('Use OtpVehiclePositionsProvider')
+typedef VehiclePositionsService = OtpVehiclePositionsProvider;

--- a/packages/trufi_core_routing/lib/trufi_core_routing.dart
+++ b/packages/trufi_core_routing/lib/trufi_core_routing.dart
@@ -57,6 +57,13 @@ export 'src/providers/otp_2_8/otp_2_8_queries.dart';
 export 'src/providers/otp_2_8/otp_2_8_response_parser.dart';
 
 // ============================================
+// SERVICES
+// ============================================
+// `VehiclePositionsService` is a deprecated typedef for
+// `OtpVehiclePositionsProvider` — both are exported for compatibility.
+export 'src/services/vehicle_positions_service.dart';
+
+// ============================================
 // Localizations
 // ============================================
 export 'l10n/routing_localizations.dart';

--- a/packages/trufi_core_routing_ui/lib/src/live_bus_badge.dart
+++ b/packages/trufi_core_routing_ui/lib/src/live_bus_badge.dart
@@ -1,0 +1,165 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
+import 'package:trufi_core_routing/trufi_core_routing.dart' as routing;
+
+/// Small pulsing wifi-style indicator shown on transit leg UI when the leg's
+/// route currently has live vehicle data flowing.
+///
+/// Consumers wire this up by providing a [RealtimeVehiclesProvider] and the
+/// widget polls [provider.hasDataForRoute] reactively.
+class LiveBusBadge extends StatefulWidget {
+  const LiveBusBadge({
+    super.key,
+    required this.provider,
+    required this.routeGtfsId,
+    this.color = const Color(0xFF22C55E),
+    this.size = 14,
+  });
+
+  /// Builder that returns [LiveBusBadge] only when the provider actually has
+  /// data for the given route, otherwise a [SizedBox.shrink].
+  static Widget whenLive({
+    required RealtimeVehiclesProvider? provider,
+    required routing.Leg leg,
+    Color color = const Color(0xFF22C55E),
+    double size = 14,
+  }) {
+    if (provider == null || !leg.transitLeg) {
+      return const SizedBox.shrink();
+    }
+    final rid = leg.route?.gtfsId;
+    if (rid == null || rid.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return _ReactiveLiveBusBadge(
+      provider: provider,
+      routeGtfsId: rid,
+      color: color,
+      size: size,
+    );
+  }
+
+  final RealtimeVehiclesProvider provider;
+  final String routeGtfsId;
+  final Color color;
+  final double size;
+
+  @override
+  State<LiveBusBadge> createState() => _LiveBusBadgeState();
+}
+
+class _LiveBusBadgeState extends State<LiveBusBadge>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _pulse;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulse = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1200),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _pulse.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _pulse,
+      builder: (context, _) {
+        final t = _pulse.value;
+        final scale = 0.8 + (t * 0.4);
+        final opacity = (1 - t).clamp(0.0, 1.0);
+        return SizedBox(
+          width: widget.size,
+          height: widget.size,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              Opacity(
+                opacity: opacity,
+                child: Transform.scale(
+                  scale: scale,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: widget.color.withValues(alpha: 0.35),
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ),
+              ),
+              Container(
+                width: widget.size * 0.55,
+                height: widget.size * 0.55,
+                decoration: BoxDecoration(
+                  color: widget.color,
+                  shape: BoxShape.circle,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Rebuilds on provider stream ticks; only shows the badge while there is
+/// at least one vehicle reported for [routeGtfsId].
+class _ReactiveLiveBusBadge extends StatefulWidget {
+  const _ReactiveLiveBusBadge({
+    required this.provider,
+    required this.routeGtfsId,
+    required this.color,
+    required this.size,
+  });
+
+  final RealtimeVehiclesProvider provider;
+  final String routeGtfsId;
+  final Color color;
+  final double size;
+
+  @override
+  State<_ReactiveLiveBusBadge> createState() => _ReactiveLiveBusBadgeState();
+}
+
+class _ReactiveLiveBusBadgeState extends State<_ReactiveLiveBusBadge> {
+  late bool _live;
+  StreamSubscription<List<VehiclePosition>>? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+    _live = widget.provider.hasDataForRoute(widget.routeGtfsId);
+    _sub = widget.provider.positionsStream.listen((_) {
+      final next = widget.provider.hasDataForRoute(widget.routeGtfsId);
+      if (mounted && next != _live) {
+        setState(() => _live = next);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_live) return const SizedBox.shrink();
+    return LiveBusBadge(
+      provider: widget.provider,
+      routeGtfsId: widget.routeGtfsId,
+      color: widget.color,
+      size: widget.size,
+    );
+  }
+}

--- a/packages/trufi_core_routing_ui/lib/trufi_core_routing_ui.dart
+++ b/packages/trufi_core_routing_ui/lib/trufi_core_routing_ui.dart
@@ -15,5 +15,8 @@ export 'src/transport_mode_ui.dart';
 export 'src/leg_ui.dart';
 export 'src/itinerary_ui.dart';
 
+// Live / real-time UI
+export 'src/live_bus_badge.dart';
+
 // SVG Icons
 export 'src/icons/transport_icons.dart';

--- a/packages/trufi_core_routing_ui/pubspec.yaml
+++ b/packages/trufi_core_routing_ui/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
     sdk: flutter
   flutter_svg: ^2.0.10+1
   intl: ^0.20.2
+  trufi_core_interfaces: ^1.0.0
   trufi_core_routing: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
## Summary

Provider-agnostic wiring for live transit data. Any `IRoutingProvider` can expose a companion `RealtimeVehiclesProvider`; `Otp28RoutingProvider` opts in via `liveVehiclesEnabled: true` and internally instantiates an `OtpVehiclePositionsProvider` that polls the OTP GraphQL endpoint.

`HomeScreen` picks it up from the active routing engine and renders:

- A **"Live buses" section** inside the map settings sheet with a persistent on/off toggle (off by default, saved via `SharedPreferencesStorage`).
- **Interpolated vehicle markers** on the map, filtered to the routes of the currently-selected itinerary (all vehicles when no itinerary selected). Markers are tinted by the route's GTFS `color` and sit between the route polyline and the origin/destination markers in z-order.
- A **pulsing live badge** on transit leg chips (itinerary card and detail screen) for routes that currently have live data.

## No breaking changes

Deploys that don't enable live vehicles see zero behavioral change. OTP 1.5 / 2.4 and the local Trufi Planner inherit the default `null` getter and simply don't expose live data.

## Usage (consumer app)

```dart
Otp28RoutingProvider(
  endpoint: 'https://otp.example.com',
  liveVehiclesEnabled: true,
)
```

That's it. The home screen picks it up automatically.

## Architecture

- `trufi_core_interfaces`: `VehiclePosition` model + `RealtimeVehiclesProvider` abstract interface (4 methods) + extension-method queries (`vehiclesForRoute`, `hasDataForRoute`, etc.)
- `trufi_core_routing`: `OtpVehiclePositionsProvider` concrete impl backed by OTP GraphQL; `IRoutingProvider.realtimeVehiclesProvider` optional getter
- `trufi_core_maps`: `VehiclePositionMarker` widget + `buildVehiclePositionsLayer` helper with route-color resolution and z-order fix in `TrufiMap._ensureLayerInitialized` (uses `belowLayerId` to maintain layer order across map source additions)
- `trufi_core_routing_ui`: `LiveBusBadge` widget + `whenLive` helper
- `trufi_core_home_screen`: internal state + `LiveVehiclesSettingsSection` widget + i18n (en/es/de)

## Test plan

- [ ] Deploy with `liveVehiclesEnabled: true` on an OTP 2.x endpoint that exposes GTFS-RT vehicle positions and confirm buses appear on the map when the toggle is on.
- [ ] Verify the toggle persists across app restarts.
- [ ] Confirm a deploy that doesn't set `liveVehiclesEnabled` behaves identically to before this change (no network calls to vehiclePositions, no new UI).
- [ ] Check i18n renders in es/en/de.