### PR TITLE
feat: add showDepartureTimeChip flag to HomeScreenConfig

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/src/config/home_screen_config.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/config/home_screen_config.dart
@@ -46,6 +46,10 @@ class HomeScreenConfig {
   /// [IRoutingProvider.realtimeVehiclesProvider] — no config needed here.
   final Widget? extraMapLayerSettings;
 
+  /// Whether to show the departure time chip above the map.
+  /// Set to false to hide the "Leave now / Arrive by" selector.
+  final bool showDepartureTimeChip;
+
   const HomeScreenConfig({
     this.chooseLocationZoom = 16.0,
     this.searchService,
@@ -56,5 +60,6 @@ class HomeScreenConfig {
     this.customMapLayers,
     this.poiLayersManager,
     this.extraMapLayerSettings,
+    this.showDepartureTimeChip = true,
   });
 }

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -1586,8 +1586,9 @@ class _HomeScreenState extends State<HomeScreen>
                                 onMenuPressed: widget.onMenuPressed,
                               ),
                               // Departure time chip (visible when locations are set)
-                              if (state.fromPlace != null ||
-                                  state.toPlace != null)
+                              if (widget.config.showDepartureTimeChip &&
+                                  (state.fromPlace != null ||
+                                      state.toPlace != null))
                                 Padding(
                                   padding: const EdgeInsets.only(top: 8),
                                   child: _DepartureTimeChip(


### PR DESCRIPTION
#872 
Add a showDepartureTimeChip boolean flag to HomeScreenConfig (default: true) to allow apps to hide the "Leave now / Arrive by" departure time selector.

When set to false, the chip is never rendered regardless of whether origin or destination locations are set. Default value preserves existing behavior for all apps that do not set this flag.