### PR TITLE
feat: SocialMediaLink accepts Widget icon + add SocialMediaPreset enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 5.9.0
+
+### Breaking
+- `SocialMediaLink.icon` is now `Widget` instead of `IconData`. Apps that pass an `IconData` must wrap it: `icon: Icons.facebook` → `icon: const Icon(Icons.facebook)`. The migration is mechanical and small (1 line per link).
+
+### Features
+- New `SocialMediaPreset` enum (exported from `trufi_core_ui`) with brand-correct icons for Facebook, Instagram, WhatsApp and Twitter/X. Use as `icon: SocialMediaPreset.instagram.icon`. Brand SVGs sourced from [Simple Icons](https://simpleicons.org) (CC0 1.0). Inherits color from the ambient `IconTheme`.
+- `trufi_core_ui` declares `flutter_svg` as a direct dependency (was already transitive via `trufi_core_maps`).
+
+---
+
 ## 5.6.0
 
 ### Features

--- a/apps/example/lib/main.dart
+++ b/apps/example/lib/main.dart
@@ -214,20 +214,20 @@ void main() {
       deepLinkScheme: _deepLinkScheme,
       defaultLocale: Locale('es'),
       themeConfig: const TrufiThemeConfig(),
-      socialMediaLinks: const [
+      socialMediaLinks: [
         SocialMediaLink(
           url: _facebookUrl,
-          icon: Icons.facebook,
+          icon: SocialMediaPreset.facebook.icon,
           label: 'Facebook',
         ),
         SocialMediaLink(
           url: _xTwitterUrl,
-          icon: Icons.close,
+          icon: SocialMediaPreset.twitter.icon,
           label: 'X (Twitter)',
         ),
         SocialMediaLink(
           url: _instagramUrl,
-          icon: Icons.camera_alt_outlined,
+          icon: SocialMediaPreset.instagram.icon,
           label: 'Instagram',
         ),
       ],

--- a/packages/trufi_core_interfaces/lib/src/config/social_media_config.dart
+++ b/packages/trufi_core_interfaces/lib/src/config/social_media_config.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/widgets.dart';
 
-/// Represents a single social media link
+/// Represents a single social media link.
+///
+/// [icon] is any widget — typically a [Icon] for font glyphs or a
+/// `SvgPicture.string(...)` for vector brand logos. For common platforms
+/// (Facebook, Instagram, WhatsApp, Twitter/X) consider using the
+/// `SocialMediaPreset` enum exported from `trufi_core_ui`.
 class SocialMediaLink {
   final String url;
-  final IconData icon;
+  final Widget icon;
   final String? label;
 
   const SocialMediaLink({required this.url, required this.icon, this.label});

--- a/packages/trufi_core_ui/lib/src/config/social_media_preset.dart
+++ b/packages/trufi_core_ui/lib/src/config/social_media_preset.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+/// Common social media presets with brand-correct icons.
+///
+/// Use the [icon] getter to obtain a ready-to-use widget for
+/// `SocialMediaLink.icon`:
+///
+/// ```dart
+/// SocialMediaLink(
+///   url: 'https://www.instagram.com/your-handle',
+///   icon: SocialMediaPreset.instagram.icon,
+///   label: 'Instagram',
+/// )
+/// ```
+///
+/// Brand SVGs are sourced from [Simple Icons](https://simpleicons.org)
+/// (CC0 1.0 Universal). Trademarks belong to their respective owners; the
+/// glyphs are intended for linking back to those platforms.
+enum SocialMediaPreset { facebook, instagram, whatsapp, twitter }
+
+extension SocialMediaPresetIcon on SocialMediaPreset {
+  /// Default icon size used by the drawer footer.
+  static const double _defaultSize = 20;
+
+  /// A widget rendering the brand glyph in `currentColor`. Wrap in
+  /// `IconTheme(data: IconThemeData(color: ...))` if you want to override
+  /// the color from the surrounding theme.
+  Widget get icon => switch (this) {
+    SocialMediaPreset.facebook => const Icon(Icons.facebook),
+    SocialMediaPreset.instagram => const _BrandSvg(_instagramSvg),
+    SocialMediaPreset.whatsapp => const _BrandSvg(_whatsappSvg),
+    SocialMediaPreset.twitter => const _BrandSvg(_twitterSvg),
+  };
+}
+
+/// Internal renderer that bakes default sizing and inherits the icon color
+/// from the ambient `IconTheme` so brand SVGs visually match `Icon` widgets.
+class _BrandSvg extends StatelessWidget {
+  final String svg;
+  const _BrandSvg(this.svg);
+
+  @override
+  Widget build(BuildContext context) {
+    final color = IconTheme.of(context).color;
+    return SvgPicture.string(
+      svg,
+      width: SocialMediaPresetIcon._defaultSize,
+      height: SocialMediaPresetIcon._defaultSize,
+      colorFilter: color != null
+          ? ColorFilter.mode(color, BlendMode.srcIn)
+          : null,
+    );
+  }
+}
+
+// ============================================================================
+// Brand SVGs — Simple Icons, CC0 1.0 Universal
+// https://github.com/simple-icons/simple-icons
+// ============================================================================
+
+const _instagramSvg =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">'
+    '<path d="M12 0C8.74 0 8.333.015 7.053.072 5.775.132 4.905.333 4.14.63c-.789.306-1.459.717-2.126 1.384S.935 3.35.63 4.14C.333 4.905.131 5.775.072 7.053.012 8.333 0 8.74 0 12s.015 3.667.072 4.947c.06 1.277.261 2.148.558 2.913.306.788.717 1.459 1.384 2.126.667.666 1.336 1.079 2.126 1.384.766.296 1.636.499 2.913.558C8.333 23.988 8.74 24 12 24s3.667-.015 4.947-.072c1.277-.06 2.148-.262 2.913-.558.788-.306 1.459-.718 2.126-1.384.666-.667 1.079-1.335 1.384-2.126.296-.765.499-1.636.558-2.913.06-1.28.072-1.687.072-4.947s-.015-3.667-.072-4.947c-.06-1.277-.262-2.149-.558-2.913-.306-.789-.718-1.459-1.384-2.126C21.319 1.347 20.651.935 19.86.63c-.765-.297-1.636-.499-2.913-.558C15.667.012 15.26 0 12 0zm0 2.16c3.203 0 3.585.016 4.85.071 1.17.055 1.805.249 2.227.415.562.217.96.477 1.382.896.419.42.679.819.896 1.381.164.422.36 1.057.413 2.227.057 1.266.07 1.646.07 4.85s-.015 3.585-.074 4.85c-.061 1.17-.256 1.805-.421 2.227-.224.562-.479.96-.899 1.382-.419.419-.824.679-1.38.896-.42.164-1.065.36-2.235.413-1.274.057-1.649.07-4.859.07-3.211 0-3.586-.015-4.859-.074-1.171-.061-1.816-.256-2.236-.421-.569-.224-.96-.479-1.379-.899-.421-.419-.69-.824-.9-1.38-.165-.42-.359-1.065-.42-2.235-.045-1.26-.061-1.649-.061-4.844 0-3.196.016-3.586.061-4.861.061-1.17.255-1.814.42-2.234.21-.57.479-.96.9-1.381.419-.419.81-.689 1.379-.898.42-.166 1.051-.361 2.221-.421 1.275-.045 1.65-.06 4.859-.06l.045.03zm0 3.678c-3.405 0-6.162 2.76-6.162 6.162 0 3.405 2.76 6.162 6.162 6.162 3.405 0 6.162-2.76 6.162-6.162 0-3.405-2.76-6.162-6.162-6.162zM12 16c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4zm7.846-10.405c0 .795-.646 1.44-1.44 1.44-.795 0-1.44-.646-1.44-1.44 0-.794.646-1.439 1.44-1.439.793-.001 1.44.645 1.44 1.439z"/>'
+    '</svg>';
+
+const _whatsappSvg =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">'
+    '<path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/>'
+    '</svg>';
+
+const _twitterSvg =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">'
+    '<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>'
+    '</svg>';

--- a/packages/trufi_core_ui/lib/src/router/app_router.dart
+++ b/packages/trufi_core_ui/lib/src/router/app_router.dart
@@ -544,7 +544,7 @@ class _DrawerFooter extends StatelessWidget {
 
 /// Social media icon button for the drawer footer
 class _SocialIconButton extends StatelessWidget {
-  final IconData icon;
+  final Widget icon;
   final String url;
   final String? label;
   final ColorScheme colorScheme;
@@ -559,7 +559,7 @@ class _SocialIconButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return IconButton(
-      icon: Icon(icon),
+      icon: icon,
       iconSize: 20,
       color: colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
       onPressed: () => launchUrl(Uri.parse(url)),

--- a/packages/trufi_core_ui/lib/trufi_core_ui.dart
+++ b/packages/trufi_core_ui/lib/trufi_core_ui.dart
@@ -2,6 +2,7 @@ export 'src/trufi_app.dart';
 export 'src/router/app_router.dart';
 export 'src/l10n/core_localizations.dart';
 export 'src/app_initializer/default_init_screen.dart';
+export 'src/config/social_media_preset.dart';
 
 // Re-export common interfaces for convenience
 export 'package:trufi_core_interfaces/trufi_core_interfaces.dart'

--- a/packages/trufi_core_ui/pubspec.yaml
+++ b/packages/trufi_core_ui/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   url_launcher: ^6.3.2
   shared_preferences: ^2.5.3
   pointer_interceptor: ^0.10.1+2
+  flutter_svg: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- `SocialMediaLink.icon` is now `Widget` instead of `IconData` so apps can render brand-correct SVGs (or any custom widget) for social media links — not just font glyphs. Required because Material Icons only ships `Icons.facebook` (no `instagram`, `whatsapp`, `twitter`).
- New `SocialMediaPreset` enum (exported from `trufi_core_ui`) with ready-to-use brand icons for **Facebook, Instagram, WhatsApp, Twitter/X**. Brand SVGs sourced from [Simple Icons](https://simpleicons.org) under **CC0 1.0**. Brand color is inherited from the ambient `IconTheme` so the drawer footer keeps a consistent muted-gray look.
- `flutter_svg` declared as a direct dep of `trufi_core_ui` (was already transitive via `trufi_core_maps`).
- `apps/example` migrated to the new API as the canonical reference.

## Breaking change

`SocialMediaLink.icon` was `IconData`, now `Widget`. Migration is a one-line wrap per link:

```diff
- SocialMediaLink(url: '...', icon: Icons.facebook, label: 'Facebook'),
+ SocialMediaLink(url: '...', icon: const Icon(Icons.facebook), label: 'Facebook'),
```

Or use a preset:

```diff
+ SocialMediaLink(url: '...', icon: SocialMediaPreset.facebook.icon, label: 'Facebook'),
```

## Why a breaking change instead of an additive one

Considered keeping `icon: IconData?` and adding `customIcon: Widget?` (backward-compatible with assert that one is non-null), but the resulting API has two parallel fields with one renderer-side precedence rule — confusing for callers. A single `Widget icon` is cleaner long-term, and the migration is mechanical (~1 line per link, all current Trufi apps have ≤4 links).

## Test plan

- [x] `melos run analyze` clean (only 2 pre-existing infos in unrelated files: `trufi_core_home_screen` import + `trufi_core_poi_layers` getter — already present on `main`).
- [x] `melos run ci:analyze` passes (matches `.github/workflows/flutter_test.yml`).
- [x] `melos run l10n --no-select` clean — no l10n drift.
- [x] `apps/example` migrated and analyze-clean.
- [x] Verified end-to-end on a Pixel 9a (Android 16) running `trufi-app` with this branch via `dependency_overrides: path:`. Drawer footer shows correct Facebook (Material), Instagram (brand SVG), WhatsApp (brand SVG); icon color inherits from theme; no console warnings related to SVG/IconTheme.

## Refs

- Refs #869 (Cochabamba branding update — the `trufi-app` PR will follow once a tag is cut).