### PR TITLE
fix: block route planning when origin and destination are within 100 m (#821)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 5.10.0
+
+### Features
+- `TrufiLatLng.distanceTo(other)` returns the great-circle distance (meters) between two coordinates.
+
+### Bug Fixes
+- Block route planning when origin and destination are within 100 m of each other (#821). Previously, identical points caused the routing engine to either return a 404 (OTP 1.5) or a nonsensical itinerary (OTP 2.8). The new banner message asks the user to walk instead. Provider-agnostic: applies to OTP 1.5/2.4/2.8 and the offline GTFS planner.
+
+---
+
 ## 5.9.0
 
 ### Breaking

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_de.arb
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_de.arb
@@ -7,6 +7,7 @@
   "noRoutesFound": "Keine ÖPNV-Routen für diese Strecke gefunden. Versuche ein anderes Ziel oder passe die Sucheinstellungen an.",
   "noRoutesFoundShort": "Keine Routen für diese Strecke gefunden",
   "errorNoRoutes": "Fehler beim Laden der Routen",
+  "originDestinationTooClose": "Sie sind sehr nah am Ziel. Zu Fuß gehen ist am schnellsten.",
   "durationMinutes": "{minutes} Min",
   "durationHoursMinutes": "{hours}h {minutes}Min",
   "distanceMeters": "{meters} m",

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_en.arb
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_en.arb
@@ -28,6 +28,10 @@
   "@errorNoRoutes": {
     "description": "Error message when routes fail to load"
   },
+  "originDestinationTooClose": "You are very close to your destination. Walking is the fastest option.",
+  "@originDestinationTooClose": {
+    "description": "Banner message when origin and destination are the same point or within the minimum planning distance"
+  },
   "durationMinutes": "{minutes} min",
   "@durationMinutes": {
     "description": "Duration in minutes",

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_es.arb
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_es.arb
@@ -7,6 +7,7 @@
   "noRoutesFound": "No encontramos rutas de transporte público para este trayecto. Puede deberse al horario seleccionado o a que no hay cobertura entre estos puntos. Intenta con un horario diferente u otro destino.",
   "noRoutesFoundShort": "No se encontraron rutas para este trayecto",
   "errorNoRoutes": "Error al cargar rutas",
+  "originDestinationTooClose": "Estás muy cerca de tu destino. Caminar es la mejor opción.",
   "durationMinutes": "{minutes} min",
   "durationHoursMinutes": "{hours}h {minutes}min",
   "distanceMeters": "{meters} m",

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations.dart
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations.dart
@@ -145,6 +145,12 @@ abstract class HomeScreenLocalizations {
   /// **'Error loading routes'**
   String get errorNoRoutes;
 
+  /// Banner message when origin and destination are the same point or within the minimum planning distance
+  ///
+  /// In en, this message translates to:
+  /// **'You are very close to your destination. Walking is the fastest option.'**
+  String get originDestinationTooClose;
+
   /// Duration in minutes
   ///
   /// In en, this message translates to:

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_de.dart
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_de.dart
@@ -31,6 +31,10 @@ class HomeScreenLocalizationsDe extends HomeScreenLocalizations {
   String get errorNoRoutes => 'Fehler beim Laden der Routen';
 
   @override
+  String get originDestinationTooClose =>
+      'Sie sind sehr nah am Ziel. Zu Fuß gehen ist am schnellsten.';
+
+  @override
   String durationMinutes(int minutes) {
     return '$minutes Min';
   }

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_en.dart
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_en.dart
@@ -31,6 +31,10 @@ class HomeScreenLocalizationsEn extends HomeScreenLocalizations {
   String get errorNoRoutes => 'Error loading routes';
 
   @override
+  String get originDestinationTooClose =>
+      'You are very close to your destination. Walking is the fastest option.';
+
+  @override
   String durationMinutes(int minutes) {
     return '$minutes min';
   }

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_es.dart
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_es.dart
@@ -31,6 +31,10 @@ class HomeScreenLocalizationsEs extends HomeScreenLocalizations {
   String get errorNoRoutes => 'Error al cargar rutas';
 
   @override
+  String get originDestinationTooClose =>
+      'Estás muy cerca de tu destino. Caminar es la mejor opción.';
+
+  @override
   String durationMinutes(int minutes) {
     return '$minutes min';
   }

--- a/packages/screens/trufi_core_home_screen/lib/src/cubit/route_planner_cubit.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/cubit/route_planner_cubit.dart
@@ -11,6 +11,14 @@ import '../services/request_plan_service.dart';
 /// Error key emitted when no routes are found (UI resolves to localized string).
 const String noRoutesErrorKey = 'no_routes_found';
 
+/// Error key emitted when origin and destination are within
+/// [minPlanningDistanceMeters] of each other.
+const String tooCloseErrorKey = 'origin_destination_too_close';
+
+/// Below this distance (meters), planning is short-circuited and the user is
+/// shown a "too close" message instead of a degenerate routing-engine result.
+const double minPlanningDistanceMeters = 100;
+
 /// Cubit for managing route planning state.
 ///
 /// If [repository] is not provided, uses [HomeScreenRepositoryImpl] by default.
@@ -115,6 +123,20 @@ class RoutePlannerCubit extends Cubit<RoutePlannerState> {
   /// Fetch route plan.
   Future<void> fetchPlan({int? selectedItineraryIndex}) async {
     if (state.fromPlace == null || state.toPlace == null) return;
+
+    if (state.fromPlace!.latLng.distanceTo(state.toPlace!.latLng) <
+        minPlanningDistanceMeters) {
+      await _cancelCurrentFetch();
+      emit(
+        state.copyWithNullable(
+          isLoading: false,
+          plan: const Optional(null),
+          selectedItinerary: const Optional(null),
+          error: Optional(tooCloseErrorKey),
+        ),
+      );
+      return;
+    }
 
     await _cancelCurrentFetch();
 

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -1879,6 +1879,14 @@ class _HomeScreenState extends State<HomeScreen>
   /// Resolve error key to localized short string (for banners).
   String _resolveError(String? error, HomeScreenLocalizations l10n) {
     if (error == noRoutesErrorKey) return l10n.noRoutesFoundShort;
+    if (error == tooCloseErrorKey) return l10n.originDestinationTooClose;
+    return error ?? l10n.errorNoRoutes;
+  }
+
+  /// Resolve error key to localized long-form string (for error panel).
+  String _resolveErrorLong(String? error, HomeScreenLocalizations l10n) {
+    if (error == noRoutesErrorKey) return l10n.noRoutesFound;
+    if (error == tooCloseErrorKey) return l10n.originDestinationTooClose;
     return error ?? l10n.errorNoRoutes;
   }
 
@@ -2234,9 +2242,7 @@ class _HomeScreenState extends State<HomeScreen>
     final l10n = HomeScreenLocalizations.of(context);
     final isError = state.hasError;
     final message = isError
-        ? (state.error == noRoutesErrorKey
-            ? l10n.noRoutesFound
-            : (state.error ?? l10n.errorNoRoutes))
+        ? _resolveErrorLong(state.error, l10n)
         : l10n.noRoutesFound;
 
     return Positioned(

--- a/packages/trufi_core_interfaces/lib/src/models/trufi_latlng.dart
+++ b/packages/trufi_core_interfaces/lib/src/models/trufi_latlng.dart
@@ -24,6 +24,10 @@ class TrufiLatLng extends Equatable {
 
   LatLng toLatLng() => LatLng(latitude, longitude);
 
+  /// Great-circle distance to [other], in meters.
+  double distanceTo(TrufiLatLng other) =>
+      const Distance().as(LengthUnit.Meter, toLatLng(), other.toLatLng());
+
   static List<LatLng> toListLatLng(List<TrufiLatLng> listTrufiLatLng) {
     return listTrufiLatLng.map((e) => e.toLatLng()).toList();
   }


### PR DESCRIPTION
## Summary

Block route planning when origin and destination are within 100 m of each other.
Previously the app forwarded the request to the routing engine, which returned
either a 404 (OTP 1.5) or a nonsensical itinerary like "20 min for 0 m" (OTP 2.8).
With this fix, the user sees a friendly banner suggesting to walk instead.

The guard lives in `RoutePlannerCubit.fetchPlan()`, **before** `RequestPlanService`
dispatches to any provider — so it's agnostic to the routing engine. Applies to
OTP 1.5 / 2.4 / 2.8 and the offline GTFS planner alike.

Also adds `TrufiLatLng.distanceTo(other)` (great-circle distance in meters,
backed by `latlong2`) for general reuse.

Closes #821

## Changes

- New `minPlanningDistanceMeters = 100` and `tooCloseErrorKey = 'origin_destination_too_close'` constants in `route_planner_cubit.dart`.
- Guard added at the top of `fetchPlan()`, after the null-check on from/to.
- New banner string `originDestinationTooClose` in en/es/de:
  - **EN**: "You are very close to your destination. Walking is the fastest option."
  - **ES**: "Estás muy cerca de tu destino. Caminar es la mejor opción."
  - **DE**: "Sie sind sehr nah am Ziel. Zu Fuß gehen ist am schnellsten."
- New public method `TrufiLatLng.distanceTo(other) → double` (meters).
- Both error-render sites (the in-results banner via `_resolveError` and the bottom error panel via the new `_resolveErrorLong`) now resolve the key to a localized string. Previously only `_resolveError` knew about error keys, which is why `_buildErrorPanel` was rendering raw keys for anything other than `noRoutesErrorKey`.
- CHANGELOG: new `## 5.10.0` heading. Minor bump justified by the new public API on `TrufiLatLng`.

## Test plan

- [x] `melos run ci:analyze` passes (no new issues; pre-existing infos unrelated).
- [x] `melos run l10n` produces no extra diff after staging the new keys.
- [x] Existing `trufi_core_home_screen` tests still pass.
- [x] Manual on Pixel 9a (Cochabamba GPS, OTP 2.8 backend):
  - Origin "Tu ubicación" + destination "Tu ubicación" → banner "Estás muy cerca de tu destino. Caminar es la mejor opción.", no OTP call, no spinner stuck.
  - Origin "Tu ubicación" + destination >100 m away → plans normally (5 routes returned).
  - Changing one of the two endpoints clears the banner and replans.
- [ ] Reviewer to optionally sanity-check the same flows on OTP 1.5 / GTFS-only deployment.

## Notes

- The 100 m threshold is a soft default; configurable in code via the `minPlanningDistanceMeters` constant if a deployment wants to tune it.
- The "Reintentar" (retry) button on the error panel is left as-is for the new error key. Tapping it just re-fires the guard; harmless. Hiding/relabeling it for this case felt out of scope for the bug fix, but I'd happily do it as a follow-up if reviewers prefer.