### PR TITLE
fix: standardize transport list display across OTP 1.5 / 2.8 / offline (#832)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bug Fixes
 - Block route planning when origin and destination are within 100 m of each other (#821). Previously, identical points caused the routing engine to either return a 404 (OTP 1.5) or a nonsensical itinerary (OTP 2.8). The new banner message asks the user to walk instead. Provider-agnostic: applies to OTP 1.5/2.4/2.8 and the offline GTFS planner.
+- Standardize transport list display across providers (#832). `Otp15RoutingProvider` was failing to match patterns to their parent route (incorrect parsing of pattern id `feedId:routeId:directionId:patternIndex`), so route badges were empty and route names fell back to the raw OTP `desc` field, which leaks identifiers like `(cochabamba:3663487388)`. The match is now correct and `agencyName` is parsed for both `Otp15RoutingProvider` and `TrufiPlannerProvider`'s offline (GTFS) mode, bringing both to parity with `Otp28RoutingProvider`.
 
 ---
 

--- a/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
@@ -216,9 +216,11 @@ class Otp15RoutingProvider extends IRoutingProvider {
 
       var routeId = patternData['routeId'] as String?;
       if (routeId == null) {
+        // Pattern id format: feedId:routeId:directionId:patternIndex
+        // (the /index/patterns list endpoint omits routeId, so derive it).
         final parts = patternId.split(':');
-        if (parts.length >= 2) {
-          routeId = parts.sublist(0, parts.length - 1).join(':');
+        if (parts.length >= 3) {
+          routeId = parts.sublist(0, parts.length - 2).join(':');
         }
       }
       final routeData = routeId != null ? routeMap[routeId] : null;
@@ -265,9 +267,10 @@ class Otp15RoutingProvider extends IRoutingProvider {
     TransitRouteInfo? routeInfo;
     var routeId = patternData['routeId'] as String?;
     if (routeId == null) {
+      // Pattern id format: feedId:routeId:directionId:patternIndex.
       final parts = id.split(':');
-      if (parts.length >= 2) {
-        routeId = parts.sublist(0, parts.length - 1).join(':');
+      if (parts.length >= 3) {
+        routeId = parts.sublist(0, parts.length - 2).join(':');
       }
     }
     if (routeId != null) {
@@ -302,12 +305,17 @@ class Otp15RoutingProvider extends IRoutingProvider {
 
   TransitRouteInfo _parseRouteInfo(Map<String, dynamic> json) {
     final modeStr = json['mode'] as String?;
+    // OTP 1.5 inconsistency: /index/routes (list) returns `agencyName`
+    // top-level; /index/routes/{id} (detail) returns `agency.name` nested.
+    final agencyJson = json['agency'] as Map<String, dynamic>?;
     return TransitRouteInfo(
       shortName: json['shortName'] as String?,
       longName: json['longName'] as String?,
       mode: modeStr != null ? TransportModeExtension.fromString(modeStr) : null,
       color: json['color'] as String?,
       textColor: json['textColor'] as String?,
+      agencyName:
+          agencyJson?['name'] as String? ?? json['agencyName'] as String?,
     );
   }
 

--- a/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_provider.dart
@@ -336,6 +336,7 @@ class TrufiPlannerProvider extends IRoutingProvider {
     final routeIndex = _dataSource.routeIndex;
     if (routeIndex == null) return [];
 
+    final agencyNames = _buildAgencyNameMap();
     final patterns = <TransitRoute>[];
 
     for (final pattern in routeIndex.patterns) {
@@ -364,6 +365,7 @@ class TrufiPlannerProvider extends IRoutingProvider {
             mode: _routeTypeToMode(route.type),
             color: route.colorHex,
             textColor: route.textColorHex,
+            agencyName: agencyNames[route.agencyId],
           ),
         ),
       );
@@ -468,10 +470,16 @@ class TrufiPlannerProvider extends IRoutingProvider {
         mode: _routeTypeToMode(route.type),
         color: route.colorHex,
         textColor: route.textColorHex,
+        agencyName: _buildAgencyNameMap()[route.agencyId],
       ),
       geometry: shape?.polyline,
       stops: stops,
     );
+  }
+
+  Map<String, String> _buildAgencyNameMap() {
+    final agencies = _dataSource.data?.agencies ?? const [];
+    return {for (final a in agencies) a.id: a.name};
   }
 
   Future<TransitRoute> _fetchTransitRouteByIdRemote(String id) async {


### PR DESCRIPTION
## Summary

Bring the "Routes" / transport list to identical visual output across all three routing providers (OTP 1.5, OTP 2.8, offline TrufiPlanner). OTP 2.8 was already the reference; this PR brings the other two to parity.

Closes #832

## Root causes

**`Otp15RoutingProvider`** had two issues:

1. **Pattern → route id derivation was off-by-one.** The OTP 1.5 `/index/patterns` list endpoint omits `routeId`, so the provider derives it from the pattern id (format `feedId:routeId:directionId:patternIndex`). The previous code dropped only the trailing element, producing `cochabamba:84:0` instead of `cochabamba:84` — so `routeMap[routeId]` never matched, `route.shortName` / `route.longName` were null, and the UI fell through to the raw `desc` field, which OTP 1.5 emits with a trailing identifier like `(cochabamba:3663487388)` (the visible bug from #832).
2. **`agencyName` was never parsed**, so the transport list grouped everything under "Otros" instead of by agency.

**`TrufiPlannerProvider` (offline GTFS path)** also did not surface `agencyName`, even though `agency.txt` is fully parsed and the GTFS route model carries `agency_id`. Two construction sites (`_fetchTransitRoutesLocal` and `_fetchTransitRouteByIdLocal`) dropped the agency on the way to `TransitRouteInfo`.

## Changes

- `otp_15_routing_provider.dart`:
  - Fix pattern id split: drop the last 2 elements (directionId + patternIndex), not 1. Both list and by-id code paths.
  - Parse `agencyName` in `_parseRouteInfo`. OTP 1.5 is inconsistent across endpoints — `/index/routes` returns `agencyName` top-level while `/index/routes/{id}` returns `agency.name` nested — so the parser tolerates both shapes.

- `trufi_planner_provider.dart`:
  - Build a small `agencyId → agencyName` lookup from `_dataSource.data?.agencies` in both offline construction sites.
  - Pass `agencyName: …` to `TransitRouteInfo`.

- CHANGELOG: bullet under `## 5.10.0`.

## Test plan

- [x] `melos run ci:analyze` passes (no new issues).
- [x] Existing routing-package tests still pass (failures observed locally are pre-existing — `Otp15Exception: No internet connection` integration tests and `Binding has not yet been initialized` unit tests; neither caused by this diff; verified by stashing the change).
- [x] Manual on Pixel 9a (Cochabamba GPS), all three providers visually verified after `pm clear app.trufi.navigator`:
  - **OTP 2.8** (reference): unchanged. Agencies grouped, badges with shortName, "X → Y" — already clean.
  - **OTP 1.5** (post-fix): agencies grouped, badges 206/119/133, "Calle Litoral → Villa Urkupiña Calvario", **no** `(cochabamba:NNNN)` suffix.
  - **Offline TrufiPlanner** (post-fix): agencies grouped, badges 252/137/111/106, clean origin → destination.

## Out of scope (follow-ups)

- OTP 1.5 emits the same `desc` for both directions of some patterns, so two rows in the list can show identical headsigns. That's a separate quality-of-life issue distinct from #832 and not addressed here.