### PR TITLE
feat: configurable fare categories + public widgets in trufi_core_fares (#848)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 5.12.0
+
+### Breaking
+- `trufi_core_fares` data model is rebuilt around arbitrary categories instead of fixed regular/student/senior slots (#848). `FareInfo` now requires a `title`, an `icon`, a `primary: FareCategory`, an optional `additional: List<FareCategory>` and an optional `notes`. The old `transportType`/`regularFare`/`studentFare`/`seniorFare` fields are removed — apps need to migrate their wiring to the new `FareCategory(label, price, icon?, color?, note?)` tuple. The previous schema couldn't represent tariffs that have more than three age tiers (e.g. Cochabamba's official Cercado tariff covers `general / primary student / secondary‑uni student / disability / senior`), and locked the chip labels into the package's localization (`faresStudent`, `faresSenior`).
+- `FaresLocalizations` no longer ships the `faresRegular`, `faresStudent`, `faresSenior` strings. Category labels come from each app's own localization (or raw strings) via `FareCategory.label`. Apps that built their own fares screen on top of `FaresLocalizations` strings need to provide the labels themselves.
+
+### Features
+- `trufi_core_fares` exposes its previously-private layout primitives as public widgets so apps can compose a custom fares screen without rewriting the chrome: `FaresHero` (gradient hero card), `FareCard` (header + chips + notes for one `FareInfo`), `FareCategoryChip` (single category chip), `FaresNotesCard` (tip-style footer card). The opinionated `FaresTrufiScreen(config: …)` keeps working as before for apps that don't need a custom layout.
+
+### Bug Fixes
+- Fix outdated Cochabamba fares (#848). `trufi-app` now ships the official Cercado tariff issued by the Movilidad Urbana de Cochabamba (`Bs 3 / Bs 2 / Bs 1 / Bs 2.50 / Bs 2.50` for general / secondary‑university student / primary student / senior / disability) and a note clarifying the tariff applies only inside the Cercado and that operator-charged fares may differ.
+
+---
+
 ## 5.11.0
 
 ### Breaking

--- a/apps/example/lib/main.dart
+++ b/apps/example/lib/main.dart
@@ -292,26 +292,64 @@ void main() {
           config: FaresConfig(
             currency: 'Bs.',
             lastUpdated: DateTime(2024, 1, 15),
-            fares: [
-              const FareInfo(
-                transportType: 'Trufi',
+            fares: const [
+              FareInfo(
+                title: 'Trufi',
                 icon: Icons.directions_bus,
-                regularFare: '2.00',
-                studentFare: '1.50',
-                seniorFare: '1.00',
+                primary: FareCategory(
+                  label: 'Regular',
+                  price: '2.00',
+                  icon: Icons.person_rounded,
+                ),
+                additional: [
+                  FareCategory(
+                    label: 'Student',
+                    price: '1.50',
+                    icon: Icons.school_rounded,
+                  ),
+                  FareCategory(
+                    label: 'Senior',
+                    price: '1.00',
+                    icon: Icons.elderly_rounded,
+                  ),
+                ],
               ),
-              const FareInfo(
-                transportType: 'Micro',
+              FareInfo(
+                title: 'Micro',
                 icon: Icons.airport_shuttle,
-                regularFare: '1.50',
-                studentFare: '1.00',
-                seniorFare: '0.75',
+                primary: FareCategory(
+                  label: 'Regular',
+                  price: '1.50',
+                  icon: Icons.person_rounded,
+                ),
+                additional: [
+                  FareCategory(
+                    label: 'Student',
+                    price: '1.00',
+                    icon: Icons.school_rounded,
+                  ),
+                  FareCategory(
+                    label: 'Senior',
+                    price: '0.75',
+                    icon: Icons.elderly_rounded,
+                  ),
+                ],
               ),
-              const FareInfo(
-                transportType: 'Minibus',
+              FareInfo(
+                title: 'Minibus',
                 icon: Icons.directions_bus_filled,
-                regularFare: '2.50',
-                studentFare: '2.00',
+                primary: FareCategory(
+                  label: 'Regular',
+                  price: '2.50',
+                  icon: Icons.person_rounded,
+                ),
+                additional: [
+                  FareCategory(
+                    label: 'Student',
+                    price: '2.00',
+                    icon: Icons.school_rounded,
+                  ),
+                ],
               ),
             ],
           ),

--- a/packages/screens/trufi_core_fares/README.md
+++ b/packages/screens/trufi_core_fares/README.md
@@ -4,13 +4,17 @@ Display fare/pricing information for public transportation.
 
 ## Features
 
-- Show fares by transport type (bus, trufi, metro, etc.)
-- Support for regular, student, and senior prices
-- Notes per fare type
+- Group prices by transport mode, tariff regime, or any other label
+- Arbitrary price categories per group (general, student, senior, disability,
+  employee, etc.) — labels are consumer-provided so each deployment owns
+  its own taxonomy
+- Per-group and per-screen notes
 - Last updated date
-- Optional external link for more info
-- Localization support (EN, ES, DE)
+- Optional external "More info" link
+- Localization support (EN, ES, DE) for the screen chrome
 - Material 3 design
+- Public composable widgets (`FaresHero`, `FareCard`, `FareCategoryChip`,
+  `FaresNotesCard`) for consumers that want a custom layout
 
 ## Quick Start
 
@@ -18,30 +22,38 @@ Display fare/pricing information for public transportation.
 FaresTrufiScreen(
   config: FaresConfig(
     currency: 'Bs.',
-    fares: [
+    fares: const [
       FareInfo(
-        transportType: 'Trufi',
-        icon: Icons.directions_bus,
-        regularFare: '2.00',
-        studentFare: '1.50',
-        seniorFare: '1.00',
+        title: 'Pasaje urbano (Cercado)',
+        icon: Icons.directions_bus_rounded,
+        primary: FareCategory(
+          label: 'Usuarios en general',
+          price: '3.00',
+          icon: Icons.person_rounded,
+        ),
+        additional: [
+          FareCategory(label: 'Estudiante sec./universitario', price: '2.00'),
+          FareCategory(label: 'Estudiante de primaria',         price: '1.00'),
+          FareCategory(label: 'Adulto mayor',                    price: '2.50'),
+          FareCategory(label: 'Persona con discapacidad',        price: '2.50'),
+        ],
       ),
     ],
   ),
 )
 ```
 
-## Configuration
+## Models
 
 ### FaresConfig
 
 ```dart
 FaresConfig(
   currency: String,                 // Required - e.g., 'Bs.', '$', '€'
-  fares: List<FareInfo>,           // Required - list of fare information
+  fares: List<FareInfo>,           // Required - groups to render
   externalFareUrl: String?,        // Optional - link to more info
-  lastUpdated: DateTime?,          // Optional - when fares were updated
-  additionalNotes: String?,        // Optional - general notes
+  lastUpdated: DateTime?,          // Optional - when fares were verified
+  additionalNotes: String?,        // Optional - screen-wide notes
 )
 ```
 
@@ -49,12 +61,43 @@ FaresConfig(
 
 ```dart
 FareInfo(
-  transportType: String,           // Required - e.g., 'Bus', 'Metro'
-  icon: IconData,                  // Required - icon for this type
-  regularFare: String,             // Required - regular price
-  studentFare: String?,            // Optional - student price
-  seniorFare: String?,             // Optional - senior price
-  notes: String?,                  // Optional - notes for this fare
+  title: String,                   // Required - card header (e.g., 'Trufi')
+  icon: IconData,                  // Required - icon next to the title
+  primary: FareCategory,           // Required - headline price (badge)
+  additional: List<FareCategory>,  // Optional - rendered as chips
+  color: Color?,                   // Optional - accent color
+  notes: String?,                  // Optional - card footer notes
+)
+```
+
+### FareCategory
+
+```dart
+FareCategory(
+  label: String,                   // Required - already-localized label
+  price: String,                   // Required - formatted, no currency
+  icon: IconData?,                 // Optional - category icon
+  color: Color?,                   // Optional - chip accent color
+  note: String?,                   // Optional - sub-note under the price
+)
+```
+
+## Composable widgets
+
+If you don't want the opinionated `FaresTrufiScreen`, the package exports the
+building blocks the screen uses internally:
+
+- `FaresHero` — gradient hero card
+- `FareCard` — header + chips + notes for one `FareInfo`
+- `FareCategoryChip` — a single `FareCategory` chip
+- `FaresNotesCard` — tip-style notes card
+
+```dart
+Column(
+  children: [
+    const FaresHero(title: 'Tarifas', subtitle: '...'),
+    for (final fare in fares) FareCard(fare: fare, currency: 'Bs.'),
+  ],
 )
 ```
 
@@ -66,20 +109,17 @@ screens: [
   FaresTrufiScreen(
     config: FaresConfig(
       currency: 'Bs.',
-      lastUpdated: DateTime(2024, 1, 15),
+      lastUpdated: DateTime(2026, 5, 6),
       additionalNotes: 'Children under 5 ride free.',
-      fares: [
+      fares: const [
         FareInfo(
-          transportType: 'Trufi',
+          title: 'Trufi',
           icon: Icons.directions_bus,
-          regularFare: '2.00',
-          studentFare: '1.50',
-          seniorFare: '1.00',
-        ),
-        FareInfo(
-          transportType: 'Micro',
-          icon: Icons.airport_shuttle,
-          regularFare: '1.50',
+          primary: FareCategory(label: 'Regular', price: '2.00'),
+          additional: [
+            FareCategory(label: 'Student', price: '1.50'),
+            FareCategory(label: 'Senior',  price: '1.00'),
+          ],
         ),
       ],
     ),

--- a/packages/screens/trufi_core_fares/example/lib/main.dart
+++ b/packages/screens/trufi_core_fares/example/lib/main.dart
@@ -16,29 +16,68 @@ class MyApp extends StatelessWidget {
         currency: 'Bs.',
         lastUpdated: DateTime(2024, 1, 15),
         additionalNotes:
-            'Fares may vary depending on the route and time of day. Children under 5 ride free.',
+            'Fares may vary depending on the route and time of day. '
+            'Children under 5 ride free.',
         externalFareUrl: 'https://example.com/fares',
-        fares: [
-          const FareInfo(
-            transportType: 'Trufi',
+        fares: const [
+          FareInfo(
+            title: 'Trufi',
             icon: Icons.directions_bus,
-            regularFare: '2.00',
-            studentFare: '1.50',
-            seniorFare: '1.00',
+            primary: FareCategory(
+              label: 'Regular',
+              price: '2.00',
+              icon: Icons.person_rounded,
+            ),
+            additional: [
+              FareCategory(
+                label: 'Student',
+                price: '1.50',
+                icon: Icons.school_rounded,
+              ),
+              FareCategory(
+                label: 'Senior',
+                price: '1.00',
+                icon: Icons.elderly_rounded,
+              ),
+            ],
             notes: 'Valid for urban routes within the city center',
           ),
-          const FareInfo(
-            transportType: 'Micro',
+          FareInfo(
+            title: 'Micro',
             icon: Icons.airport_shuttle,
-            regularFare: '1.50',
-            studentFare: '1.00',
-            seniorFare: '0.75',
+            primary: FareCategory(
+              label: 'Regular',
+              price: '1.50',
+              icon: Icons.person_rounded,
+            ),
+            additional: [
+              FareCategory(
+                label: 'Student',
+                price: '1.00',
+                icon: Icons.school_rounded,
+              ),
+              FareCategory(
+                label: 'Senior',
+                price: '0.75',
+                icon: Icons.elderly_rounded,
+              ),
+            ],
           ),
-          const FareInfo(
-            transportType: 'Minibus',
+          FareInfo(
+            title: 'Minibus',
             icon: Icons.directions_bus_filled,
-            regularFare: '2.50',
-            studentFare: '2.00',
+            primary: FareCategory(
+              label: 'Regular',
+              price: '2.50',
+              icon: Icons.person_rounded,
+            ),
+            additional: [
+              FareCategory(
+                label: 'Student',
+                price: '2.00',
+                icon: Icons.school_rounded,
+              ),
+            ],
             notes: 'Covers longer routes to peripheral areas',
           ),
         ],

--- a/packages/screens/trufi_core_fares/lib/l10n/fares_de.arb
+++ b/packages/screens/trufi_core_fares/lib/l10n/fares_de.arb
@@ -12,18 +12,6 @@
   "@faresSubtitle": {
     "description": "Subtitle explaining the fares screen"
   },
-  "faresRegular": "Normal",
-  "@faresRegular": {
-    "description": "Label for regular fare"
-  },
-  "faresStudent": "Schüler/Student",
-  "@faresStudent": {
-    "description": "Label for student fare"
-  },
-  "faresSenior": "Senior",
-  "@faresSenior": {
-    "description": "Label for senior/elderly fare"
-  },
   "faresLastUpdated": "Zuletzt aktualisiert: {date}",
   "@faresLastUpdated": {
     "description": "Shows when fare info was last updated",

--- a/packages/screens/trufi_core_fares/lib/l10n/fares_en.arb
+++ b/packages/screens/trufi_core_fares/lib/l10n/fares_en.arb
@@ -12,18 +12,6 @@
   "@faresSubtitle": {
     "description": "Subtitle explaining the fares screen"
   },
-  "faresRegular": "Regular",
-  "@faresRegular": {
-    "description": "Label for regular fare"
-  },
-  "faresStudent": "Student",
-  "@faresStudent": {
-    "description": "Label for student fare"
-  },
-  "faresSenior": "Senior",
-  "@faresSenior": {
-    "description": "Label for senior/elderly fare"
-  },
   "faresLastUpdated": "Last updated: {date}",
   "@faresLastUpdated": {
     "description": "Shows when fare info was last updated",

--- a/packages/screens/trufi_core_fares/lib/l10n/fares_es.arb
+++ b/packages/screens/trufi_core_fares/lib/l10n/fares_es.arb
@@ -12,18 +12,6 @@
   "@faresSubtitle": {
     "description": "Subtitle explaining the fares screen"
   },
-  "faresRegular": "Regular",
-  "@faresRegular": {
-    "description": "Label for regular fare"
-  },
-  "faresStudent": "Estudiante",
-  "@faresStudent": {
-    "description": "Label for student fare"
-  },
-  "faresSenior": "Adulto Mayor",
-  "@faresSenior": {
-    "description": "Label for senior/elderly fare"
-  },
   "faresLastUpdated": "Última actualización: {date}",
   "@faresLastUpdated": {
     "description": "Shows when fare info was last updated",

--- a/packages/screens/trufi_core_fares/lib/l10n/fares_localizations.dart
+++ b/packages/screens/trufi_core_fares/lib/l10n/fares_localizations.dart
@@ -118,24 +118,6 @@ abstract class FaresLocalizations {
   /// **'Current prices for public transportation'**
   String get faresSubtitle;
 
-  /// Label for regular fare
-  ///
-  /// In en, this message translates to:
-  /// **'Regular'**
-  String get faresRegular;
-
-  /// Label for student fare
-  ///
-  /// In en, this message translates to:
-  /// **'Student'**
-  String get faresStudent;
-
-  /// Label for senior/elderly fare
-  ///
-  /// In en, this message translates to:
-  /// **'Senior'**
-  String get faresSenior;
-
   /// Shows when fare info was last updated
   ///
   /// In en, this message translates to:

--- a/packages/screens/trufi_core_fares/lib/l10n/fares_localizations_de.dart
+++ b/packages/screens/trufi_core_fares/lib/l10n/fares_localizations_de.dart
@@ -18,15 +18,6 @@ class FaresLocalizationsDe extends FaresLocalizations {
   String get faresSubtitle => 'Aktuelle Preise für den öffentlichen Nahverkehr';
 
   @override
-  String get faresRegular => 'Normal';
-
-  @override
-  String get faresStudent => 'Schüler/Student';
-
-  @override
-  String get faresSenior => 'Senior';
-
-  @override
   String faresLastUpdated(String date) {
     return 'Zuletzt aktualisiert: $date';
   }

--- a/packages/screens/trufi_core_fares/lib/l10n/fares_localizations_en.dart
+++ b/packages/screens/trufi_core_fares/lib/l10n/fares_localizations_en.dart
@@ -18,15 +18,6 @@ class FaresLocalizationsEn extends FaresLocalizations {
   String get faresSubtitle => 'Current prices for public transportation';
 
   @override
-  String get faresRegular => 'Regular';
-
-  @override
-  String get faresStudent => 'Student';
-
-  @override
-  String get faresSenior => 'Senior';
-
-  @override
   String faresLastUpdated(String date) {
     return 'Last updated: $date';
   }

--- a/packages/screens/trufi_core_fares/lib/l10n/fares_localizations_es.dart
+++ b/packages/screens/trufi_core_fares/lib/l10n/fares_localizations_es.dart
@@ -18,15 +18,6 @@ class FaresLocalizationsEs extends FaresLocalizations {
   String get faresSubtitle => 'Precios actuales del transporte público';
 
   @override
-  String get faresRegular => 'Regular';
-
-  @override
-  String get faresStudent => 'Estudiante';
-
-  @override
-  String get faresSenior => 'Adulto Mayor';
-
-  @override
   String faresLastUpdated(String date) {
     return 'Última actualización: $date';
   }

--- a/packages/screens/trufi_core_fares/lib/src/fares_trufi_screen.dart
+++ b/packages/screens/trufi_core_fares/lib/src/fares_trufi_screen.dart
@@ -4,68 +4,16 @@ import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../l10n/fares_localizations.dart';
+import 'models/fare_models.dart';
+import 'widgets/fare_card.dart';
+import 'widgets/fares_hero.dart';
+import 'widgets/fares_notes_card.dart';
 
-/// Fare information model
-class FareInfo {
-  /// Name of the transport type (e.g., "Bus", "Trufi", "Metro")
-  final String transportType;
-
-  /// Icon for this transport type
-  final IconData icon;
-
-  /// Color for this transport type (optional, uses primary if not set)
-  final Color? color;
-
-  /// Regular fare price
-  final String regularFare;
-
-  /// Student fare price (optional)
-  final String? studentFare;
-
-  /// Senior/elderly fare price (optional)
-  final String? seniorFare;
-
-  /// Additional notes about this fare
-  final String? notes;
-
-  const FareInfo({
-    required this.transportType,
-    required this.icon,
-    this.color,
-    required this.regularFare,
-    this.studentFare,
-    this.seniorFare,
-    this.notes,
-  });
-}
-
-/// Fares screen configuration
-class FaresConfig {
-  /// List of fare information to display
-  final List<FareInfo> fares;
-
-  /// Currency symbol (e.g., "Bs.", "$", "€")
-  final String currency;
-
-  /// Optional URL to external fare information
-  final String? externalFareUrl;
-
-  /// Last updated date for fare information
-  final DateTime? lastUpdated;
-
-  /// Additional notes shown at the bottom
-  final String? additionalNotes;
-
-  const FaresConfig({
-    required this.fares,
-    required this.currency,
-    this.externalFareUrl,
-    this.lastUpdated,
-    this.additionalNotes,
-  });
-}
-
-/// Fares screen module that implements TrufiScreen
+/// Drop-in fares screen wired to a [FaresConfig].
+///
+/// Apps that want a custom layout can compose [FaresHero], [FareCard],
+/// [FareCategoryChip] and [FaresNotesCard] from this package directly
+/// instead of using this screen.
 class FaresTrufiScreen extends TrufiScreen {
   final FaresConfig config;
 
@@ -102,13 +50,11 @@ class FaresTrufiScreen extends TrufiScreen {
   }
 }
 
-/// Main screen widget with header and content
 class _FaresScreenWidget extends StatelessWidget {
   final FaresConfig config;
 
   const _FaresScreenWidget({required this.config});
 
-  /// Try to open the drawer from the nearest ancestor Scaffold
   void _tryOpenDrawer(BuildContext context) {
     HapticFeedback.lightImpact();
     final scaffold = Scaffold.maybeOf(context);
@@ -128,12 +74,10 @@ class _FaresScreenWidget extends StatelessWidget {
       child: SafeArea(
         child: Column(
           children: [
-            // Modern header
             _FaresHeader(
               title: localization.menuFares,
               onMenuPressed: () => _tryOpenDrawer(context),
             ),
-            // Content
             Expanded(child: _FaresContent(config: config)),
           ],
         ),
@@ -142,7 +86,6 @@ class _FaresScreenWidget extends StatelessWidget {
   }
 }
 
-/// Modern header for fares screen
 class _FaresHeader extends StatelessWidget {
   final String title;
   final VoidCallback onMenuPressed;
@@ -158,7 +101,6 @@ class _FaresHeader extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
       child: Row(
         children: [
-          // Menu button
           Material(
             color: colorScheme.surfaceContainerHighest,
             borderRadius: BorderRadius.circular(14),
@@ -178,7 +120,6 @@ class _FaresHeader extends StatelessWidget {
             ),
           ),
           const SizedBox(width: 16),
-          // Title
           Expanded(
             child: Text(
               title,
@@ -194,7 +135,6 @@ class _FaresHeader extends StatelessWidget {
   }
 }
 
-/// Fares content widget with staggered animations
 class _FaresContent extends StatefulWidget {
   final FaresConfig config;
 
@@ -215,7 +155,6 @@ class _FaresContentState extends State<_FaresContent>
       vsync: this,
       duration: const Duration(milliseconds: 800),
     );
-    // Start animation after build
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _staggerController.forward();
     });
@@ -267,50 +206,44 @@ class _FaresContentState extends State<_FaresContent>
     final localization = FaresLocalizations.of(context);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final fares = widget.config.fares;
 
     return SingleChildScrollView(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Hero header card
           _buildAnimatedItem(
             index: 0,
-            child: _FaresHeroCard(localization: localization),
+            child: FaresHero(
+              title: localization.faresTitle,
+              subtitle: localization.faresSubtitle,
+            ),
           ),
           const SizedBox(height: 20),
-
-          // Section title
           _buildAnimatedItem(
             index: 1,
-            child: _buildSectionHeader(
-              context,
-              localization.faresTitle,
-              Icons.receipt_long_rounded,
+            child: _SectionHeader(
+              title: localization.faresTitle,
+              icon: Icons.receipt_long_rounded,
             ),
           ),
           const SizedBox(height: 12),
-
-          // Fare cards
-          ...widget.config.fares.asMap().entries.map(
-            (entry) => _buildAnimatedItem(
-              index: 2 + entry.key,
+          for (var i = 0; i < fares.length; i++)
+            _buildAnimatedItem(
+              index: 2 + i,
               child: Padding(
                 padding: const EdgeInsets.only(bottom: 12),
-                child: _FareCard(
-                  fare: entry.value,
+                child: FareCard(
+                  fare: fares[i],
                   currency: widget.config.currency,
-                  localization: localization,
                 ),
               ),
             ),
-          ),
-
-          // Last updated
           if (widget.config.lastUpdated != null) ...[
             const SizedBox(height: 8),
             _buildAnimatedItem(
-              index: 2 + widget.config.fares.length,
+              index: 2 + fares.length,
               child: Center(
                 child: Container(
                   padding: const EdgeInsets.symmetric(
@@ -346,21 +279,17 @@ class _FaresContentState extends State<_FaresContent>
               ),
             ),
           ],
-
-          // Additional notes
           if (widget.config.additionalNotes != null) ...[
             const SizedBox(height: 20),
             _buildAnimatedItem(
-              index: 3 + widget.config.fares.length,
-              child: _NotesCard(notes: widget.config.additionalNotes!),
+              index: 3 + fares.length,
+              child: FaresNotesCard(notes: widget.config.additionalNotes!),
             ),
           ],
-
-          // External link button
           if (widget.config.externalFareUrl != null) ...[
             const SizedBox(height: 24),
             _buildAnimatedItem(
-              index: 4 + widget.config.fares.length,
+              index: 4 + fares.length,
               child: SizedBox(
                 width: double.infinity,
                 child: FilledButton.icon(
@@ -383,11 +312,19 @@ class _FaresContentState extends State<_FaresContent>
     );
   }
 
-  Widget _buildSectionHeader(
-    BuildContext context,
-    String title,
-    IconData icon,
-  ) {
+  String _formatDate(DateTime date) {
+    return '${date.day}/${date.month}/${date.year}';
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  final String title;
+  final IconData icon;
+
+  const _SectionHeader({required this.title, required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
@@ -410,354 +347,6 @@ class _FaresContentState extends State<_FaresContent>
               color: colorScheme.onSurface,
               fontWeight: FontWeight.w600,
               letterSpacing: 0.2,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  String _formatDate(DateTime date) {
-    return '${date.day}/${date.month}/${date.year}';
-  }
-}
-
-/// Hero card at the top of fares screen
-class _FaresHeroCard extends StatelessWidget {
-  final FaresLocalizations localization;
-
-  const _FaresHeroCard({required this.localization});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: [
-            colorScheme.primaryContainer,
-            colorScheme.primaryContainer.withValues(alpha: 0.7),
-          ],
-        ),
-        borderRadius: BorderRadius.circular(20),
-        boxShadow: [
-          BoxShadow(
-            color: colorScheme.primary.withValues(alpha: 0.15),
-            blurRadius: 20,
-            offset: const Offset(0, 8),
-          ),
-        ],
-      ),
-      child: Column(
-        children: [
-          // Icon with decorative background
-          Container(
-            width: 72,
-            height: 72,
-            decoration: BoxDecoration(
-              color: colorScheme.onPrimaryContainer.withValues(alpha: 0.15),
-              shape: BoxShape.circle,
-            ),
-            child: Icon(
-              Icons.payments_rounded,
-              size: 36,
-              color: colorScheme.onPrimaryContainer,
-            ),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            localization.faresTitle,
-            style: theme.textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.bold,
-              color: colorScheme.onPrimaryContainer,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            localization.faresSubtitle,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: colorScheme.onPrimaryContainer.withValues(alpha: 0.8),
-            ),
-            textAlign: TextAlign.center,
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Modernized fare card with improved styling
-class _FareCard extends StatelessWidget {
-  final FareInfo fare;
-  final String currency;
-  final FaresLocalizations localization;
-
-  const _FareCard({
-    required this.fare,
-    required this.currency,
-    required this.localization,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final fareColor = fare.color ?? colorScheme.primary;
-
-    return Container(
-      decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerLow,
-        borderRadius: BorderRadius.circular(18),
-        border: Border.all(
-          color: colorScheme.outlineVariant.withValues(alpha: 0.3),
-        ),
-      ),
-      child: Column(
-        children: [
-          // Header with transport type
-          Container(
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: fareColor.withValues(alpha: 0.08),
-              borderRadius: const BorderRadius.vertical(
-                top: Radius.circular(17),
-              ),
-            ),
-            child: Row(
-              children: [
-                Container(
-                  width: 48,
-                  height: 48,
-                  decoration: BoxDecoration(
-                    color: fareColor.withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(14),
-                  ),
-                  child: Icon(fare.icon, color: fareColor, size: 26),
-                ),
-                const SizedBox(width: 14),
-                Expanded(
-                  child: Text(
-                    fare.transportType,
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                      color: colorScheme.onSurface,
-                    ),
-                  ),
-                ),
-                // Main price badge
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 14,
-                    vertical: 8,
-                  ),
-                  decoration: BoxDecoration(
-                    color: fareColor,
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                  child: Text(
-                    '$currency ${fare.regularFare}',
-                    style: theme.textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.bold,
-                      color: Colors.white,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          // Price details
-          if (fare.studentFare != null ||
-              fare.seniorFare != null ||
-              fare.notes != null)
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                children: [
-                  if (fare.studentFare != null || fare.seniorFare != null) ...[
-                    Row(
-                      children: [
-                        if (fare.studentFare != null)
-                          Expanded(
-                            child: _CompactPriceChip(
-                              icon: Icons.school_rounded,
-                              label: localization.faresStudent,
-                              price: '$currency ${fare.studentFare}',
-                              color: Colors.blue,
-                            ),
-                          ),
-                        if (fare.studentFare != null && fare.seniorFare != null)
-                          const SizedBox(width: 10),
-                        if (fare.seniorFare != null)
-                          Expanded(
-                            child: _CompactPriceChip(
-                              icon: Icons.elderly_rounded,
-                              label: localization.faresSenior,
-                              price: '$currency ${fare.seniorFare}',
-                              color: Colors.teal,
-                            ),
-                          ),
-                      ],
-                    ),
-                  ],
-                  if (fare.notes != null) ...[
-                    if (fare.studentFare != null || fare.seniorFare != null)
-                      const SizedBox(height: 12),
-                    Container(
-                      width: double.infinity,
-                      padding: const EdgeInsets.all(12),
-                      decoration: BoxDecoration(
-                        color: colorScheme.surfaceContainerHighest.withValues(
-                          alpha: 0.5,
-                        ),
-                        borderRadius: BorderRadius.circular(10),
-                      ),
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Icon(
-                            Icons.info_outline_rounded,
-                            size: 16,
-                            color: colorScheme.onSurfaceVariant,
-                          ),
-                          const SizedBox(width: 8),
-                          Expanded(
-                            child: Text(
-                              fare.notes!,
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Compact price chip for student/senior fares
-class _CompactPriceChip extends StatelessWidget {
-  final IconData icon;
-  final String label;
-  final String price;
-  final Color color;
-
-  const _CompactPriceChip({
-    required this.icon,
-    required this.label,
-    required this.price,
-    required this.color,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
-    return Container(
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.08),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: color.withValues(alpha: 0.2)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(icon, size: 16, color: color),
-              const SizedBox(width: 6),
-              Text(
-                label,
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: colorScheme.onSurfaceVariant,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 4),
-          Text(
-            price,
-            style: theme.textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.bold,
-              color: color,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Notes card with info styling
-class _NotesCard extends StatelessWidget {
-  final String notes;
-
-  const _NotesCard({required this.notes});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: colorScheme.tertiaryContainer.withValues(alpha: 0.3),
-        borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: colorScheme.tertiary.withValues(alpha: 0.3)),
-      ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Container(
-            padding: const EdgeInsets.all(8),
-            decoration: BoxDecoration(
-              color: colorScheme.tertiary.withValues(alpha: 0.15),
-              borderRadius: BorderRadius.circular(10),
-            ),
-            child: Icon(
-              Icons.lightbulb_outline_rounded,
-              size: 20,
-              color: colorScheme.tertiary,
-            ),
-          ),
-          const SizedBox(width: 14),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Tips',
-                  style: theme.textTheme.labelMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
-                    color: colorScheme.tertiary,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  notes,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: colorScheme.onSurface,
-                    height: 1.4,
-                  ),
-                ),
-              ],
             ),
           ),
         ],

--- a/packages/screens/trufi_core_fares/lib/src/models/fare_models.dart
+++ b/packages/screens/trufi_core_fares/lib/src/models/fare_models.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+/// A single price entry within a fare group (e.g., "Adulto: 3.00 Bs").
+///
+/// Apps provide already-localized labels. The package intentionally avoids
+/// hardcoding category names like "student" or "senior" so each deployment
+/// can model its own tariff structure (general, primary student, secondary
+/// student, disability, senior, employee, etc.).
+class FareCategory {
+  /// Display label, already localized by the consumer.
+  final String label;
+
+  /// Formatted price string without currency (e.g., `"3.00"`).
+  final String price;
+
+  /// Optional category icon. Renders a generic person icon when null.
+  final IconData? icon;
+
+  /// Optional accent color for the category chip.
+  final Color? color;
+
+  /// Optional sub-note shown under the price (e.g., promotional period).
+  final String? note;
+
+  const FareCategory({
+    required this.label,
+    required this.price,
+    this.icon,
+    this.color,
+    this.note,
+  });
+}
+
+/// A fare grouping rendered as a single card on the fares screen.
+///
+/// Models a transport mode (e.g., "Trufi"), a tariff regime (e.g., "Pasaje
+/// urbano (Cercado)"), or any other grouping. The [primary] category is
+/// rendered as a headline price badge in the card header; [additional]
+/// categories render as chips below.
+class FareInfo {
+  /// Group title shown in the card header.
+  final String title;
+
+  /// Icon shown next to [title].
+  final IconData icon;
+
+  /// Optional accent color; defaults to the theme's primary color.
+  final Color? color;
+
+  /// Headline category — its price appears as a badge in the header.
+  final FareCategory primary;
+
+  /// Additional categories rendered as chips below the header.
+  final List<FareCategory> additional;
+
+  /// Long-form notes shown at the bottom of the card.
+  final String? notes;
+
+  const FareInfo({
+    required this.title,
+    required this.icon,
+    required this.primary,
+    this.color,
+    this.additional = const [],
+    this.notes,
+  });
+}
+
+/// Top-level configuration for the fares screen.
+class FaresConfig {
+  /// Currency symbol prepended to every price (e.g., `"Bs."`, `"$"`).
+  final String currency;
+
+  /// Fare groups to render, in display order.
+  final List<FareInfo> fares;
+
+  /// URL launched when the "More info" button is tapped.
+  final String? externalFareUrl;
+
+  /// When the fare data was last verified.
+  final DateTime? lastUpdated;
+
+  /// Free-form notes shown at the bottom of the screen.
+  final String? additionalNotes;
+
+  const FaresConfig({
+    required this.currency,
+    required this.fares,
+    this.externalFareUrl,
+    this.lastUpdated,
+    this.additionalNotes,
+  });
+}

--- a/packages/screens/trufi_core_fares/lib/src/widgets/fare_card.dart
+++ b/packages/screens/trufi_core_fares/lib/src/widgets/fare_card.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+
+import '../models/fare_models.dart';
+import 'fare_category_chip.dart';
+
+/// Card rendering a [FareInfo]: header (icon + title + primary price badge)
+/// over a wrapping list of [FareCategoryChip]s for [FareInfo.additional].
+class FareCard extends StatelessWidget {
+  final FareInfo fare;
+  final String currency;
+
+  const FareCard({super.key, required this.fare, required this.currency});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final fareColor = fare.color ?? colorScheme.primary;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(
+          color: colorScheme.outlineVariant.withValues(alpha: 0.3),
+        ),
+      ),
+      child: Column(
+        children: [
+          _Header(fare: fare, currency: currency, fareColor: fareColor),
+          if (fare.additional.isNotEmpty || fare.notes != null)
+            _Body(fare: fare, currency: currency),
+        ],
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  final FareInfo fare;
+  final String currency;
+  final Color fareColor;
+
+  const _Header({
+    required this.fare,
+    required this.currency,
+    required this.fareColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: fareColor.withValues(alpha: 0.08),
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(17)),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: fareColor.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: Icon(fare.icon, color: fareColor, size: 26),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  fare.title,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: colorScheme.onSurface,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  fare.primary.label,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+            decoration: BoxDecoration(
+              color: fareColor,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Text(
+              '$currency ${fare.primary.price}',
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  final FareInfo fare;
+  final String currency;
+
+  const _Body({required this.fare, required this.currency});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        children: [
+          if (fare.additional.isNotEmpty)
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final twoColumns = constraints.maxWidth >= 320;
+                final width = twoColumns
+                    ? (constraints.maxWidth - 10) / 2
+                    : constraints.maxWidth;
+                return Wrap(
+                  spacing: 10,
+                  runSpacing: 10,
+                  children: [
+                    for (final cat in fare.additional)
+                      SizedBox(
+                        width: width,
+                        child: FareCategoryChip(
+                          category: cat,
+                          currency: currency,
+                        ),
+                      ),
+                  ],
+                );
+              },
+            ),
+          if (fare.notes != null) ...[
+            if (fare.additional.isNotEmpty) const SizedBox(height: 12),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainerHighest.withValues(
+                  alpha: 0.5,
+                ),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(
+                    Icons.info_outline_rounded,
+                    size: 16,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      fare.notes!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/packages/screens/trufi_core_fares/lib/src/widgets/fare_category_chip.dart
+++ b/packages/screens/trufi_core_fares/lib/src/widgets/fare_category_chip.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+import '../models/fare_models.dart';
+
+/// Compact chip rendering a single [FareCategory] (label + price).
+class FareCategoryChip extends StatelessWidget {
+  /// The category to render.
+  final FareCategory category;
+
+  /// Currency prefix prepended to the price (e.g., `"Bs."`).
+  final String currency;
+
+  const FareCategoryChip({
+    super.key,
+    required this.category,
+    required this.currency,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final color = category.color ?? colorScheme.primary;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withValues(alpha: 0.2)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Icon(
+                category.icon ?? Icons.person_rounded,
+                size: 16,
+                color: color,
+              ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  category.label,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                    fontWeight: FontWeight.w500,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '$currency ${category.price}',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: color,
+            ),
+          ),
+          if (category.note != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              category.note!,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/packages/screens/trufi_core_fares/lib/src/widgets/fares_hero.dart
+++ b/packages/screens/trufi_core_fares/lib/src/widgets/fares_hero.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+/// Gradient hero card shown at the top of the fares screen.
+///
+/// Public so consumers building a custom screen can reuse it directly.
+class FaresHero extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final IconData icon;
+
+  const FaresHero({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    this.icon = Icons.payments_rounded,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            colorScheme.primaryContainer,
+            colorScheme.primaryContainer.withValues(alpha: 0.7),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.primary.withValues(alpha: 0.15),
+            blurRadius: 20,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          Container(
+            width: 72,
+            height: 72,
+            decoration: BoxDecoration(
+              color: colorScheme.onPrimaryContainer.withValues(alpha: 0.15),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(
+              icon,
+              size: 36,
+              color: colorScheme.onPrimaryContainer,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            title,
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: colorScheme.onPrimaryContainer,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            subtitle,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onPrimaryContainer.withValues(alpha: 0.8),
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/screens/trufi_core_fares/lib/src/widgets/fares_notes_card.dart
+++ b/packages/screens/trufi_core_fares/lib/src/widgets/fares_notes_card.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+/// Tip card with a lightbulb icon, used at the bottom of the fares screen.
+class FaresNotesCard extends StatelessWidget {
+  final String notes;
+  final String label;
+
+  const FaresNotesCard({super.key, required this.notes, this.label = 'Tips'});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.tertiaryContainer.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: colorScheme.tertiary.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: colorScheme.tertiary.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(
+              Icons.lightbulb_outline_rounded,
+              size: 20,
+              color: colorScheme.tertiary,
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: colorScheme.tertiary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  notes,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurface,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/screens/trufi_core_fares/lib/trufi_core_fares.dart
+++ b/packages/screens/trufi_core_fares/lib/trufi_core_fares.dart
@@ -1,2 +1,7 @@
 export 'src/fares_trufi_screen.dart';
+export 'src/models/fare_models.dart';
+export 'src/widgets/fare_card.dart';
+export 'src/widgets/fare_category_chip.dart';
+export 'src/widgets/fares_hero.dart';
+export 'src/widgets/fares_notes_card.dart';
 export 'l10n/fares_localizations.dart';


### PR DESCRIPTION
## Summary
- Replace `FareInfo`'s rigid `regularFare`/`studentFare`/`seniorFare` slots with arbitrary `List<FareCategory>` (label, price, icon?, color?, note?). The previous schema couldn't represent tariffs that have more than three age tiers — Cochabamba's official Cercado tariff covers *general / primary student / sec.-uni student / disability / senior*, and there are similar 4–5 tier regimes elsewhere.
- Expose the layout primitives that were private in `_FaresScreenWidget` as public composable widgets: `FaresHero`, `FareCard`, `FareCategoryChip`, `FaresNotesCard`. Apps that want a custom layout can drop them in directly; the opinionated `FaresTrufiScreen(config: …)` keeps working as before for apps that don't.
- Drop the now-irrelevant `faresRegular`/`faresStudent`/`faresSenior` strings from `FaresLocalizations`. Category labels are consumer-provided so each deployment owns its own taxonomy.
- Update `apps/example` and the package's own `example/` to the new API; refresh the README.

The Cochabamba data update (the unified Cercado tariff) lives in the trufi-app companion PR — it consumes this package via the new schema.

Closes #848

## Test plan
- [x] `melos run ci:analyze` — all packages pass, no new warnings
- [x] `melos run l10n` — regenerated, `git diff --staged --exit-code` clean
- [x] `flutter analyze` in `packages/screens/trufi_core_fares/` — no issues
- [x] `flutter analyze` in `apps/example/` — no issues
- [x] Runtime verified on a Pixel 9a (Android 16) running trufi-app with a local `path:` override on this branch: the new `FareCard` renders correctly with a `Bs. 3.00` headline badge and four wrapping chips for student-primary, student-secondary, senior, and disability, plus the existing last-updated chip and tip card.