### PR TITLE
feat: routingTimeOverride + ServiceHours indicator (works for OTP 1.5/2.4/2.8 via lookup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 5.14.0
+
+### Breaking
+- `HomeScreenConfig.showDepartureTimeChip` is removed. The chip is now driven by the new `AppConfiguration.routingTimeOverride: TimeOfDay?` — when null (default) the user picks their departure time as before; when set, the chip is hidden and every plan is resolved against today at the override time. Cities like Cochabamba that ran with a fixed mid-day request can switch from `showDepartureTimeChip: false` to `routingTimeOverride: TimeOfDay(hour: 12, minute: 0)`.
+- All absolute HH:mm labels in the home screen (itinerary card start/end, itinerary list "departs at … arrives at …", itinerary detail header + per-place arrival times) are suppressed when `routingTimeOverride` is set, since they would be the override time projected onto a real day and confuse users.
+
+### Features
+- New `ServiceHoursIndicator` widget in `trufi_core_routing` — one-line "🟢 Activo · cierra a las 22:00 ⌄" / "🔴 Cerrado · abre lun a las 06:00 ⌄" badge, evaluated against `DateTime.now()` (not `routingTimeOverride`) so it always answers "is this bus running right now?". Tap expands a 7-day schedule inline. Localized via `RoutingLocalizations` (es/en/de) with `intl` `DateFormat` for locale-aware day names. Re-renders every minute aligned to the wall-clock so the label flips at open/close time without the user having to reopen the screen.
+- New `ServiceHours` model + `ServiceHoursLookup` interface in `trufi_core_routing`. `TrufiPlannerDataSource` implements the lookup by deriving daysOfWeek + start/end from the bundled GTFS calendar and frequencies. The lookup tolerates OTP-style `feedId:routeId` ids by falling back to the `:`-suffix.
+- The indicator is rendered in three surfaces: the transit list `TransportTile`, the route detail screen, and each transit leg of the itinerary detail. The shared widget lives in `trufi_core_routing` so transit list and home screen render identical badges without depending on each other.
+- `RoutePlannerCubit` accepts an optional `ServiceHoursLookup` and post-processes every plan to enrich `Leg.serviceHours` for legs that the provider didn't populate. This makes the indicator work for OTP 1.5 / OTP 2.4 / OTP 2.8 plans as well, not just the local Trufi planner — OTP REST/GraphQL doesn't expose calendar+frequencies in a usable shape, so we side-channel them through the bundled GTFS.
+- `Leg` gains a nullable `serviceHours` field (preserved through `copyWith` and `toJson` / `fromJson`).
+- The itinerary detail leg row is reorganized so identity (badge + route name) takes a full row, with duration/distance, the operating-hours indicator, and the right-aligned "X paradas" toggle stacked underneath. The timeline line uses `IntrinsicHeight` so it grows with the leg's content (previously a fixed 90px height left a visible gap when the schedule was expanded).
+
+### Bug Fixes
+- The local `TrufiPlannerProvider` now sets `Leg.agency` from the GTFS agencies list, so transit legs show "Operado por …" the same way OTP-backed legs do. Previously only OTP plans rendered the operator line, creating a visible inconsistency.
+- OTP 1.5 plan requests now include `showIntermediateStops=true`. Without it, OTP 1.5 only returned boarding/alighting stops on each transit leg, leaving the detail screen with nothing to show under "X paradas". OTP 2.x already requested them via GraphQL; this aligns OTP 1.5 with the local planner and 2.x.
+
+---
+
 ## 5.12.0
 
 ### Breaking

--- a/packages/screens/trufi_core_home_screen/lib/src/config/home_screen_config.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/config/home_screen_config.dart
@@ -46,10 +46,6 @@ class HomeScreenConfig {
   /// [IRoutingProvider.realtimeVehiclesProvider] — no config needed here.
   final Widget? extraMapLayerSettings;
 
-  /// Whether to show the departure time chip above the map.
-  /// Set to false to hide the "Leave now / Arrive by" selector.
-  final bool showDepartureTimeChip;
-
   const HomeScreenConfig({
     this.chooseLocationZoom = 16.0,
     this.searchService,
@@ -60,6 +56,5 @@ class HomeScreenConfig {
     this.customMapLayers,
     this.poiLayersManager,
     this.extraMapLayerSettings,
-    this.showDepartureTimeChip = true,
   });
 }

--- a/packages/screens/trufi_core_home_screen/lib/src/cubit/route_planner_cubit.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/cubit/route_planner_cubit.dart
@@ -1,4 +1,5 @@
 import 'package:async/async.dart';
+import 'package:flutter/material.dart' show TimeOfDay;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart' as routing;
@@ -26,14 +27,54 @@ class RoutePlannerCubit extends Cubit<RoutePlannerState> {
   final HomeScreenRepository _repository;
   final RequestPlanService _requestService;
 
+  /// Optional fixed time-of-day used in place of `DateTime.now()` for
+  /// routing requests. Threaded down from `AppConfiguration` (see
+  /// `routingTimeOverride`). When non-null, every plan request is
+  /// resolved against today at this time.
+  final TimeOfDay? _routingTimeOverride;
+
+  /// Optional GTFS-backed lookup used to enrich [routing.Leg.serviceHours]
+  /// after the provider has parsed a plan. OTP REST/GraphQL doesn't
+  /// expose calendar+frequencies in a directly usable shape, so this
+  /// side-channel lets OTP-backed legs show the same operating-hours
+  /// indicator as the local Trufi planner.
+  final routing.ServiceHoursLookup? _serviceHoursLookup;
+
   CancelableOperation<routing.Plan>? _currentFetchOperation;
 
   RoutePlannerCubit({
     HomeScreenRepository? repository,
     required RequestPlanService requestService,
+    TimeOfDay? routingTimeOverride,
+    routing.ServiceHoursLookup? serviceHoursLookup,
   }) : _repository = repository ?? HomeScreenRepositoryImpl(),
        _requestService = requestService,
+       _routingTimeOverride = routingTimeOverride,
+       _serviceHoursLookup = serviceHoursLookup,
        super(const RoutePlannerState());
+
+  /// Returns [plan] with each transit leg's `serviceHours` populated
+  /// when the lookup has a record for the leg's route id. Legs that
+  /// already have `serviceHours` (e.g. produced by the local Trufi
+  /// planner) are left untouched.
+  routing.Plan _enrichServiceHours(routing.Plan plan) {
+    final lookup = _serviceHoursLookup;
+    if (lookup == null) return plan;
+    final itineraries = plan.itineraries;
+    if (itineraries == null) return plan;
+    return plan.copyWith(
+      itineraries: itineraries.map((it) {
+        final newLegs = it.legs.map((leg) {
+          if (leg.serviceHours != null) return leg;
+          final routeId = leg.route?.gtfsId;
+          if (routeId == null || routeId.isEmpty) return leg;
+          final sh = lookup.serviceHoursForRouteId(routeId);
+          return sh != null ? leg.copyWith(serviceHours: sh) : leg;
+        }).toList();
+        return it.copyWith(legs: newLegs);
+      }).toList(),
+    );
+  }
 
   /// Initialize and load saved state.
   Future<void> initialize() async {
@@ -149,20 +190,45 @@ class RoutePlannerCubit extends Cubit<RoutePlannerState> {
       ),
     );
 
-    // Compute dateTime and arriveBy from time settings
+    // Compute dateTime and arriveBy from time settings.
+    //
+    // Two modes:
+    //
+    // - `routingTimeOverride` set → resolve every request against
+    //   today @ override-time, ignoring `state.timeMode/dateTime`.
+    //   The picker UI is hidden in this mode, so the user can't
+    //   even reach the other branch.
+    //
+    // - Override not set → honour the user's choice from the
+    //   departure-time chip: `leaveNow` uses `DateTime.now()`,
+    //   `departAt`/`arriveBy` use the time the user picked
+    //   (`state.dateTime`), with `arriveBy` flipping the flag.
+    final DateTime now = DateTime.now();
     final DateTime effectiveDateTime;
     final bool arriveBy;
 
-    switch (state.timeMode) {
-      case TimeMode.leaveNow:
-        effectiveDateTime = DateTime.now();
-        arriveBy = false;
-      case TimeMode.departAt:
-        effectiveDateTime = state.dateTime ?? DateTime.now();
-        arriveBy = false;
-      case TimeMode.arriveBy:
-        effectiveDateTime = state.dateTime ?? DateTime.now();
-        arriveBy = true;
+    final override = _routingTimeOverride;
+    if (override != null) {
+      effectiveDateTime = DateTime(
+        now.year,
+        now.month,
+        now.day,
+        override.hour,
+        override.minute,
+      );
+      arriveBy = false;
+    } else {
+      switch (state.timeMode) {
+        case TimeMode.leaveNow:
+          effectiveDateTime = now;
+          arriveBy = false;
+        case TimeMode.departAt:
+          effectiveDateTime = state.dateTime ?? now;
+          arriveBy = false;
+        case TimeMode.arriveBy:
+          effectiveDateTime = state.dateTime ?? now;
+          arriveBy = true;
+      }
     }
 
     try {
@@ -175,17 +241,21 @@ class RoutePlannerCubit extends Cubit<RoutePlannerState> {
         ),
       );
 
-      final plan = await _currentFetchOperation?.valueOrCancellation();
+      final rawPlan = await _currentFetchOperation?.valueOrCancellation();
 
-      if (plan == null) {
+      if (rawPlan == null) {
         // Operation was cancelled
         return;
       }
 
-      if (!plan.hasItineraries) {
+      if (!rawPlan.hasItineraries) {
         emit(state.copyWith(isLoading: false, error: noRoutesErrorKey));
         return;
       }
+
+      // Enrich legs with operating hours from the bundled GTFS so OTP
+      // 1.5/2.8 plans show the indicator just like the local planner.
+      final plan = _enrichServiceHours(rawPlan);
 
       final index = selectedItineraryIndex ?? 0;
       final selectedItinerary =

--- a/packages/screens/trufi_core_home_screen/lib/src/home_screen_trufi_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/home_screen_trufi_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:provider/provider.dart' show ChangeNotifierProvider;
+import 'package:provider/provider.dart' show ChangeNotifierProvider, Provider;
 import 'package:provider/single_child_widget.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:trufi_core_poi_layers/trufi_core_poi_layers.dart';
@@ -61,6 +61,22 @@ class HomeScreenTrufiScreen extends TrufiScreen {
     return RoutingEngineRequestPlanService(manager: routingEngineManager);
   }
 
+  /// Pick a [routing.ServiceHoursLookup] from the registered engines,
+  /// falling back to a [routing.TrufiPlannerProvider]'s data source if
+  /// present. Returns null when no engine can answer the lookup.
+  routing.ServiceHoursLookup? _findServiceHoursLookup(BuildContext context) {
+    final manager = routing.RoutingEngineManager.read(context);
+    for (final engine in manager.engines) {
+      if (engine is routing.ServiceHoursLookup) {
+        return engine as routing.ServiceHoursLookup;
+      }
+      if (engine is routing.TrufiPlannerProvider) {
+        return engine.dataSource;
+      }
+    }
+    return null;
+  }
+
   @override
   String get id => 'home';
 
@@ -98,6 +114,19 @@ class HomeScreenTrufiScreen extends TrufiScreen {
       create: (context) => RoutePlannerCubit(
         repository: _repository,
         requestService: _createRequestService(context),
+        // Read once at create-time. The override is a startup
+        // config, not something that can flip while the cubit is
+        // live, so a non-listening read is fine.
+        routingTimeOverride: Provider.of<AppConfiguration?>(
+          context,
+          listen: false,
+        )?.routingTimeOverride,
+        // Pick the first ServiceHoursLookup-capable engine (typically
+        // the bundled-GTFS Trufi planner). OTP engines don't expose
+        // calendar+frequencies in a usable shape, so we side-channel
+        // operating hours through this lookup regardless of which
+        // engine produced the plan.
+        serviceHoursLookup: _findServiceHoursLookup(context),
       )..initialize(),
     ),
     if (config.poiLayersManager != null)

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -1585,8 +1585,16 @@ class _HomeScreenState extends State<HomeScreen>
                                 onRoutingSettings: _onRoutingSettings,
                                 onMenuPressed: widget.onMenuPressed,
                               ),
-                              // Departure time chip (visible when locations are set)
-                              if (widget.config.showDepartureTimeChip &&
+                              // Departure time chip (visible when
+                              // locations are set, and only when no
+                              // app-level `routingTimeOverride` is
+                              // configured — when set, every request
+                              // resolves against a fixed time of day
+                              // and the picker would mislead).
+                              if (context
+                                          .read<AppConfiguration?>()
+                                          ?.routingTimeOverride ==
+                                      null &&
                                   (state.fromPlace != null ||
                                       state.toPlace != null))
                                 Padding(

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_card.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_card.dart
@@ -71,7 +71,7 @@ class ItineraryCard extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 // Top row: Duration and time
-                _buildHeaderRow(theme, l10n),
+                _buildHeaderRow(context, theme, l10n),
                 const SizedBox(height: 10),
                 // Transport modes summary
                 _buildTransportSummary(context),
@@ -86,7 +86,11 @@ class ItineraryCard extends StatelessWidget {
     );
   }
 
-  Widget _buildHeaderRow(ThemeData theme, HomeScreenLocalizations l10n) {
+  Widget _buildHeaderRow(
+    BuildContext context,
+    ThemeData theme,
+    HomeScreenLocalizations l10n,
+  ) {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
@@ -107,33 +111,39 @@ class ItineraryCard extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 12),
-        // Time range
-        Expanded(
-          child: Row(
-            children: [
-              Text(
-                DateFormat('HH:mm').format(itinerary.startTime),
-                style: theme.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
+        // Time range. Hidden when `routingTimeOverride` is set on the
+        // app config — under that mode the routing request uses a
+        // fixed time-of-day, so the resulting `startTime`/`endTime`
+        // are not the user's real wall-clock and would mislead.
+        if (context.watch<AppConfiguration?>()?.routingTimeOverride == null)
+          Expanded(
+            child: Row(
+              children: [
+                Text(
+                  DateFormat('HH:mm').format(itinerary.startTime),
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 6),
-                child: Icon(
-                  Icons.arrow_forward_rounded,
-                  size: 16,
-                  color: theme.colorScheme.onSurfaceVariant,
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 6),
+                  child: Icon(
+                    Icons.arrow_forward_rounded,
+                    size: 16,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                 ),
-              ),
-              Text(
-                DateFormat('HH:mm').format(itinerary.endTime),
-                style: theme.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
+                Text(
+                  DateFormat('HH:mm').format(itinerary.endTime),
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
-              ),
-            ],
-          ),
-        ),
+              ],
+            ),
+          )
+        else
+          const Spacer(),
         // Go button or selection indicator
         if (isSelected && onStartNavigation != null)
           FilledButton.icon(

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_detail_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_detail_screen.dart
@@ -154,27 +154,32 @@ class ItineraryDetailContent extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 12),
-              // Time range
-              Text(
-                DateFormat('HH:mm').format(itinerary.startTime),
-                style: theme.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
+              // Time range — hidden when the app pins routing time to
+              // a fixed value, since startTime/endTime would be
+              // synthetic ("today @ 12:xx") and confuse the user.
+              if (context.watch<AppConfiguration?>()?.routingTimeOverride ==
+                  null) ...[
+                Text(
+                  DateFormat('HH:mm').format(itinerary.startTime),
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 6),
-                child: Icon(
-                  Icons.arrow_forward_rounded,
-                  size: 16,
-                  color: colorScheme.onSurfaceVariant,
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 6),
+                  child: Icon(
+                    Icons.arrow_forward_rounded,
+                    size: 16,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
                 ),
-              ),
-              Text(
-                DateFormat('HH:mm').format(itinerary.endTime),
-                style: theme.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
+                Text(
+                  DateFormat('HH:mm').format(itinerary.endTime),
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
-              ),
+              ],
               const Spacer(),
               // Go button
               if (onStartNavigation != null)
@@ -444,8 +449,10 @@ class _PlaceItem extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
           ),
         ),
-        // Time
-        if (time != null)
+        // Time — hidden when the routing time is overridden, since
+        // the value would be from a synthetic "midday" plan.
+        if (time != null &&
+            context.watch<AppConfiguration?>()?.routingTimeOverride == null)
           Text(
             DateFormat('HH:mm').format(time!),
             style: theme.textTheme.bodyMedium?.copyWith(
@@ -582,58 +589,62 @@ class _LegItemState extends State<_LegItem> {
         leg.intermediatePlaces != null && leg.intermediatePlaces!.isNotEmpty;
     final stopsCount = leg.intermediatePlaces?.length ?? 0;
 
+    // IntrinsicHeight + stretch lets the timeline line grow with the
+    // content. Without it the line had a fixed height and visibly
+    // ended mid-leg when extra rows (expanded service hours, stops
+    // count) pushed the leg content below 90px.
     return Column(
       children: [
-        // Main leg row
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Icon + Timeline column
-            Column(
-              children: [
-                // Icon (only for walking/biking)
-                SizedBox(
-                  width: 32,
-                  height: 24,
-                  child: (isWalk || isBike)
-                      ? Icon(
-                          _getModeIcon(leg.transportMode),
-                          size: 20,
-                          color: colorScheme.onSurfaceVariant,
-                        )
-                      : null,
-                ),
-              ],
-            ),
-            // Timeline line with fixed height based on content type
-            SizedBox(
-              width: 20,
-              height: (isWalk || isBike) ? 32 : 90,
-              child: Center(
-                child: Container(
-                  width: 4,
-                  color: (isWalk || isBike)
-                      ? widget.lineColor.withValues(alpha: 0.5)
-                      : widget.lineColor,
+        IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Icon (only for walking/biking) — fixed-size, top-aligned.
+              SizedBox(
+                width: 32,
+                child: Align(
+                  alignment: Alignment.topCenter,
+                  child: SizedBox(
+                    height: 24,
+                    child: (isWalk || isBike)
+                        ? Icon(
+                            _getModeIcon(leg.transportMode),
+                            size: 20,
+                            color: colorScheme.onSurfaceVariant,
+                          )
+                        : null,
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(width: 12),
-            // Leg content
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.only(top: 2, bottom: 4),
-                child: _buildLegContent(
-                  theme,
-                  colorScheme,
-                  isWalk,
-                  isBike,
-                  hasStops,
-                  stopsCount,
+              // Timeline line — stretches vertically with the row.
+              SizedBox(
+                width: 20,
+                child: Center(
+                  child: Container(
+                    width: 4,
+                    color: (isWalk || isBike)
+                        ? widget.lineColor.withValues(alpha: 0.5)
+                        : widget.lineColor,
+                  ),
                 ),
               ),
-            ),
-          ],
+              const SizedBox(width: 12),
+              // Leg content
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 2, bottom: 4),
+                  child: _buildLegContent(
+                    theme,
+                    colorScheme,
+                    isWalk,
+                    isBike,
+                    hasStops,
+                    stopsCount,
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
 
         // Expanded stops
@@ -777,33 +788,61 @@ class _LegItemState extends State<_LegItem> {
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        // First row: identity (tappable) + stops count (tappable, toggles)
-        Row(
-          children: [
-            // Tappable identity row, flat (no border). Ripple from
-            // InkWell signals interactivity on press; the chevron at
-            // the end acts as the static affordance — same pattern
-            // Google Maps uses for transit legs.
-            Expanded(
-              child: widget.onRouteTap != null
-                  ? InkWell(
-                      onTap: _handleRouteTap,
-                      borderRadius: BorderRadius.circular(6),
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 4),
-                        child: identityRow,
-                      ),
-                    )
-                  : identityRow,
+        // First row: identity (tappable, full width). The "stops count"
+        // toggle used to live here, but it created a visual inconsistency
+        // — placing it on the same line as the route name made it look
+        // like part of the identity. It now sits below the operating
+        // hours, in document order, as just another expand control.
+        widget.onRouteTap != null
+            ? InkWell(
+                onTap: _handleRouteTap,
+                borderRadius: BorderRadius.circular(6),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: identityRow,
+                ),
+              )
+            : identityRow,
+        // Second row: duration and distance below the identity, so
+        // the route name reads as the primary label and the trip
+        // metrics sit underneath as secondary information (mirrors
+        // how the search list and detail header are stacked).
+        Padding(
+          padding: const EdgeInsets.only(top: 2),
+          child: Text(
+            '$durationText, $distanceText',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
             ),
-            const SizedBox(width: 8),
-            // Stops count (tappable)
-            if (hasStops)
-              GestureDetector(
-                onTap: () {
-                  HapticFeedback.selectionClick();
-                  setState(() => _isExpanded = !_isExpanded);
-                },
+          ),
+        ),
+        // Third row: live operating-hours indicator (only when the
+        // local planner has populated `serviceHours` from the bundled
+        // GTFS — OTP providers don't expose calendar+frequencies via
+        // their public APIs, so this row is silently skipped there).
+        if (leg.serviceHours != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: routing.ServiceHoursIndicator(
+              serviceHours: leg.serviceHours!,
+            ),
+          ),
+        // Fourth row: stops count toggle, right-aligned. Same expand
+        // pattern as the operating-hours indicator above — tap flips
+        // the chevron and reveals the stop list inline. Aligned right
+        // so it doesn't compete with the leg's left-anchored content
+        // (route name, duration, hours).
+        if (hasStops)
+          Align(
+            alignment: Alignment.centerRight,
+            child: InkWell(
+              onTap: () {
+                HapticFeedback.selectionClick();
+                setState(() => _isExpanded = !_isExpanded);
+              },
+              borderRadius: BorderRadius.circular(4),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 2),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
@@ -819,27 +858,14 @@ class _LegItemState extends State<_LegItem> {
                       _isExpanded
                           ? Icons.expand_less_rounded
                           : Icons.expand_more_rounded,
-                      size: 18,
+                      size: 16,
                       color: _legibleColor(widget.lineColor),
                     ),
                   ],
                 ),
               ),
-          ],
-        ),
-        // Second row: duration and distance below the identity, so
-        // the route name reads as the primary label and the trip
-        // metrics sit underneath as secondary information (mirrors
-        // how the search list and detail header are stacked).
-        Padding(
-          padding: const EdgeInsets.only(top: 2),
-          child: Text(
-            '$durationText, $distanceText',
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: colorScheme.onSurfaceVariant,
             ),
           ),
-        ),
         // Third row: Agency info (if available)
         if (leg.agency?.name != null)
           Padding(
@@ -932,8 +958,10 @@ class _LegItemState extends State<_LegItem> {
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
-                // Time
-                if (stop.arrivalTime != null)
+                // Time — hidden under routing time override (synthetic).
+                if (stop.arrivalTime != null &&
+                    context.watch<AppConfiguration?>()?.routingTimeOverride ==
+                        null)
                   Text(
                     DateFormat('HH:mm').format(stop.arrivalTime!),
                     style: theme.textTheme.bodySmall?.copyWith(

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_list.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_list.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart' as intl;
+import 'package:provider/provider.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart' as routing;
 import 'package:trufi_core_utils/trufi_core_utils.dart';
 
@@ -663,25 +665,31 @@ class _AlternativeTimeCard extends StatelessWidget {
                   color: theme.colorScheme.primary,
                 ),
                 const SizedBox(width: 8),
-                Text(
-                  l10n.departsAt(timeFormat.format(itinerary.startTime)),
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    fontWeight: FontWeight.w500,
+                // Hide absolute clock times when the app pins the
+                // routing time to a fixed value — startTime/endTime
+                // are then synthetic and would mislead the user.
+                if (context.watch<AppConfiguration?>()?.routingTimeOverride ==
+                    null) ...[
+                  Text(
+                    l10n.departsAt(timeFormat.format(itinerary.startTime)),
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w500,
+                    ),
                   ),
-                ),
-                const SizedBox(width: 8),
-                Icon(
-                  Icons.arrow_forward_rounded,
-                  size: 14,
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-                const SizedBox(width: 8),
-                Text(
-                  timeFormat.format(itinerary.endTime),
-                  style: theme.textTheme.bodyMedium?.copyWith(
+                  const SizedBox(width: 8),
+                  Icon(
+                    Icons.arrow_forward_rounded,
+                    size: 14,
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
-                ),
+                  const SizedBox(width: 8),
+                  Text(
+                    timeFormat.format(itinerary.endTime),
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
                 const Spacer(),
                 if (isSelected)
                   Icon(

--- a/packages/screens/trufi_core_transport_list/lib/src/gtfs_transport_data_provider.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/gtfs_transport_data_provider.dart
@@ -186,10 +186,53 @@ class GtfsTransportDataProvider extends TransportListDataProvider {
         headsign: trip.headsign,
         description: route?.description,
         directionId: trip.directionId?.value,
+        serviceHours: _serviceHoursForTrip(data, trip),
       ));
     }
 
     return routes;
+  }
+
+  /// Build a [ServiceHours] for [trip] by combining its `calendar`
+  /// (which days the service runs) with its `frequencies` (or
+  /// `stop_times` as fallback) for the daily start/end window.
+  ///
+  /// Returns null if the feed has neither calendar nor any usable
+  /// time bounds — the UI then suppresses the operating-hours card.
+  ServiceHours? _serviceHoursForTrip(GtfsData data, GtfsTrip trip) {
+    final calendar = data.calendars[trip.serviceId];
+    if (calendar == null) return null;
+    final days = <int>{
+      if (calendar.monday) DateTime.monday,
+      if (calendar.tuesday) DateTime.tuesday,
+      if (calendar.wednesday) DateTime.wednesday,
+      if (calendar.thursday) DateTime.thursday,
+      if (calendar.friday) DateTime.friday,
+      if (calendar.saturday) DateTime.saturday,
+      if (calendar.sunday) DateTime.sunday,
+    };
+    if (days.isEmpty) return null;
+
+    Duration? minStart;
+    Duration? maxEnd;
+    for (final f in data.frequencies) {
+      if (f.tripId != trip.id) continue;
+      if (minStart == null || f.startTime < minStart) minStart = f.startTime;
+      if (maxEnd == null || f.endTime > maxEnd) maxEnd = f.endTime;
+    }
+    if (minStart == null || maxEnd == null) return null;
+
+    return ServiceHours(
+      daysOfWeek: days,
+      startTime: TimeOfDay(
+        hour: minStart.inHours % 24,
+        minute: minStart.inMinutes % 60,
+      ),
+      endTime: TimeOfDay(
+        hour: maxEnd.inHours % 24,
+        minute: maxEnd.inMinutes % 60,
+      ),
+    );
   }
 
   List<String> _getStopsForTrip(GtfsData data, String tripId) {

--- a/packages/screens/trufi_core_transport_list/lib/src/models/transport_route.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/models/transport_route.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:trufi_core_routing/trufi_core_routing.dart' show ServiceHours;
+
+export 'package:trufi_core_routing/trufi_core_routing.dart' show ServiceHours;
 
 /// Represents a transport route for display in the list
 class TransportRoute {
@@ -14,6 +17,7 @@ class TransportRoute {
   final String? headsign;
   final String? description;
   final int? directionId;
+  final ServiceHours? serviceHours;
 
   const TransportRoute({
     required this.id,
@@ -28,6 +32,7 @@ class TransportRoute {
     this.headsign,
     this.description,
     this.directionId,
+    this.serviceHours,
   });
 
   String get displayName => shortName ?? name;
@@ -96,6 +101,7 @@ class TransportRouteDetails extends TransportRoute {
     super.headsign,
     super.description,
     super.directionId,
+    super.serviceHours,
     this.geometry,
     this.stops,
     this.modeName,

--- a/packages/screens/trufi_core_transport_list/lib/src/transport_detail_screen.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/transport_detail_screen.dart
@@ -1010,6 +1010,17 @@ class _StopsSheetContentState extends State<_StopsSheetContent> {
             ),
           ),
 
+        // Operating hours indicator (when the feed exposes service
+        // calendar + frequencies). One-line dot+label so the user
+        // sees "is the bus running right now?" before committing.
+        if (widget.route.serviceHours != null)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+            child: ServiceHoursIndicator(
+              serviceHours: widget.route.serviceHours!,
+            ),
+          ),
+
         // Route statistics
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
@@ -2142,3 +2153,7 @@ class _RouteIdentity extends StatelessWidget {
     );
   }
 }
+
+// `ServiceHoursIndicator` lives in widgets/service_hours_indicator.dart so
+// both the list tile and this detail screen can render the same
+// dot+label badge without duplicating the status logic.

--- a/packages/screens/trufi_core_transport_list/lib/src/widgets/transport_tile.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/widgets/transport_tile.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:trufi_core_routing/trufi_core_routing.dart'
+    show ServiceHoursIndicator;
 
 import '../models/transport_route.dart';
 
@@ -131,6 +133,17 @@ class TransportTile extends StatelessWidget {
                                     ),
                                   ),
                                 ],
+                              ),
+                            ],
+                            // Service status indicator (when feed has
+                            // calendar + frequencies). Always evaluates
+                            // against `DateTime.now()`, independent of
+                            // the app's `routingTimeOverride`, so the
+                            // user sees whether the bus runs *right now*.
+                            if (route.serviceHours != null) ...[
+                              const SizedBox(height: 4),
+                              ServiceHoursIndicator(
+                                serviceHours: route.serviceHours!,
                               ),
                             ],
                           ],

--- a/packages/trufi_core_interfaces/lib/src/config/app_configuration.dart
+++ b/packages/trufi_core_interfaces/lib/src/config/app_configuration.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart' show TimeOfDay;
 import 'package:flutter/widgets.dart';
 import 'package:provider/single_child_widget.dart';
 
@@ -134,6 +135,23 @@ class AppConfiguration {
   /// Defaults to Duration.zero (no minimum).
   final Duration minSplashDuration;
 
+  /// Optional fixed time-of-day used for every transit-routing
+  /// request on the current calendar day. When set, the
+  /// departure-time picker is hidden and absolute `HH:mm` labels in
+  /// itinerary cards/details are also hidden — the routing time is
+  /// fictitious, so showing it would mislead the user.
+  ///
+  /// Use this for cities where service doesn't run 24h: planning at
+  /// 02:00 against the real `now` returns 0 results because no
+  /// service is active. Setting this to e.g.
+  /// `TimeOfDay(hour: 12, minute: 0)` makes every request resolve
+  /// against midday on today's date, so the user always sees
+  /// representative routes regardless of when they open the app.
+  ///
+  /// Default: null → users see the picker, requests use
+  /// `DateTime.now()`, and time labels render normally.
+  final TimeOfDay? routingTimeOverride;
+
   const AppConfiguration({
     required this.appName,
     this.appTagline,
@@ -149,5 +167,6 @@ class AppConfiguration {
     this.drawerFooterExtra,
     this.logo,
     this.minSplashDuration = Duration.zero,
+    this.routingTimeOverride,
   });
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_de.arb
+++ b/packages/trufi_core_routing/lib/l10n/routing_de.arb
@@ -12,5 +12,10 @@
   "prefsModeBicycle": "Fahrrad",
   "prefsWheelchairAccessible": "Rollstuhlgerecht",
   "prefsWheelchairOn": "Routen vermeiden Treppen und steile Hänge",
-  "prefsWheelchairOff": "Alle Routen einschließen"
+  "prefsWheelchairOff": "Alle Routen einschließen",
+  "serviceActiveClosesAt": "Aktiv · schließt um {time}",
+  "serviceClosedOpensAt": "Geschlossen · öffnet um {time}",
+  "serviceClosedOpensDayAt": "Geschlossen · öffnet {day} um {time}",
+  "serviceClosed": "Geschlossen",
+  "serviceTomorrow": "morgen"
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_en.arb
+++ b/packages/trufi_core_routing/lib/l10n/routing_en.arb
@@ -51,5 +51,35 @@
   "prefsWheelchairOff": "Include all routes",
   "@prefsWheelchairOff": {
     "description": "Description when wheelchair mode is disabled"
+  },
+  "serviceActiveClosesAt": "Active · closes at {time}",
+  "@serviceActiveClosesAt": {
+    "description": "Service-hours indicator label when the route is currently running. {time} is the closing time, e.g. '22:00'.",
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  },
+  "serviceClosedOpensAt": "Closed · opens at {time}",
+  "@serviceClosedOpensAt": {
+    "description": "Service-hours indicator label when the route runs today but the current time is before its start. {time} is the opening time.",
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  },
+  "serviceClosedOpensDayAt": "Closed · opens {day} at {time}",
+  "@serviceClosedOpensDayAt": {
+    "description": "Service-hours indicator label when the next service is on a different weekday. {day} is the localized day name (e.g. 'tomorrow', 'Mon'), {time} is the opening time.",
+    "placeholders": {
+      "day": { "type": "String" },
+      "time": { "type": "String" }
+    }
+  },
+  "serviceClosed": "Closed",
+  "@serviceClosed": {
+    "description": "Fallback service-hours label and per-day cell when the route doesn't operate that day."
+  },
+  "serviceTomorrow": "tomorrow",
+  "@serviceTomorrow": {
+    "description": "Used inside serviceClosedOpensDayAt when the next service is on the next calendar day."
   }
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_es.arb
+++ b/packages/trufi_core_routing/lib/l10n/routing_es.arb
@@ -12,5 +12,10 @@
   "prefsModeBicycle": "Bicicleta",
   "prefsWheelchairAccessible": "Accesible en silla de ruedas",
   "prefsWheelchairOn": "Las rutas evitan escaleras y pendientes pronunciadas",
-  "prefsWheelchairOff": "Incluir todas las rutas"
+  "prefsWheelchairOff": "Incluir todas las rutas",
+  "serviceActiveClosesAt": "Activo · cierra a las {time}",
+  "serviceClosedOpensAt": "Cerrado · abre a las {time}",
+  "serviceClosedOpensDayAt": "Cerrado · abre {day} a las {time}",
+  "serviceClosed": "Cerrado",
+  "serviceTomorrow": "mañana"
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_localizations.dart
+++ b/packages/trufi_core_routing/lib/l10n/routing_localizations.dart
@@ -180,6 +180,36 @@ abstract class RoutingLocalizations {
   /// In en, this message translates to:
   /// **'Include all routes'**
   String get prefsWheelchairOff;
+
+  /// Service-hours indicator label when the route is currently running. {time} is the closing time, e.g. '22:00'.
+  ///
+  /// In en, this message translates to:
+  /// **'Active · closes at {time}'**
+  String serviceActiveClosesAt(String time);
+
+  /// Service-hours indicator label when the route runs today but the current time is before its start. {time} is the opening time.
+  ///
+  /// In en, this message translates to:
+  /// **'Closed · opens at {time}'**
+  String serviceClosedOpensAt(String time);
+
+  /// Service-hours indicator label when the next service is on a different weekday. {day} is the localized day name (e.g. 'tomorrow', 'Mon'), {time} is the opening time.
+  ///
+  /// In en, this message translates to:
+  /// **'Closed · opens {day} at {time}'**
+  String serviceClosedOpensDayAt(String day, String time);
+
+  /// Fallback service-hours label and per-day cell when the route doesn't operate that day.
+  ///
+  /// In en, this message translates to:
+  /// **'Closed'**
+  String get serviceClosed;
+
+  /// Used inside serviceClosedOpensDayAt when the next service is on the next calendar day.
+  ///
+  /// In en, this message translates to:
+  /// **'tomorrow'**
+  String get serviceTomorrow;
 }
 
 class _RoutingLocalizationsDelegate

--- a/packages/trufi_core_routing/lib/l10n/routing_localizations_de.dart
+++ b/packages/trufi_core_routing/lib/l10n/routing_localizations_de.dart
@@ -46,4 +46,25 @@ class RoutingLocalizationsDe extends RoutingLocalizations {
 
   @override
   String get prefsWheelchairOff => 'Alle Routen einschließen';
+
+  @override
+  String serviceActiveClosesAt(String time) {
+    return 'Aktiv · schließt um $time';
+  }
+
+  @override
+  String serviceClosedOpensAt(String time) {
+    return 'Geschlossen · öffnet um $time';
+  }
+
+  @override
+  String serviceClosedOpensDayAt(String day, String time) {
+    return 'Geschlossen · öffnet $day um $time';
+  }
+
+  @override
+  String get serviceClosed => 'Geschlossen';
+
+  @override
+  String get serviceTomorrow => 'morgen';
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_localizations_en.dart
+++ b/packages/trufi_core_routing/lib/l10n/routing_localizations_en.dart
@@ -46,4 +46,25 @@ class RoutingLocalizationsEn extends RoutingLocalizations {
 
   @override
   String get prefsWheelchairOff => 'Include all routes';
+
+  @override
+  String serviceActiveClosesAt(String time) {
+    return 'Active · closes at $time';
+  }
+
+  @override
+  String serviceClosedOpensAt(String time) {
+    return 'Closed · opens at $time';
+  }
+
+  @override
+  String serviceClosedOpensDayAt(String day, String time) {
+    return 'Closed · opens $day at $time';
+  }
+
+  @override
+  String get serviceClosed => 'Closed';
+
+  @override
+  String get serviceTomorrow => 'tomorrow';
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_localizations_es.dart
+++ b/packages/trufi_core_routing/lib/l10n/routing_localizations_es.dart
@@ -47,4 +47,25 @@ class RoutingLocalizationsEs extends RoutingLocalizations {
 
   @override
   String get prefsWheelchairOff => 'Incluir todas las rutas';
+
+  @override
+  String serviceActiveClosesAt(String time) {
+    return 'Activo · cierra a las $time';
+  }
+
+  @override
+  String serviceClosedOpensAt(String time) {
+    return 'Cerrado · abre a las $time';
+  }
+
+  @override
+  String serviceClosedOpensDayAt(String day, String time) {
+    return 'Cerrado · abre $day a las $time';
+  }
+
+  @override
+  String get serviceClosed => 'Cerrado';
+
+  @override
+  String get serviceTomorrow => 'mañana';
 }

--- a/packages/trufi_core_routing/lib/src/models/leg.dart
+++ b/packages/trufi_core_routing/lib/src/models/leg.dart
@@ -7,6 +7,7 @@ import 'agency.dart';
 import 'place.dart';
 import 'realtime_state.dart';
 import 'route.dart';
+import 'service_hours.dart';
 import 'step.dart';
 import 'transport_mode.dart';
 
@@ -34,6 +35,7 @@ class Leg extends Equatable {
     this.interlineWithPreviousLeg,
     this.headsign,
     this.tripPatternId,
+    this.serviceHours,
   });
 
   final String mode;
@@ -57,6 +59,13 @@ class Leg extends Equatable {
   final bool? interlineWithPreviousLeg;
   final String? headsign;
   final String? tripPatternId;
+
+  /// Operating hours for the route this leg belongs to. Set by the
+  /// local planner (which can read `calendar.txt` + `frequencies.txt`
+  /// directly from the bundled GTFS); remote OTP providers leave it
+  /// null. UI consumers (e.g. the itinerary plan leg) render a small
+  /// status badge when this is non-null.
+  final ServiceHours? serviceHours;
 
   /// Returns the transport mode enum.
   TransportMode get transportMode =>
@@ -181,6 +190,7 @@ class Leg extends Equatable {
     bool? interlineWithPreviousLeg,
     String? headsign,
     String? tripPatternId,
+    ServiceHours? serviceHours,
   }) {
     return Leg(
       mode: mode ?? this.mode,
@@ -205,6 +215,7 @@ class Leg extends Equatable {
           interlineWithPreviousLeg ?? this.interlineWithPreviousLeg,
       headsign: headsign ?? this.headsign,
       tripPatternId: tripPatternId ?? this.tripPatternId,
+      serviceHours: serviceHours ?? this.serviceHours,
     );
   }
 

--- a/packages/trufi_core_routing/lib/src/models/service_hours.dart
+++ b/packages/trufi_core_routing/lib/src/models/service_hours.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart' show TimeOfDay;
+
+/// Operating hours for a transit route, derived from the GTFS
+/// calendar (which days the service runs) plus a representative
+/// daily window — usually the union of `frequencies.txt` ranges or
+/// the bounds of `stop_times.txt` for the trip.
+///
+/// All fields are local-time as expressed in the feed; the consumer
+/// is responsible for applying the agency's timezone if needed.
+///
+/// Lives in `trufi_core_routing` so both the transit list (route
+/// detail / list tile) and the home screen (itinerary plan leg) can
+/// render the same indicator without a cross-screen dependency.
+class ServiceHours {
+  /// Days the service runs, keyed by `DateTime.weekday` (1=Mon … 7=Sun).
+  /// Empty set means the data wasn't available; the UI should fall
+  /// back to "operating hours unavailable" rather than rendering
+  /// "Closed every day".
+  final Set<int> daysOfWeek;
+
+  /// Earliest service start across the days listed above.
+  final TimeOfDay startTime;
+
+  /// Latest service end across the days listed above. May be after
+  /// midnight (i.e. `startTime` > `endTime`) when the schedule wraps.
+  final TimeOfDay endTime;
+
+  const ServiceHours({
+    required this.daysOfWeek,
+    required this.startTime,
+    required this.endTime,
+  });
+
+  /// Whether the service is currently active given a [now] timestamp.
+  /// `now` defaults to `DateTime.now()` so callers in widgets can omit
+  /// it; tests pass an explicit value for reproducibility.
+  bool isActiveAt(DateTime now) {
+    if (!daysOfWeek.contains(now.weekday)) return false;
+    final mins = now.hour * 60 + now.minute;
+    final start = startTime.hour * 60 + startTime.minute;
+    final end = endTime.hour * 60 + endTime.minute;
+    if (start <= end) {
+      return mins >= start && mins < end;
+    }
+    return mins >= start || mins < end;
+  }
+}

--- a/packages/trufi_core_routing/lib/src/models/service_hours_lookup.dart
+++ b/packages/trufi_core_routing/lib/src/models/service_hours_lookup.dart
@@ -1,0 +1,21 @@
+import 'service_hours.dart';
+
+/// Resolves a route id to its [ServiceHours] when the host app has
+/// access to a GTFS source.
+///
+/// OTP's REST/GraphQL APIs don't expose calendar+frequencies in a
+/// shape we can use to derive operating hours per route, so providers
+/// like [Otp15RoutingProvider] / [Otp28RoutingProvider] return [Leg]s
+/// with `serviceHours == null`. The [RoutePlannerCubit] takes an
+/// optional [ServiceHoursLookup] and uses it as a side-channel to
+/// enrich those legs after the parse — typically backed by the same
+/// GTFS asset bundled with the app.
+abstract class ServiceHoursLookup {
+  /// Returns operating hours for [routeId], or null when the lookup
+  /// has no record of it (different feed, missing calendar, etc.).
+  ///
+  /// Implementations should be tolerant of provider-specific id
+  /// shapes: OTP returns `feedId:routeId` whereas the bundled GTFS
+  /// uses bare `routeId`, so a robust implementation tries both.
+  ServiceHours? serviceHoursForRouteId(String routeId);
+}

--- a/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
@@ -127,6 +127,12 @@ class Otp15RoutingProvider extends IRoutingProvider {
       'date': date,
       'time': time,
       if (arriveBy) 'arriveBy': 'true',
+      // Without this, OTP 1.5 returns only the boarding/alighting
+      // stops on each transit leg — the detail screen then has no
+      // intermediate stops to show. The local Trufi planner emits
+      // them by default, so requesting them here keeps OTP-backed
+      // legs at parity.
+      'showIntermediateStops': 'true',
     };
 
     if (_prefs.wheelchair) {

--- a/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_data_source.dart
+++ b/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_data_source.dart
@@ -3,8 +3,11 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:flutter/material.dart' show TimeOfDay;
 import 'package:trufi_core_planner/trufi_core_planner.dart';
 
+import '../../models/service_hours.dart';
+import '../../models/service_hours_lookup.dart';
 import 'trufi_planner_config.dart';
 
 /// Status of the data source.
@@ -29,7 +32,7 @@ class _GtfsLoadResult {
 ///
 /// Manages a [PlannerRoutingClient] that can be either local or remote,
 /// and provides convenience methods for accessing data.
-class TrufiPlannerDataSource {
+class TrufiPlannerDataSource implements ServiceHoursLookup {
   final TrufiPlannerConfig config;
   late final PlannerRoutingClient _client;
 
@@ -81,6 +84,63 @@ class TrufiPlannerDataSource {
 
   /// Raw GTFS data (local mode only).
   GtfsData? get data => _localData;
+
+  /// Resolve [routeId] → [ServiceHours] using the bundled GTFS feed.
+  ///
+  /// Tolerant of OTP-style `feedId:routeId` ids: tries the literal id
+  /// first, then falls back to the suffix after `:`. Returns null when
+  /// the route, its calendar, or its frequencies are missing — the UI
+  /// then suppresses the indicator instead of rendering half-empty.
+  @override
+  ServiceHours? serviceHoursForRouteId(String routeId) {
+    final data = _localData;
+    if (data == null) return null;
+    final candidates = <String>{
+      routeId,
+      if (routeId.contains(':')) routeId.split(':').last,
+    };
+    GtfsTrip? trip;
+    for (final t in data.trips.values) {
+      if (candidates.contains(t.routeId)) {
+        trip = t;
+        break;
+      }
+    }
+    if (trip == null) return null;
+    final calendar = data.calendars[trip.serviceId];
+    if (calendar == null) return null;
+    final days = <int>{
+      if (calendar.monday) DateTime.monday,
+      if (calendar.tuesday) DateTime.tuesday,
+      if (calendar.wednesday) DateTime.wednesday,
+      if (calendar.thursday) DateTime.thursday,
+      if (calendar.friday) DateTime.friday,
+      if (calendar.saturday) DateTime.saturday,
+      if (calendar.sunday) DateTime.sunday,
+    };
+    if (days.isEmpty) return null;
+
+    Duration? minStart;
+    Duration? maxEnd;
+    for (final f in data.frequencies) {
+      if (f.tripId != trip.id) continue;
+      if (minStart == null || f.startTime < minStart) minStart = f.startTime;
+      if (maxEnd == null || f.endTime > maxEnd) maxEnd = f.endTime;
+    }
+    if (minStart == null || maxEnd == null) return null;
+
+    return ServiceHours(
+      daysOfWeek: days,
+      startTime: TimeOfDay(
+        hour: minStart.inHours % 24,
+        minute: minStart.inMinutes % 60,
+      ),
+      endTime: TimeOfDay(
+        hour: maxEnd.inHours % 24,
+        minute: maxEnd.inMinutes % 60,
+      ),
+    );
+  }
 
   /// Preload data. Call at app startup.
   Future<void> preload() async {

--- a/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../../utils/polyline_decoder.dart';
+import '../../models/agency.dart';
 import '../../models/itinerary.dart';
 import '../../models/leg.dart';
 import '../../models/place.dart';
@@ -11,6 +12,7 @@ import '../../models/plan.dart';
 import '../../models/plan_location.dart';
 import '../../models/route.dart' as domain;
 import '../../models/routing_location.dart';
+import '../../models/service_hours.dart';
 import '../../models/stop.dart';
 import '../../models/transit_route.dart';
 import '../../models/transport_mode.dart';
@@ -256,6 +258,7 @@ class TrufiPlannerProvider extends IRoutingProvider {
     }
 
     // Transit segments
+    final agencyNames = _buildAgencyNameMap();
     for (final segment in path.segments) {
       final points = segment.shapePoints.isNotEmpty
           ? segment.shapePoints
@@ -320,6 +323,17 @@ class TrufiPlannerProvider extends IRoutingProvider {
           // variant whenever a route has > 1 pattern.
           tripPatternId: '${segment.route.id}#${segment.pattern.id}',
           intermediatePlaces: intermediatePlaces,
+          serviceHours: _buildServiceHours(segment),
+          // Resolve agency from the GTFS agencies list so the leg
+          // exposes the same "operated by …" line that OTP-backed
+          // legs show. Without this, only OTP plans displayed the
+          // agency, creating a visible inconsistency.
+          agency: (segment.route.agencyId?.isNotEmpty ?? false)
+              ? Agency(
+                  gtfsId: segment.route.agencyId,
+                  name: agencyNames[segment.route.agencyId!],
+                )
+              : null,
         ),
       );
 
@@ -568,6 +582,11 @@ class TrufiPlannerProvider extends IRoutingProvider {
       stops: stops,
     );
   }
+
+  /// Build a [ServiceHours] for the route a [segment] belongs to,
+  /// by delegating to the data source's public lookup.
+  ServiceHours? _buildServiceHours(RoutingSegment segment) =>
+      _dataSource.serviceHoursForRouteId(segment.route.id);
 
   Map<String, String> _buildAgencyNameMap() {
     final agencies = _dataSource.data?.agencies ?? const [];

--- a/packages/trufi_core_routing/lib/src/widgets/service_hours_indicator.dart
+++ b/packages/trufi_core_routing/lib/src/widgets/service_hours_indicator.dart
@@ -1,0 +1,252 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../l10n/routing_localizations.dart';
+import '../models/service_hours.dart';
+
+/// One-line service indicator: a colored dot + a short label
+/// telling the user whether the route is running right now.
+///
+/// Always evaluated against `DateTime.now()` (not the app's
+/// `routingTimeOverride`) so the answer matches the user's
+/// wall-clock — "is this bus running right now?". Tapping the
+/// indicator expands a 7-day schedule inline (same pattern as the
+/// "X paradas" toggle in the itinerary leg), with the chevron
+/// flipping to signal the open state.
+///
+/// Examples (Spanish locale):
+///   🟢  Activo · cierra a las 22:00      ⌄
+///   🔴  Cerrado · abre a las 06:00       ⌄
+///   🔴  Cerrado · abre lun a las 06:00   ⌄
+///
+/// Lives in `trufi_core_routing` so both the transit list (route tile
+/// / detail) and the home screen (itinerary plan leg) can render the
+/// same badge without depending on each other.
+class ServiceHoursIndicator extends StatefulWidget {
+  final ServiceHours serviceHours;
+
+  const ServiceHoursIndicator({super.key, required this.serviceHours});
+
+  @override
+  State<ServiceHoursIndicator> createState() => _ServiceHoursIndicatorState();
+}
+
+class _ServiceHoursIndicatorState extends State<ServiceHoursIndicator> {
+  bool _expanded = false;
+  Timer? _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    // Re-render every minute so the label flips at open/close time
+    // without the user having to reopen the screen. Aligned to the
+    // next wall-clock minute so the first tick lands right when the
+    // displayed minute would change.
+    final now = DateTime.now();
+    final delay = Duration(
+      seconds: 60 - now.second,
+      milliseconds: -now.millisecond,
+    );
+    Future.delayed(delay, () {
+      if (!mounted) return;
+      setState(() {});
+      _ticker = Timer.periodic(const Duration(minutes: 1), (_) {
+        if (mounted) setState(() {});
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    super.dispose();
+  }
+
+  static String _fmt(TimeOfDay t) =>
+      '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
+
+  // Convert ISO weekday (1=Mon..7=Sun) → a sample DateTime in that
+  // weekday so DateFormat can render the locale-specific name.
+  static DateTime _sampleDateForWeekday(int isoWeekday) {
+    // 2024-01-01 was a Monday → adding (isoWeekday-1) days lands on the
+    // requested weekday in any locale.
+    return DateTime(2024, 1, isoWeekday);
+  }
+
+  ({String label, bool active}) _status(
+    DateTime now,
+    RoutingLocalizations l10n,
+    String locale,
+  ) {
+    final sh = widget.serviceHours;
+    final mins = now.hour * 60 + now.minute;
+    final start = sh.startTime.hour * 60 + sh.startTime.minute;
+    final end = sh.endTime.hour * 60 + sh.endTime.minute;
+    final today = now.weekday;
+    final runsToday = sh.daysOfWeek.contains(today);
+    final inWindow = start <= end
+        ? (mins >= start && mins < end)
+        : (mins >= start || mins < end);
+
+    if (runsToday && inWindow) {
+      return (
+        label: l10n.serviceActiveClosesAt(_fmt(sh.endTime)),
+        active: true,
+      );
+    }
+    if (runsToday && mins < start) {
+      return (
+        label: l10n.serviceClosedOpensAt(_fmt(sh.startTime)),
+        active: false,
+      );
+    }
+    for (int offset = 1; offset <= 7; offset++) {
+      final candidate = ((today - 1 + offset) % 7) + 1;
+      if (sh.daysOfWeek.contains(candidate)) {
+        final whenLabel = offset == 1
+            ? l10n.serviceTomorrow
+            : DateFormat.E(locale).format(_sampleDateForWeekday(candidate));
+        return (
+          label: l10n.serviceClosedOpensDayAt(whenLabel, _fmt(sh.startTime)),
+          active: false,
+        );
+      }
+    }
+    return (label: l10n.serviceClosed, active: false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = RoutingLocalizations.of(context);
+    final locale = Localizations.localeOf(context).toLanguageTag();
+    final status = _status(DateTime.now(), l10n, locale);
+    final dotColor = status.active ? Colors.green : Colors.red;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        InkWell(
+          onTap: () => setState(() => _expanded = !_expanded),
+          borderRadius: BorderRadius.circular(4),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 2),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 8,
+                  height: 8,
+                  decoration: BoxDecoration(
+                    color: dotColor,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+                const SizedBox(width: 6),
+                Flexible(
+                  child: Text(
+                    status.label,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: 2),
+                Icon(
+                  _expanded
+                      ? Icons.expand_less_rounded
+                      : Icons.expand_more_rounded,
+                  size: 16,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (_expanded)
+          Padding(
+            padding: const EdgeInsets.only(top: 4, left: 14, bottom: 4),
+            child: _ScheduleList(serviceHours: widget.serviceHours),
+          ),
+      ],
+    );
+  }
+}
+
+/// 7-row list showing each weekday's hours, with the current day
+/// highlighted. Rendered inline below [ServiceHoursIndicator] when
+/// expanded.
+class _ScheduleList extends StatelessWidget {
+  final ServiceHours serviceHours;
+
+  const _ScheduleList({required this.serviceHours});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final l10n = RoutingLocalizations.of(context);
+    final locale = Localizations.localeOf(context).toLanguageTag();
+    final today = DateTime.now().weekday;
+    final hours =
+        '${_ServiceHoursIndicatorState._fmt(serviceHours.startTime)} — '
+        '${_ServiceHoursIndicatorState._fmt(serviceHours.endTime)}';
+    // Capitalize the first letter — DateFormat.EEEE returns lowercase
+    // in Spanish ("lunes") but the schedule reads better with title
+    // case ("Lunes"), matching common UI conventions.
+    String dayLong(int isoWeekday) {
+      final raw = DateFormat.EEEE(locale).format(
+        _ServiceHoursIndicatorState._sampleDateForWeekday(isoWeekday),
+      );
+      if (raw.isEmpty) return raw;
+      return raw[0].toUpperCase() + raw.substring(1);
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (int day = 1; day <= 7; day++)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 2),
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 100,
+                  child: Text(
+                    dayLong(day),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontWeight: day == today
+                          ? FontWeight.w700
+                          : FontWeight.w400,
+                      color: colorScheme.onSurface,
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: Text(
+                    serviceHours.daysOfWeek.contains(day)
+                        ? hours
+                        : l10n.serviceClosed,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontWeight: day == today
+                          ? FontWeight.w700
+                          : FontWeight.w400,
+                      color: serviceHours.daysOfWeek.contains(day)
+                          ? colorScheme.onSurface
+                          : colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/packages/trufi_core_routing/lib/trufi_core_routing.dart
+++ b/packages/trufi_core_routing/lib/trufi_core_routing.dart
@@ -17,6 +17,8 @@ export 'src/models/plan_location.dart';
 export 'src/models/realtime_state.dart';
 export 'src/models/route.dart';
 export 'src/models/routing_location.dart';
+export 'src/models/service_hours.dart';
+export 'src/models/service_hours_lookup.dart';
 export 'src/models/step.dart';
 export 'src/models/stop.dart';
 export 'src/models/transit_route.dart';
@@ -62,6 +64,11 @@ export 'src/providers/otp_2_8/otp_2_8_response_parser.dart';
 // `VehiclePositionsService` is a deprecated typedef for
 // `OtpVehiclePositionsProvider` — both are exported for compatibility.
 export 'src/services/vehicle_positions_service.dart';
+
+// ============================================
+// Widgets
+// ============================================
+export 'src/widgets/service_hours_indicator.dart';
 
 // ============================================
 // Localizations

--- a/packages/trufi_core_ui/lib/src/trufi_app.dart
+++ b/packages/trufi_core_ui/lib/src/trufi_app.dart
@@ -122,9 +122,14 @@ class _TrufiAppState extends State<TrufiApp> {
         .expand((s) => s.providers)
         .toList();
 
-    // Layer 1: Inject all providers (without initializing yet)
+    // Layer 1: Inject all providers (without initializing yet).
+    // The `AppConfiguration` itself is exposed via Provider so deep
+    // widgets (home_screen, itinerary cards, routing engines wired
+    // up later) can read app-wide flags like `routingTimeOverride`
+    // without threading them through every constructor.
     return MultiProvider(
       providers: [
+        Provider<AppConfiguration>.value(value: widget.config),
         ChangeNotifierProvider.value(value: _localeManager),
         ChangeNotifierProvider.value(value: _themeManager),
         ChangeNotifierProvider.value(value: _sharedRouteNotifier),


### PR DESCRIPTION
## Summary

Two related additions, both motivated by Cochabamba ergonomics but useful as core features.

### `AppConfiguration.routingTimeOverride`
Lets a city app pin every plan request to a fixed time-of-day (e.g. mid-day) so the user doesn't have to think about a chip choice that — for a frequencies-based GTFS — produces nearly identical results regardless. When set, the departure-time chip is hidden and all absolute HH:mm labels in the itinerary card / list / detail are suppressed. Drops the now-redundant `HomeScreenConfig.showDepartureTimeChip`.

### Operating-hours indicator
Surfaces a one-line dot+text status ("🟢 Activo · cierra a las 22:00 ⌄" / "🔴 Cerrado · abre lun a las 06:00 ⌄") on the transit list `TransportTile`, the route detail screen, and each transit leg of the itinerary detail. Tap expands a 7-day schedule inline. Always evaluated against real `DateTime.now()` (independent of `routingTimeOverride`) — answers the question "is this bus running right now?" not "would it run at 12:00?".

To make it work everywhere — not just on the local Trufi planner — there's a `ServiceHoursLookup` interface backed by the bundled GTFS, plus a post-process step in `RoutePlannerCubit` that enriches `Leg.serviceHours` for legs the provider didn't populate. So OTP 1.5 / 2.4 / 2.8 plans show the indicator too.

## Notable details

- `Leg` gains `serviceHours: ServiceHours?` (nullable, preserved through `copyWith` / `toJson` / `fromJson`).
- The local `TrufiPlannerProvider` now sets `Leg.agency` from the GTFS agencies list. Previously only OTP-backed legs displayed "Operado por …", which was a visible inconsistency.
- OTP 1.5 plan requests now include `showIntermediateStops=true` — without it the detail screen had no intermediate stops to render. OTP 2.x already requested them via GraphQL.
- Itinerary detail leg row is reorganized so identity (badge + route name) takes a full row, with duration/distance, the operating-hours indicator, and the right-aligned "X paradas" toggle stacked underneath. Timeline line uses `IntrinsicHeight` so it grows with the leg's content (previously a fixed 90 px height left a visible gap when the schedule was expanded).
- `ServiceHoursIndicator` is locale-aware: strings via `RoutingLocalizations` (es/en/de), day names via `intl` `DateFormat` so any added locale works for free. Re-renders every minute, aligned to the wall-clock so the label flips at open/close time without the user having to reopen the screen.

## Breaking

- `HomeScreenConfig.showDepartureTimeChip` removed. Migration: switch to `AppConfiguration(..., routingTimeOverride: TimeOfDay(hour: 12, minute: 0))` to get the same "no chip, fixed mid-day" behavior, or omit `routingTimeOverride` to get the regular chip-driven flow.

## Test plan

- [x] `melos run ci:analyze` clean
- [x] `melos run l10n` reproducible (no diff after re-running)
- [x] Cochabamba app on Pixel 9a, all three providers (Local, OTP 1.5, OTP 2.8): list shows indicator, route detail shows indicator + tap-to-expand schedule, itinerary plan leg shows indicator (timeline grows with expanded schedule), "Operado por …" + intermediate stops appear on every provider.
- [x] Verified inactive state with a fake clock (then reverted) — indicator turns red and label flips to "Cerrado · abre …" with tomorrow / next-running weekday.

## Followup

After this merges and a `v5.14.0` tag is cut, `trufi-app` will bump every `trufi_core_*` ref accordingly and switch from `showDepartureTimeChip: false` to `routingTimeOverride: TimeOfDay(hour: 12, minute: 0)`.