### PR TITLE
fix: hide departure-time chip on wide layout + persist Leg.serviceHours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 5.14.1
+
+### Bug Fixes
+- Departure-time chip is now also hidden in the wide/web home layout when `AppConfiguration.routingTimeOverride` is set. The 5.14.0 release added the guard around the chip in the mobile layout but the wide layout (used on landscape phones, tablets and web) had a second copy of the chip without the guard, so apps that set `routingTimeOverride` still saw "Salir ahora" / "Leave now" on those surfaces. Both copies now share the same guard.
+- `Leg.serviceHours` is now serialized through `toJson` / `fromJson`. The 5.14.0 release added the field but didn't include it in the JSON shape, so any plan persisted to disk by `HomeScreenRepository` lost it on reload — visible as the operating-hours indicator disappearing after rotating the device or relaunching the app, even though the same plan showed it right after the original fetch. `ServiceHours` itself gains `toJson` / `fromJson` (encoded as `{daysOfWeek, startMinutes, endMinutes}`).
+
+---
+
 ## 5.14.0
 
 ### Breaking

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -2000,8 +2000,15 @@ class _HomeScreenState extends State<HomeScreen>
                       onRoutingSettings: _onRoutingSettings,
                       onMenuPressed: widget.onMenuPressed,
                     ),
-                    // Departure time chip
-                    if (state.fromPlace != null || state.toPlace != null)
+                    // Departure time chip — same guard as the mobile
+                    // layout above: hidden when an app-level
+                    // `routingTimeOverride` is set, since every plan
+                    // request resolves to a fixed time of day.
+                    if (context
+                                .read<AppConfiguration?>()
+                                ?.routingTimeOverride ==
+                            null &&
+                        (state.fromPlace != null || state.toPlace != null))
                       Padding(
                         padding: const EdgeInsets.only(top: 8),
                         child: _DepartureTimeChip(

--- a/packages/trufi_core_routing/lib/src/models/leg.dart
+++ b/packages/trufi_core_routing/lib/src/models/leg.dart
@@ -120,6 +120,11 @@ class Leg extends Equatable {
       interlineWithPreviousLeg: json['interlineWithPreviousLeg'] as bool?,
       headsign: json['headsign'] as String?,
       tripPatternId: json['tripPatternId'] as String?,
+      serviceHours: json['serviceHours'] != null
+          ? ServiceHours.fromJson(
+              json['serviceHours'] as Map<String, dynamic>,
+            )
+          : null,
     );
   }
 
@@ -164,6 +169,7 @@ class Leg extends Equatable {
       'interlineWithPreviousLeg': interlineWithPreviousLeg,
       'headsign': headsign,
       'tripPatternId': tripPatternId,
+      'serviceHours': serviceHours?.toJson(),
     };
   }
 

--- a/packages/trufi_core_routing/lib/src/models/service_hours.dart
+++ b/packages/trufi_core_routing/lib/src/models/service_hours.dart
@@ -44,4 +44,23 @@ class ServiceHours {
     }
     return mins >= start || mins < end;
   }
+
+  /// JSON shape: `{daysOfWeek: [1,2,...], startMinutes: int, endMinutes: int}`.
+  /// Encoding minutes-from-midnight is more compact than a `HH:mm` string
+  /// and matches how the model is reasoned about internally.
+  Map<String, dynamic> toJson() => {
+    'daysOfWeek': daysOfWeek.toList(),
+    'startMinutes': startTime.hour * 60 + startTime.minute,
+    'endMinutes': endTime.hour * 60 + endTime.minute,
+  };
+
+  factory ServiceHours.fromJson(Map<String, dynamic> json) {
+    final start = (json['startMinutes'] as num).toInt();
+    final end = (json['endMinutes'] as num).toInt();
+    return ServiceHours(
+      daysOfWeek: (json['daysOfWeek'] as List).map((e) => e as int).toSet(),
+      startTime: TimeOfDay(hour: start ~/ 60, minute: start % 60),
+      endTime: TimeOfDay(hour: end ~/ 60, minute: end % 60),
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Two follow-up fixes for 5.14.0, both surfaced while validating the new feature on web / landscape:

### 1. Wide-layout chip duplicate

`HomeScreen` has two layouts — mobile and wide/web. The 5.14.0 release added the `routingTimeOverride` guard around `_DepartureTimeChip` in the mobile layout, but the wide-layout copy of the chip had no guard. Web users (and landscape phones, tablets) saw "Salir ahora" / "Leave now" even when the override was set. Both copies now share the same guard.

### 2. `Leg.serviceHours` wasn't persisted

`Leg.serviceHours` was added to the model in 5.14.0 but `toJson` / `fromJson` didn't carry it through. So any plan persisted to disk by `HomeScreenRepository` lost the field on reload — visible as the operating-hours indicator disappearing after rotating the device or relaunching the app, even though the same plan showed it right after the original fetch (which kept the value in cubit memory).

`ServiceHours` itself gains `toJson` / `fromJson` (encoded as `{daysOfWeek, startMinutes, endMinutes}` — minutes-from-midnight is more compact than `HH:mm` and matches the model's internal reasoning).

## Test plan

- [x] `melos run ci:analyze` clean
- [x] Verified on the Android emulator (`store_phone`) in landscape: chip hidden, operating-hours indicator visible after a fresh fetch and survives rotation back to portrait
- [x] No-op on mobile portrait — same behavior as 5.14.0

CHANGELOG: 5.14.1.