### PR TITLE
fix: Tu Ubicación button freeze and silent location fallback (#897)

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -594,15 +594,42 @@ class _HomeScreenState extends State<HomeScreen>
             chooseOnMapText: l10n.chooseOnMap,
           ),
           onYourLocation: () async {
-            // Try to get GPS location
+            // Fast path: reuse a fresh location when the map is already tracking.
+            if (_locationService.isTracking &&
+                _locationService.currentLocation != null) {
+              final loc = _locationService.currentLocation!;
+              return SearchLocation(
+                id: 'current_location',
+                displayName: l10n.yourLocation,
+                latitude: loc.latitude,
+                longitude: loc.longitude,
+              );
+            }
+
             var status = await _locationService.checkPermission();
 
             if (status == LocationPermissionStatus.denied) {
               status = await _locationService.requestPermission();
             }
 
-            if (status == LocationPermissionStatus.granted) {
-              final location = await _locationService.getCurrentLocation();
+            if (status == LocationPermissionStatus.deniedForever) {
+              if (mounted) _showPermissionDeniedDialog();
+              return null;
+            }
+
+            if (status == LocationPermissionStatus.serviceDisabled) {
+              if (mounted) _showLocationDisabledDialog();
+              return null;
+            }
+
+            if (status != LocationPermissionStatus.granted) {
+              return null;
+            }
+
+            try {
+              final location = await _locationService.getCurrentLocation(
+                timeout: const Duration(seconds: 10),
+              );
               if (location != null) {
                 return SearchLocation(
                   id: 'current_location',
@@ -611,15 +638,13 @@ class _HomeScreenState extends State<HomeScreen>
                   longitude: location.longitude,
                 );
               }
+            } catch (_) {
+              // Timeout or geolocator failure — fall through to null so the
+              // user stays on the search screen instead of being silently
+              // teleported to the city's default center.
             }
 
-            // Fallback to default center if GPS not available
-            return SearchLocation(
-              id: 'current_location',
-              displayName: l10n.yourLocation,
-              latitude: defaultCenter.latitude,
-              longitude: defaultCenter.longitude,
-            );
+            return null;
           },
           onChooseOnMap: () async {
             final result = await Navigator.push<MapLocationResult>(
@@ -1034,18 +1059,30 @@ class _HomeScreenState extends State<HomeScreen>
       }
 
       if (status == LocationPermissionStatus.granted) {
-        // Start tracking location continuously
+        // Fast path: center on last-known position instantly so the user gets
+        // immediate feedback while the accurate fix is still being acquired.
+        final lastKnown = await _locationService.getLastKnownLocation();
+        if (lastKnown != null && mounted) {
+          _mapController?.moveCamera(
+            TrufiCameraPosition(
+              target: LatLng(lastKnown.latitude, lastKnown.longitude),
+              zoom: 16,
+            ),
+          );
+        }
+
+        // Start tracking; this also captures an initial accurate position
+        // into _locationService.currentLocation — no need to fetch it again.
         final started = await _locationService.startTracking();
 
         if (started && mounted) {
-          // Get initial location to center the map
-          final location = await _locationService.getCurrentLocation();
-          if (location != null && mounted) {
-            final position = LatLng(location.latitude, location.longitude);
-
-            // Move camera to location
+          final location = _locationService.currentLocation;
+          if (location != null) {
             _mapController?.moveCamera(
-              TrufiCameraPosition(target: position, zoom: 16),
+              TrufiCameraPosition(
+                target: LatLng(location.latitude, location.longitude),
+                zoom: 16,
+              ),
             );
           }
         }

--- a/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
+++ b/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
@@ -104,6 +104,7 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
   List<SearchLocation> _searchResults = [];
   bool _isSearching = false;
   List<SearchLocation> _loadedPlaces = [];
+  bool _isLoadingYourLocation = false;
 
   @override
   void initState() {
@@ -267,10 +268,22 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
                     _buildAnimatedItem(
                       index: 1,
                       child: _QuickActionsSection(
+                        isLoadingYourLocation: _isLoadingYourLocation,
                         onYourLocation: widget.onYourLocation != null
                             ? () async {
+                                if (_isLoadingYourLocation) return;
                                 HapticFeedback.lightImpact();
-                                final location = await widget.onYourLocation!();
+                                setState(() => _isLoadingYourLocation = true);
+                                SearchLocation? location;
+                                try {
+                                  location = await widget.onYourLocation!();
+                                } finally {
+                                  if (mounted) {
+                                    setState(
+                                      () => _isLoadingYourLocation = false,
+                                    );
+                                  }
+                                }
                                 if (location != null && context.mounted) {
                                   Navigator.pop(context, location);
                                 }
@@ -502,6 +515,7 @@ class _QuickActionsSection extends StatelessWidget {
   final String chooseOnMapText;
   final IconData yourLocationIcon;
   final IconData chooseOnMapIcon;
+  final bool isLoadingYourLocation;
 
   const _QuickActionsSection({
     this.onYourLocation,
@@ -510,6 +524,7 @@ class _QuickActionsSection extends StatelessWidget {
     required this.chooseOnMapText,
     required this.yourLocationIcon,
     required this.chooseOnMapIcon,
+    this.isLoadingYourLocation = false,
   });
 
   @override
@@ -535,6 +550,7 @@ class _QuickActionsSection extends StatelessWidget {
               onTap: onYourLocation!,
               isFirst: true,
               isLast: onChooseOnMap == null,
+              isLoading: isLoadingYourLocation,
             ),
           if (onYourLocation != null && onChooseOnMap != null)
             Divider(
@@ -565,6 +581,7 @@ class _QuickActionItem extends StatelessWidget {
   final VoidCallback onTap;
   final bool isFirst;
   final bool isLast;
+  final bool isLoading;
 
   const _QuickActionItem({
     required this.icon,
@@ -573,6 +590,7 @@ class _QuickActionItem extends StatelessWidget {
     required this.onTap,
     this.isFirst = false,
     this.isLast = false,
+    this.isLoading = false,
   });
 
   @override
@@ -583,7 +601,7 @@ class _QuickActionItem extends StatelessWidget {
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap: onTap,
+        onTap: isLoading ? null : onTap,
         borderRadius: BorderRadius.vertical(
           top: isFirst ? const Radius.circular(16) : Radius.zero,
           bottom: isLast ? const Radius.circular(16) : Radius.zero,
@@ -599,7 +617,18 @@ class _QuickActionItem extends StatelessWidget {
                   color: iconColor.withValues(alpha: 0.12),
                   borderRadius: BorderRadius.circular(12),
                 ),
-                child: Icon(icon, color: iconColor, size: 22),
+                child: isLoading
+                    ? Center(
+                        child: SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2.2,
+                            valueColor: AlwaysStoppedAnimation<Color>(iconColor),
+                          ),
+                        ),
+                      )
+                    : Icon(icon, color: iconColor, size: 22),
               ),
               const SizedBox(width: 14),
               Expanded(
@@ -607,7 +636,9 @@ class _QuickActionItem extends StatelessWidget {
                   title,
                   style: theme.textTheme.bodyLarge?.copyWith(
                     fontWeight: FontWeight.w500,
-                    color: colorScheme.onSurface,
+                    color: isLoading
+                        ? colorScheme.onSurface.withValues(alpha: 0.6)
+                        : colorScheme.onSurface,
                   ),
                 ),
               ),

--- a/packages/trufi_core_utils/lib/src/location_service.dart
+++ b/packages/trufi_core_utils/lib/src/location_service.dart
@@ -52,6 +52,16 @@ enum LocationPermissionStatus {
 /// }
 /// ```
 class LocationService extends ChangeNotifier {
+  /// Creates a [LocationService].
+  ///
+  /// [platform] can be provided to inject a custom [GeolocatorPlatform]
+  /// implementation; defaults to [GeolocatorPlatform.instance]. Primarily
+  /// useful for unit testing — production code should leave it null.
+  LocationService({GeolocatorPlatform? platform})
+    : _platform = platform ?? GeolocatorPlatform.instance;
+
+  final GeolocatorPlatform _platform;
+
   Position? _lastKnownPosition;
   LocationPermissionStatus? _lastPermissionStatus;
   StreamSubscription<Position>? _positionStreamSubscription;
@@ -80,7 +90,7 @@ class LocationService extends ChangeNotifier {
 
   /// Checks if location services are enabled on the device.
   Future<bool> isLocationServiceEnabled() async {
-    return Geolocator.isLocationServiceEnabled();
+    return _platform.isLocationServiceEnabled();
   }
 
   /// Checks the current permission status without requesting.
@@ -92,7 +102,7 @@ class LocationService extends ChangeNotifier {
       return LocationPermissionStatus.serviceDisabled;
     }
 
-    final permission = await Geolocator.checkPermission();
+    final permission = await _platform.checkPermission();
     _lastPermissionStatus = _mapPermission(permission);
     _safeNotifyListeners();
     return _lastPermissionStatus!;
@@ -109,7 +119,7 @@ class LocationService extends ChangeNotifier {
       return LocationPermissionStatus.serviceDisabled;
     }
 
-    final permission = await Geolocator.requestPermission();
+    final permission = await _platform.requestPermission();
     _lastPermissionStatus = _mapPermission(permission);
     _safeNotifyListeners();
     return _lastPermissionStatus!;
@@ -129,7 +139,7 @@ class LocationService extends ChangeNotifier {
     }
 
     try {
-      final position = await Geolocator.getCurrentPosition(
+      final position = await _platform.getCurrentPosition(
         locationSettings: LocationSettings(
           accuracy: accuracy,
           timeLimit: timeout ?? const Duration(seconds: 15),
@@ -159,7 +169,7 @@ class LocationService extends ChangeNotifier {
     }
 
     try {
-      final position = await Geolocator.getLastKnownPosition();
+      final position = await _platform.getLastKnownPosition();
       if (position == null) return null;
 
       _lastKnownPosition = position;
@@ -179,14 +189,14 @@ class LocationService extends ChangeNotifier {
   ///
   /// Use this when location services are disabled.
   Future<bool> openLocationSettings() async {
-    return Geolocator.openLocationSettings();
+    return _platform.openLocationSettings();
   }
 
   /// Opens the app's settings page.
   ///
   /// Use this when permission is permanently denied.
   Future<bool> openAppSettings() async {
-    return Geolocator.openAppSettings();
+    return _platform.openAppSettings();
   }
 
   /// Calculates the distance in meters between two points.
@@ -196,7 +206,7 @@ class LocationService extends ChangeNotifier {
     double endLatitude,
     double endLongitude,
   ) {
-    return Geolocator.distanceBetween(
+    return _platform.distanceBetween(
       startLatitude,
       startLongitude,
       endLatitude,
@@ -231,7 +241,7 @@ class LocationService extends ChangeNotifier {
       );
 
       _positionStreamSubscription =
-          Geolocator.getPositionStream(
+          _platform.getPositionStream(
             locationSettings: locationSettings,
           ).listen(
             (Position position) {
@@ -252,10 +262,15 @@ class LocationService extends ChangeNotifier {
 
       _isTracking = true;
 
-      // Get initial position immediately so the marker shows right away
+      // Get initial position immediately so the marker shows right away.
+      // timeLimit prevents hangs on web where high-accuracy fixes can be slow
+      // or never arrive; the stream will keep providing updates regardless.
       try {
-        final initialPosition = await Geolocator.getCurrentPosition(
-          locationSettings: LocationSettings(accuracy: accuracy),
+        final initialPosition = await _platform.getCurrentPosition(
+          locationSettings: LocationSettings(
+            accuracy: accuracy,
+            timeLimit: const Duration(seconds: 10),
+          ),
         );
         _lastKnownPosition = initialPosition;
         _currentLocation = LocationResult(
@@ -285,8 +300,11 @@ class LocationService extends ChangeNotifier {
   }
 
   /// Disposes of the service and stops any active tracking.
+  ///
+  /// Safe to call multiple times; subsequent calls are no-ops.
   @override
   void dispose() {
+    if (_isDisposed) return;
     _isDisposed = true;
     _positionStreamSubscription?.cancel();
     _positionStreamSubscription = null;

--- a/packages/trufi_core_utils/pubspec.yaml
+++ b/packages/trufi_core_utils/pubspec.yaml
@@ -21,6 +21,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  mocktail: ^1.0.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/trufi_core_utils/test/location_service_test.dart
+++ b/packages/trufi_core_utils/test/location_service_test.dart
@@ -1,0 +1,381 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:trufi_core_utils/src/location_service.dart';
+
+class _MockGeolocatorPlatform extends Mock implements GeolocatorPlatform {}
+
+Position _fakePosition({double lat = -17.39, double lng = -66.16, double acc = 5}) {
+  return Position(
+    latitude: lat,
+    longitude: lng,
+    accuracy: acc,
+    timestamp: DateTime(2026, 1, 1),
+    altitude: 0,
+    altitudeAccuracy: 0,
+    heading: 0,
+    headingAccuracy: 0,
+    speed: 0,
+    speedAccuracy: 0,
+  );
+}
+
+void main() {
+  late _MockGeolocatorPlatform mockPlatform;
+  late LocationService service;
+
+  setUpAll(() {
+    registerFallbackValue(const LocationSettings());
+  });
+
+  setUp(() {
+    mockPlatform = _MockGeolocatorPlatform();
+    service = LocationService(platform: mockPlatform);
+
+    // Sensible defaults — individual tests override what they care about.
+    when(() => mockPlatform.isLocationServiceEnabled())
+        .thenAnswer((_) async => true);
+    when(() => mockPlatform.checkPermission())
+        .thenAnswer((_) async => LocationPermission.always);
+    when(() => mockPlatform.requestPermission())
+        .thenAnswer((_) async => LocationPermission.always);
+    when(
+      () => mockPlatform.getPositionStream(
+        locationSettings: any(named: 'locationSettings'),
+      ),
+    ).thenAnswer((_) => const Stream<Position>.empty());
+  });
+
+  tearDown(() => service.dispose());
+
+  group('checkPermission', () {
+    test('returns serviceDisabled when location services are off', () async {
+      when(() => mockPlatform.isLocationServiceEnabled())
+          .thenAnswer((_) async => false);
+
+      final status = await service.checkPermission();
+
+      expect(status, LocationPermissionStatus.serviceDisabled);
+      verifyNever(() => mockPlatform.checkPermission());
+    });
+
+    test('maps LocationPermission.always to granted', () async {
+      when(() => mockPlatform.checkPermission())
+          .thenAnswer((_) async => LocationPermission.always);
+
+      expect(await service.checkPermission(), LocationPermissionStatus.granted);
+    });
+
+    test('maps LocationPermission.whileInUse to granted', () async {
+      when(() => mockPlatform.checkPermission())
+          .thenAnswer((_) async => LocationPermission.whileInUse);
+
+      expect(await service.checkPermission(), LocationPermissionStatus.granted);
+    });
+
+    test('maps LocationPermission.denied to denied', () async {
+      when(() => mockPlatform.checkPermission())
+          .thenAnswer((_) async => LocationPermission.denied);
+
+      expect(await service.checkPermission(), LocationPermissionStatus.denied);
+    });
+
+    test('maps LocationPermission.deniedForever to deniedForever', () async {
+      when(() => mockPlatform.checkPermission())
+          .thenAnswer((_) async => LocationPermission.deniedForever);
+
+      expect(
+        await service.checkPermission(),
+        LocationPermissionStatus.deniedForever,
+      );
+    });
+
+    test('maps LocationPermission.unableToDetermine to denied', () async {
+      when(() => mockPlatform.checkPermission())
+          .thenAnswer((_) async => LocationPermission.unableToDetermine);
+
+      expect(await service.checkPermission(), LocationPermissionStatus.denied);
+    });
+  });
+
+  group('requestPermission', () {
+    test('returns serviceDisabled without prompting when services are off',
+        () async {
+      when(() => mockPlatform.isLocationServiceEnabled())
+          .thenAnswer((_) async => false);
+
+      final status = await service.requestPermission();
+
+      expect(status, LocationPermissionStatus.serviceDisabled);
+      verifyNever(() => mockPlatform.requestPermission());
+    });
+
+    test('returns granted when the user accepts', () async {
+      when(() => mockPlatform.requestPermission())
+          .thenAnswer((_) async => LocationPermission.whileInUse);
+
+      expect(
+        await service.requestPermission(),
+        LocationPermissionStatus.granted,
+      );
+    });
+  });
+
+  group('getCurrentLocation', () {
+    test('returns null when permission is denied', () async {
+      when(() => mockPlatform.checkPermission())
+          .thenAnswer((_) async => LocationPermission.denied);
+
+      final result = await service.getCurrentLocation();
+
+      expect(result, isNull);
+      verifyNever(
+        () => mockPlatform.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      );
+    });
+
+    test('returns a LocationResult when permission is granted', () async {
+      when(
+        () => mockPlatform.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).thenAnswer((_) async => _fakePosition(lat: 1, lng: 2, acc: 7));
+
+      final result = await service.getCurrentLocation();
+
+      expect(result, isNotNull);
+      expect(result!.latitude, 1);
+      expect(result.longitude, 2);
+      expect(result.accuracy, 7);
+    });
+
+    test('propagates the provided timeout as timeLimit', () async {
+      when(
+        () => mockPlatform.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).thenAnswer((_) async => _fakePosition());
+
+      await service.getCurrentLocation(timeout: const Duration(seconds: 3));
+
+      final captured = verify(
+        () => mockPlatform.getCurrentPosition(
+          locationSettings: captureAny(named: 'locationSettings'),
+        ),
+      ).captured.single as LocationSettings;
+      expect(captured.timeLimit, const Duration(seconds: 3));
+    });
+
+    test('defaults to a 15-second timeLimit when none is provided', () async {
+      when(
+        () => mockPlatform.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).thenAnswer((_) async => _fakePosition());
+
+      await service.getCurrentLocation();
+
+      final captured = verify(
+        () => mockPlatform.getCurrentPosition(
+          locationSettings: captureAny(named: 'locationSettings'),
+        ),
+      ).captured.single as LocationSettings;
+      expect(captured.timeLimit, const Duration(seconds: 15));
+    });
+
+    test('wraps platform errors in LocationServiceException', () async {
+      when(
+        () => mockPlatform.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).thenThrow(TimeoutException('GPS timed out'));
+
+      expect(
+        () => service.getCurrentLocation(),
+        throwsA(isA<LocationServiceException>()),
+      );
+    });
+  });
+
+  group('getLastKnownLocation', () {
+    test('returns null when permission is denied', () async {
+      when(() => mockPlatform.checkPermission())
+          .thenAnswer((_) async => LocationPermission.denied);
+
+      expect(await service.getLastKnownLocation(), isNull);
+    });
+
+    test('returns null when platform has no last position', () async {
+      when(() => mockPlatform.getLastKnownPosition())
+          .thenAnswer((_) async => null);
+
+      expect(await service.getLastKnownLocation(), isNull);
+    });
+
+    test('returns a LocationResult when a last position is available',
+        () async {
+      when(() => mockPlatform.getLastKnownPosition())
+          .thenAnswer((_) async => _fakePosition(lat: 5, lng: 6));
+
+      final result = await service.getLastKnownLocation();
+
+      expect(result?.latitude, 5);
+      expect(result?.longitude, 6);
+    });
+
+    test('swallows platform errors and returns null', () async {
+      when(() => mockPlatform.getLastKnownPosition())
+          .thenThrow(Exception('boom'));
+
+      expect(await service.getLastKnownLocation(), isNull);
+    });
+  });
+
+  group('startTracking', () {
+    test('returns false and does not subscribe when permission is denied',
+        () async {
+      when(() => mockPlatform.checkPermission())
+          .thenAnswer((_) async => LocationPermission.deniedForever);
+
+      final started = await service.startTracking();
+
+      expect(started, isFalse);
+      expect(service.isTracking, isFalse);
+      verifyNever(
+        () => mockPlatform.getPositionStream(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      );
+    });
+
+    test('returns true and flips isTracking when permission is granted',
+        () async {
+      when(
+        () => mockPlatform.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).thenAnswer((_) async => _fakePosition());
+
+      final started = await service.startTracking();
+
+      expect(started, isTrue);
+      expect(service.isTracking, isTrue);
+    });
+
+    test('is a no-op when already tracking', () async {
+      when(
+        () => mockPlatform.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).thenAnswer((_) async => _fakePosition());
+
+      await service.startTracking();
+      final secondStart = await service.startTracking();
+
+      expect(secondStart, isTrue);
+      verify(
+        () => mockPlatform.getPositionStream(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).called(1);
+    });
+
+    test(
+      'initial getCurrentPosition has a 10s timeLimit (issue #897 web freeze fix)',
+      () async {
+        when(
+          () => mockPlatform.getCurrentPosition(
+            locationSettings: any(named: 'locationSettings'),
+          ),
+        ).thenAnswer((_) async => _fakePosition());
+
+        await service.startTracking();
+
+        final captured = verify(
+          () => mockPlatform.getCurrentPosition(
+            locationSettings: captureAny(named: 'locationSettings'),
+          ),
+        ).captured.single as LocationSettings;
+        expect(
+          captured.timeLimit,
+          const Duration(seconds: 10),
+          reason:
+              'Without a timeLimit, getCurrentPosition can hang indefinitely '
+              'on web waiting for a high-accuracy fix.',
+        );
+      },
+    );
+
+    test('stays tracking even when initial fix times out', () async {
+      when(
+        () => mockPlatform.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).thenThrow(TimeoutException('no fix'));
+
+      final started = await service.startTracking();
+
+      expect(started, isTrue);
+      expect(service.isTracking, isTrue);
+      expect(service.currentLocation, isNull);
+    });
+
+    test('updates currentLocation as the position stream emits', () async {
+      final controller = StreamController<Position>();
+      addTearDown(controller.close);
+
+      when(
+        () => mockPlatform.getPositionStream(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).thenAnswer((_) => controller.stream);
+      when(
+        () => mockPlatform.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).thenAnswer((_) async => _fakePosition());
+
+      await service.startTracking();
+      controller.add(_fakePosition(lat: 10, lng: 20));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(service.currentLocation?.latitude, 10);
+      expect(service.currentLocation?.longitude, 20);
+    });
+  });
+
+  group('stopTracking', () {
+    test('flips isTracking back to false', () async {
+      when(
+        () => mockPlatform.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).thenAnswer((_) async => _fakePosition());
+
+      await service.startTracking();
+      expect(service.isTracking, isTrue);
+
+      await service.stopTracking();
+      expect(service.isTracking, isFalse);
+    });
+  });
+
+  group('dispose', () {
+    test('stops tracking', () async {
+      when(
+        () => mockPlatform.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).thenAnswer((_) async => _fakePosition());
+
+      await service.startTracking();
+      service.dispose();
+
+      expect(service.isTracking, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the two distinct issues reported in #897:

- **Bug A — Web/Desktop freeze on the map's *Mi Ubicación* button.** `LocationService.startTracking()` could hang indefinitely waiting for a high-accuracy fix because its internal `getCurrentPosition()` had no `timeLimit`. Added a 10-second `timeLimit` and removed the redundant `getCurrentLocation()` call that `_onMyLocationPressed` made after `startTracking()` — the initial position is already captured in `LocationService.currentLocation`. Also added a `getLastKnownLocation()` fast-path so the camera repositions instantly while the accurate fix is acquired.
- **Bug B — Mobile silent fallback in the route search.** `onYourLocation` inside the search flow silently returned the city's `defaultCenter` for *every* failure case (permission denied forever, services disabled, timeout, null location), which appeared to users as a "random location" with no permission prompt. It now handles `deniedForever` / `serviceDisabled` with the same dialogs as the map button, and returns `null` (which keeps the user on the search screen) instead of teleporting them to `defaultCenter`. Also added a fast-path that reuses `currentLocation` when the map is already tracking.

### Other changes
- `LocationService` now accepts an optional `GeolocatorPlatform` via the constructor — production code path is unchanged (defaults to `GeolocatorPlatform.instance`), but the seam enables unit testing with `mocktail`.
- `LocationService.dispose()` is now idempotent.

### Tests
Added 25 unit tests in `packages/trufi_core_utils/test/location_service_test.dart` covering:
- Permission enum mapping (`always`, `whileInUse`, `denied`, `deniedForever`, `unableToDetermine`)
- `serviceDisabled` handling for both `checkPermission` and `requestPermission`
- `getCurrentLocation` / `getLastKnownLocation` (granted, denied, null, error paths)
- `startTracking` lifecycle, no-op-when-already-tracking, stream updates
- **Regression test pinning the 10-second `timeLimit` on the initial `getCurrentPosition` call (this is what fixes Bug A)**
- `stopTracking` / `dispose` lifecycle

Closes #897.

## Test plan

- [x] `flutter test packages/trufi_core_utils/test/location_service_test.dart` — 25 tests pass
- [x] `dart analyze` clean on all changed files
- [ ] Manual on a mobile device with the Cochabamba app:
  - [ ] Map *Mi Ubicación* button: camera jumps to last-known instantly, then refines. No multi-click "freeze".
  - [ ] Search field *Tu Ubicación* with permission never granted: system permission prompt appears.
  - [ ] Permission `deniedForever`: dialog with "Open Settings" (not a silent jump to defaultCenter).
  - [ ] Location services off: "Enable location" dialog.
  - [ ] Permission denied once, user cancels: stays on search screen (no random fallback).
  - [ ] Map already tracking → search *Tu Ubicación* reuses cached location without re-prompting.