### PR TITLE
Fixes #907 Prevent app closure on back button from sidebar sections

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_list.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_list.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart' as intl;
-import 'package:provider/provider.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart' as routing;
 import 'package:trufi_core_utils/trufi_core_utils.dart';

--- a/packages/trufi_core_ui/lib/src/router/app_router.dart
+++ b/packages/trufi_core_ui/lib/src/router/app_router.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
-import 'package:trufi_core_utils/trufi_core_utils.dart' show PackageInfoPlatform;
+import 'package:trufi_core_utils/trufi_core_utils.dart'
+    show PackageInfoPlatform;
 import 'package:url_launcher/url_launcher.dart';
 
 /// Application router using GoRouter with dynamic screen support
@@ -187,7 +188,11 @@ class AppShell extends StatelessWidget {
                       (s) => s.id == 'about',
                       orElse: () => screens.first,
                     );
-                    context.go(aboutScreen.path);
+                    _navigateToDrawerSection(
+                      context,
+                      currentPath,
+                      aboutScreen.path,
+                    );
                   },
                 ),
               ],
@@ -246,7 +251,12 @@ class AppDrawer extends StatelessWidget {
       child: Column(
         children: [
           // Modern header with layered design
-          _DrawerHeader(theme: theme, appName: appName, appTagline: appTagline, logo: logo),
+          _DrawerHeader(
+            theme: theme,
+            appName: appName,
+            appTagline: appTagline,
+            logo: logo,
+          ),
 
           const SizedBox(height: 8),
 
@@ -259,7 +269,11 @@ class AppDrawer extends StatelessWidget {
           ),
 
           // Modern footer
-          _DrawerFooter(theme: theme, socialMediaLinks: socialMediaLinks, extra: footerExtra),
+          _DrawerFooter(
+            theme: theme,
+            socialMediaLinks: socialMediaLinks,
+            extra: footerExtra,
+          ),
         ],
       ),
     );
@@ -294,7 +308,7 @@ class AppDrawer extends StatelessWidget {
           isSelected: currentPath == screen.path,
           onTap: () {
             Navigator.pop(context);
-            context.go(screen.path);
+            _navigateToDrawerSection(context, currentPath, screen.path);
           },
         ),
       );
@@ -304,6 +318,28 @@ class AppDrawer extends StatelessWidget {
   }
 }
 
+void _navigateToDrawerSection(
+  BuildContext context,
+  String currentPath,
+  String path,
+) {
+  if (currentPath == path) {
+    return;
+  }
+
+  if (currentPath == '/') {
+    context.push(path);
+    return;
+  }
+
+  context.go('/');
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    if (context.mounted) {
+      context.push(path);
+    }
+  });
+}
+
 /// Modern drawer header with layered design
 class _DrawerHeader extends StatelessWidget {
   final ThemeData theme;
@@ -311,7 +347,12 @@ class _DrawerHeader extends StatelessWidget {
   final String? appTagline;
   final Widget? logo;
 
-  const _DrawerHeader({required this.theme, required this.appName, this.appTagline, this.logo});
+  const _DrawerHeader({
+    required this.theme,
+    required this.appName,
+    this.appTagline,
+    this.logo,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -331,7 +372,10 @@ class _DrawerHeader extends StatelessWidget {
             children: [
               // Logo/Avatar with modern styling
               logo != null
-                  ? ConstrainedBox(constraints: const BoxConstraints(maxHeight: 56), child: logo!)
+                  ? ConstrainedBox(
+                      constraints: const BoxConstraints(maxHeight: 56),
+                      child: logo!,
+                    )
                   : Container(
                       width: 56,
                       height: 56,
@@ -463,7 +507,11 @@ class _DrawerFooter extends StatelessWidget {
   final List<SocialMediaLink> socialMediaLinks;
   final Widget? extra;
 
-  const _DrawerFooter({required this.theme, this.socialMediaLinks = const [], this.extra});
+  const _DrawerFooter({
+    required this.theme,
+    this.socialMediaLinks = const [],
+    this.extra,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -480,10 +528,7 @@ class _DrawerFooter extends StatelessWidget {
       ),
       child: Column(
         children: [
-          if (extra != null) ...[
-            extra!,
-            const SizedBox(height: 12),
-          ],
+          if (extra != null) ...[extra!, const SizedBox(height: 12)],
           // Version info
           FutureBuilder<String>(
             future: PackageInfoPlatform.version(),
@@ -502,7 +547,9 @@ class _DrawerFooter extends StatelessWidget {
                   Text(
                     'v$version',
                     style: theme.textTheme.bodySmall?.copyWith(
-                      color: colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
+                      color: colorScheme.onSurfaceVariant.withValues(
+                        alpha: 0.6,
+                      ),
                     ),
                   ),
                 ],
@@ -579,14 +626,25 @@ class ErrorScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(Localizations.localeOf(context).languageCode == 'es' ? 'Error' : 'Error')),
+      appBar: AppBar(
+        title: Text(
+          Localizations.localeOf(context).languageCode == 'es'
+              ? 'Error'
+              : 'Error',
+        ),
+      ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             const Icon(Icons.error_outline, size: 64, color: Colors.red),
             const SizedBox(height: 16),
-            Text(Localizations.localeOf(context).languageCode == 'es' ? 'Página no encontrada' : 'Page not found', style: TextStyle(fontSize: 24)),
+            Text(
+              Localizations.localeOf(context).languageCode == 'es'
+                  ? 'Página no encontrada'
+                  : 'Page not found',
+              style: TextStyle(fontSize: 24),
+            ),
             const SizedBox(height: 8),
             if (error != null)
               Text(
@@ -596,7 +654,11 @@ class ErrorScreen extends StatelessWidget {
             const SizedBox(height: 24),
             ElevatedButton(
               onPressed: () => context.go('/'),
-              child: Text(Localizations.localeOf(context).languageCode == 'es' ? 'Ir al inicio' : 'Go Home'),
+              child: Text(
+                Localizations.localeOf(context).languageCode == 'es'
+                    ? 'Ir al inicio'
+                    : 'Go Home',
+              ),
             ),
           ],
         ),

--- a/packages/trufi_core_ui/lib/src/router/app_router.dart
+++ b/packages/trufi_core_ui/lib/src/router/app_router.dart
@@ -183,16 +183,11 @@ class AppShell extends StatelessWidget {
                   icon: const Icon(Icons.info_outline),
                   tooltip: 'About',
                   onPressed: () {
-                    // Navegar a la pantalla de About si existe
                     final aboutScreen = screens.firstWhere(
                       (s) => s.id == 'about',
                       orElse: () => screens.first,
                     );
-                    _navigateToDrawerSection(
-                      context,
-                      currentPath,
-                      aboutScreen.path,
-                    );
+                    _navigateToSection(context, aboutScreen.path);
                   },
                 ),
               ],
@@ -307,8 +302,8 @@ class AppDrawer extends StatelessWidget {
           title: screen.getLocalizedTitle(context),
           isSelected: currentPath == screen.path,
           onTap: () {
-            Navigator.pop(context);
-            _navigateToDrawerSection(context, currentPath, screen.path);
+            Scaffold.of(context).closeDrawer();
+            _navigateToSection(context, screen.path);
           },
         ),
       );
@@ -318,25 +313,28 @@ class AppDrawer extends StatelessWidget {
   }
 }
 
-void _navigateToDrawerSection(
-  BuildContext context,
-  String currentPath,
-  String path,
-) {
-  if (currentPath == path) {
-    return;
-  }
+/// Navigates to a top-level section, keeping `/` at the bottom of the stack
+/// so the system back button always returns to home.
+void _navigateToSection(BuildContext context, String path) {
+  final router = GoRouter.of(context);
+  final currentPath = router.routeInformationProvider.value.uri.path;
+
+  if (currentPath == path) return;
 
   if (currentPath == '/') {
-    context.push(path);
+    router.push(path);
     return;
   }
 
-  context.go('/');
+  if (router.canPop()) {
+    router.pushReplacement(path);
+    return;
+  }
+
+  // Deep-linked into a section; reset stack to [/, path].
+  router.go('/');
   WidgetsBinding.instance.addPostFrameCallback((_) {
-    if (context.mounted) {
-      context.push(path);
-    }
+    if (context.mounted) router.push(path);
   });
 }
 


### PR DESCRIPTION
Fixes #907 This pull request fixes the navigation issue described in #907, where the application would close when pressing the device back button after navigating to sections from the sidebar menu instead of returning to the home map screen.

## Root cause

Drawer section navigation was not preserving the expected navigation stack behavior, causing Android back navigation to exit the app instead of returning to the previous screen.

## Changes made

### Navigation fix

- Added a private `_navigateToDrawerSection` helper function to centralize and standardize drawer navigation behavior.
- Updated all drawer section navigation calls to use the new helper.
- Improved route transition handling when navigating between the home map and drawer sections.
- Ensured device back button navigation correctly returns users to the home map instead of closing the application.

### Code readability improvements

- Refactored `_DrawerHeader` and `_DrawerFooter` constructors into multi-line formatting for improved readability.
- Reformatted widget trees and localized text blocks for better maintainability and consistency.
- Cleaned up imports and removed unused dependencies.

## Result

https://github.com/user-attachments/assets/ad346eb2-50b5-4501-a39b-5da94b281d6f



Users can now navigate to sections such as Routes from the sidebar and safely return to the home map using the Android back button without the app closing unexpectedly.