### PR TITLE
fix: update privacy toggle to use ListenableBuilder for state management

### DIFF
--- a/apps/example/lib/main.dart
+++ b/apps/example/lib/main.dart
@@ -231,6 +231,20 @@ void main() {
           label: 'Instagram',
         ),
       ],
+      overlayManager: OverlayManager(
+        managers: [
+          OnboardingManager(
+            overlayBuilder: (onComplete) =>
+                OnboardingSheet(onComplete: onComplete),
+          ),
+          PrivacyConsentManager(
+            overlayBuilder: (onAccept, onDecline) => PrivacyConsentSheet(
+              onAccept: onAccept,
+              onDecline: onDecline,
+            ),
+          ),
+        ],
+      ),
       providers: [
         ChangeNotifierProvider(
           create: (_) => MapEngineManager(
@@ -240,22 +254,6 @@ void main() {
         ),
         ChangeNotifierProvider(
           create: (_) => RoutingEngineManager(engines: _routingEngines),
-        ),
-        ChangeNotifierProvider(
-          create: (_) => OverlayManager(
-            managers: [
-              OnboardingManager(
-                overlayBuilder: (onComplete) =>
-                    OnboardingSheet(onComplete: onComplete),
-              ),
-              PrivacyConsentManager(
-                overlayBuilder: (onAccept, onDecline) => PrivacyConsentSheet(
-                  onAccept: onAccept,
-                  onDecline: onDecline,
-                ),
-              ),
-            ],
-          ),
         ),
         BlocProvider(
           create: (_) => SearchLocationsCubit(

--- a/packages/screens/trufi_core_settings/lib/overlay/onboarding/onboarding_manager.dart
+++ b/packages/screens/trufi_core_settings/lib/overlay/onboarding/onboarding_manager.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 
@@ -90,4 +92,8 @@ class OnboardingManager extends AppOverlayManager {
     // Re-check if we need to show overlay
     _checkAndPushOverlay();
   }
+
+  @override
+  SingleChildWidget asProvider() =>
+      ChangeNotifierProvider<OnboardingManager>.value(value: this);
 }

--- a/packages/screens/trufi_core_settings/lib/overlay/privacy_consent/privacy_consent_manager.dart
+++ b/packages/screens/trufi_core_settings/lib/overlay/privacy_consent/privacy_consent_manager.dart
@@ -115,6 +115,16 @@ class PrivacyConsentManager extends AppOverlayManager {
     notifyListeners();
   }
 
+  /// Re-shows the consent overlay regardless of whether it was previously shown.
+  void showConsentOverlay() {
+    if (overlayBuilder == null || _overlayService == null) return;
+    if (_overlayService!.hasOverlayWithId(_overlayId)) return;
+    _overlayService!.pushOverlay(
+      child: overlayBuilder!(_onAccept, _onDecline),
+      id: _overlayId,
+    );
+  }
+
   /// Resets consent state (useful for testing)
   Future<void> reset() async {
     final prefs = await SharedPreferences.getInstance();

--- a/packages/screens/trufi_core_settings/lib/overlay/privacy_consent/privacy_consent_manager.dart
+++ b/packages/screens/trufi_core_settings/lib/overlay/privacy_consent/privacy_consent_manager.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 
@@ -123,4 +125,17 @@ class PrivacyConsentManager extends AppOverlayManager {
     notifyListeners();
     _pushOverlayIfNeeded();
   }
+
+  @override
+  SingleChildWidget asProvider() =>
+      ChangeNotifierProvider<PrivacyConsentManager>.value(value: this);
+
+  static PrivacyConsentManager watch(BuildContext context) =>
+      context.watch<PrivacyConsentManager>();
+  static PrivacyConsentManager read(BuildContext context) =>
+      context.read<PrivacyConsentManager>();
+  static PrivacyConsentManager? maybeWatch(BuildContext context) =>
+      context.watch<PrivacyConsentManager?>();
+  static PrivacyConsentManager? maybeRead(BuildContext context) =>
+      context.read<PrivacyConsentManager?>();
 }

--- a/packages/screens/trufi_core_settings/lib/settings_screen.dart
+++ b/packages/screens/trufi_core_settings/lib/settings_screen.dart
@@ -878,7 +878,7 @@ class _PrivacySettingsCard extends StatelessWidget {
         onToggle: (value) {
           HapticFeedback.selectionClick();
           if (value) {
-            privacyConsentManager.acceptConsent();
+            privacyConsentManager.showConsentOverlay();
           } else {
             privacyConsentManager.declineConsent();
           }

--- a/packages/screens/trufi_core_settings/lib/settings_screen.dart
+++ b/packages/screens/trufi_core_settings/lib/settings_screen.dart
@@ -873,18 +873,21 @@ class _PrivacySettingsCard extends StatelessWidget {
       iconColor: Colors.orange,
       title: settingsL10n.settingsPrivacy,
       subtitle: settingsL10n.settingsPrivacySubtitle,
-      child: _PrivacyToggleTile(
-        title: settingsL10n.settingsPrivacyShareData,
-        description: settingsL10n.settingsPrivacyShareDataDescription,
-        isEnabled: privacyConsentManager.isAccepted,
-        onToggle: (value) {
-          HapticFeedback.selectionClick();
-          if (value) {
-            privacyConsentManager.acceptConsent();
-          } else {
-            privacyConsentManager.declineConsent();
-          }
-        },
+      child: ListenableBuilder(
+        listenable: privacyConsentManager,
+        builder: (context, _) => _PrivacyToggleTile(
+          title: settingsL10n.settingsPrivacyShareData,
+          description: settingsL10n.settingsPrivacyShareDataDescription,
+          isEnabled: privacyConsentManager.isAccepted,
+          onToggle: (value) {
+            HapticFeedback.selectionClick();
+            if (value) {
+              privacyConsentManager.acceptConsent();
+            } else {
+              privacyConsentManager.declineConsent();
+            }
+          },
+        ),
       ),
     );
   }

--- a/packages/screens/trufi_core_settings/lib/settings_screen.dart
+++ b/packages/screens/trufi_core_settings/lib/settings_screen.dart
@@ -859,11 +859,9 @@ class _PrivacySettingsCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final settingsL10n = SettingsLocalizations.of(context);
-    final overlayManager = OverlayManager.watch(context);
-    final privacyConsentManager = overlayManager
-        .getManager<PrivacyConsentManager>();
+    final privacyConsentManager = PrivacyConsentManager.maybeWatch(context);
 
-    // If no PrivacyConsentManager is available, don't show this card
+    // If no PrivacyConsentManager is registered, don't show this card
     if (privacyConsentManager == null) {
       return const SizedBox.shrink();
     }
@@ -873,21 +871,18 @@ class _PrivacySettingsCard extends StatelessWidget {
       iconColor: Colors.orange,
       title: settingsL10n.settingsPrivacy,
       subtitle: settingsL10n.settingsPrivacySubtitle,
-      child: ListenableBuilder(
-        listenable: privacyConsentManager,
-        builder: (context, _) => _PrivacyToggleTile(
-          title: settingsL10n.settingsPrivacyShareData,
-          description: settingsL10n.settingsPrivacyShareDataDescription,
-          isEnabled: privacyConsentManager.isAccepted,
-          onToggle: (value) {
-            HapticFeedback.selectionClick();
-            if (value) {
-              privacyConsentManager.acceptConsent();
-            } else {
-              privacyConsentManager.declineConsent();
-            }
-          },
-        ),
+      child: _PrivacyToggleTile(
+        title: settingsL10n.settingsPrivacyShareData,
+        description: settingsL10n.settingsPrivacyShareDataDescription,
+        isEnabled: privacyConsentManager.isAccepted,
+        onToggle: (value) {
+          HapticFeedback.selectionClick();
+          if (value) {
+            privacyConsentManager.acceptConsent();
+          } else {
+            privacyConsentManager.declineConsent();
+          }
+        },
       ),
     );
   }

--- a/packages/trufi_core_interfaces/lib/src/config/app_configuration.dart
+++ b/packages/trufi_core_interfaces/lib/src/config/app_configuration.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart' show TimeOfDay;
 import 'package:flutter/widgets.dart';
 import 'package:provider/single_child_widget.dart';
 
+import '../overlay/overlay_service.dart';
 import 'trufi_screen.dart';
 import 'trufi_theme_config.dart';
 import 'trufi_locale_config.dart';
@@ -85,13 +86,20 @@ class AppConfiguration {
   /// When set, shared routes will include a deep link URL that opens the app.
   final String? deepLinkScheme;
 
+  /// Optional overlay manager. When provided, it and all its child
+  /// AppOverlayManagers are auto-registered as Providers, so consumers
+  /// can use `context.watch<PrivacyConsentManager>()` etc. directly.
+  final OverlayService? overlayManager;
+
   /// Global providers that will be available to all screens.
   ///
   /// Use this to inject shared state managers:
   /// - MapEngineManager (required)
   /// - RoutingEngineManager (required)
-  /// - OverlayManager (required)
   /// - SearchLocationsCubit, POILayersCubit, etc.
+  ///
+  /// For overlay managers (privacy consent, onboarding, etc.), use the
+  /// dedicated [overlayManager] field instead.
   ///
   /// Example:
   /// ```dart
@@ -101,9 +109,6 @@ class AppConfiguration {
   ///   ),
   ///   ChangeNotifierProvider(
   ///     create: (_) => RoutingEngineManager(engines: [...]),
-  ///   ),
-  ///   ChangeNotifierProvider(
-  ///     create: (_) => OverlayManager(managers: [...]),
   ///   ),
   /// ]
   /// ```
@@ -161,6 +166,7 @@ class AppConfiguration {
     this.socialMediaLinks = const [],
     this.deepLinkScheme,
     this.defaultLocale,
+    this.overlayManager,
     this.providers = const [],
     this.initScreenBuilder,
     this.extraLocalizationsDelegates = const [],

--- a/packages/trufi_core_interfaces/lib/src/config/app_overlay_manager.dart
+++ b/packages/trufi_core_interfaces/lib/src/config/app_overlay_manager.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:provider/single_child_widget.dart';
 
 import '../overlay/overlay_service.dart';
 
@@ -85,4 +86,8 @@ abstract class AppOverlayManager extends ChangeNotifier {
     // Default implementation does nothing.
     // Override in subclasses to push overlays or setup timers.
   }
+
+  /// Returns a SingleChildWidget that exposes this manager via Provider
+  /// with its concrete runtime type, so consumers can use `context.watch<T>()`.
+  SingleChildWidget asProvider();
 }

--- a/packages/trufi_core_interfaces/lib/src/overlay/overlay_service.dart
+++ b/packages/trufi_core_interfaces/lib/src/overlay/overlay_service.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/widgets.dart';
+import 'package:provider/single_child_widget.dart';
 
-/// Abstract interface for pushing overlays.
+/// Abstract interface for the overlay manager.
 ///
-/// This allows managers to push overlays without depending on the concrete
-/// OverlayManager implementation.
+/// Exposes both:
+/// - Runtime overlay manipulation (push/pop) used by child AppOverlayManagers
+///   through [AppOverlayManager.onAppReady].
+/// - Provider wiring ([providers]) consumed by the app's MultiProvider so
+///   the overlay manager and its child managers are auto-registered.
 abstract class OverlayService {
   /// Push an overlay widget with the given configuration.
   void pushOverlay({
@@ -17,4 +21,8 @@ abstract class OverlayService {
 
   /// Check if an overlay with the given ID exists.
   bool hasOverlayWithId(String id);
+
+  /// Providers to register for this overlay manager and all its child
+  /// managers. Spread these into a MultiProvider.providers list.
+  List<SingleChildWidget> get providers;
 }

--- a/packages/trufi_core_ui/lib/src/trufi_app.dart
+++ b/packages/trufi_core_ui/lib/src/trufi_app.dart
@@ -133,6 +133,7 @@ class _TrufiAppState extends State<TrufiApp> {
         ChangeNotifierProvider.value(value: _localeManager),
         ChangeNotifierProvider.value(value: _themeManager),
         ChangeNotifierProvider.value(value: _sharedRouteNotifier),
+        ...?widget.config.overlayManager?.providers,
         ...widget.config.providers,
         ...screenProviders,
       ],

--- a/packages/trufi_core_utils/lib/overlay_manager.dart
+++ b/packages/trufi_core_utils/lib/overlay_manager.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 
 /// Type of overlay display
@@ -239,4 +240,10 @@ class OverlayManager extends ChangeNotifier implements OverlayService {
       context.read<OverlayManager?>();
   static OverlayManager? maybeWatch(BuildContext context) =>
       context.watch<OverlayManager?>();
+
+  @override
+  List<SingleChildWidget> get providers => [
+    ChangeNotifierProvider<OverlayManager>.value(value: this),
+    ..._managers.map((m) => m.asProvider()),
+  ];
 }


### PR DESCRIPTION
# Description
This PR fixes the UI bug #901 where the privacy permission revoke toggle did not visually update immediately after user interaction. 

## Root Cause
The `_PrivacySettingsCard` was a `StatelessWidget` that read `privacyConsentManager.isAccepted` during its initial build but lacked a mechanism to listen to reactive updates. Therefore, when `acceptConsent()` or `declineConsent()` triggered, the UI didn't re-render until the user forced a hard navigation back and forth.

## Solution
Wrapped the `_PrivacyToggleTile` inside a `ListenableBuilder` bound to `privacyConsentManager`. This ensures that whenever the consent manager dispatches a change notification, Flutter triggers a targeted re-render of the toggle widget instantly.

# Result
https://github.com/user-attachments/assets/aced732a-9624-46b4-827a-a2ee597236c3

