### PR TITLE
fix: shared-route deep links plan the trip, not just fill the fields

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -235,7 +235,7 @@ class _HomeScreenState extends State<HomeScreen>
     }
   }
 
-  void _onSharedRouteChanged() {
+  Future<void> _onSharedRouteChanged() async {
     final route = _sharedRouteNotifier?.pendingRoute;
     if (route == null) return;
 
@@ -257,10 +257,13 @@ class _HomeScreenState extends State<HomeScreen>
       longitude: route.toLng,
     );
 
-    // Set locations and fetch plan with selected itinerary index
-    cubit.setFromPlace(fromPlace);
-    cubit.setToPlace(toPlace);
-    cubit.fetchPlan(selectedItineraryIndex: route.selectedItineraryIndex);
+    // Await the place updates before fetching: setFromPlace/setToPlace emit
+    // their state asynchronously, and fetchPlan bails out early when
+    // fromPlace/toPlace are still null. Without awaiting, the shared link
+    // populated the fields but never planned the trip.
+    await cubit.setFromPlace(fromPlace);
+    await cubit.setToPlace(toPlace);
+    await cubit.fetchPlan(selectedItineraryIndex: route.selectedItineraryIndex);
   }
 
   // ============================================================


### PR DESCRIPTION
## Summary

While verifying the shared-route deep link flow for [#899](https://github.com/trufi-association/trufi-core/issues/899) on a device, opening an `https://.../route?...` link correctly populated the origin and destination fields but **never showed the itinerary** — the trip wasn't planned.

Root cause is a race in `_onSharedRouteChanged` (`trufi_core_home_screen`):

```dart
cubit.setFromPlace(fromPlace);   // async — emits state AFTER an await
cubit.setToPlace(toPlace);       // async — emits state AFTER an await
cubit.fetchPlan(...);            // runs now; fetchPlan returns early because
                                 // state.fromPlace/toPlace are still null
```

`setFromPlace`/`setToPlace` are `Future<void>` and emit their state after awaiting the repository, but they were called without `await`, so `fetchPlan` ran first and bailed at its `if (state.fromPlace == null || state.toPlace == null) return;` guard. The fields populated once the emits eventually fired, but the plan was never fetched.

Every other call site in this file already awaits these methods (e.g. the choose-on-map and search flows) — only the deep-link handler didn't.

## Fix

Make `_onSharedRouteChanged` async and await the place updates before fetching the plan. (`addListener` still accepts it: a `Future<void> Function()` is assignable to `VoidCallback`.)

## Test plan

- [x] `dart analyze` clean on the changed file.
- [x] On-device end-to-end: built the Cochabamba app against this branch, fired `https://planner.trufi.app/route?fromLat=...&toName=CalaCala&...` via an Android App Link. Before: origin/destination filled, no plan. After: the itinerary list ("5 rutas encontradas") and the route line render correctly.

Relates to #899 (the trufi-app side — App Links / Universal Links wiring — is in trufi-association/trufi-app#31).