### PR TITLE
fix: keep navigation ETA consistent with planned route duration (#917)

### DIFF
--- a/packages/trufi_core_navigation/lib/src/cubit/navigation_cubit.dart
+++ b/packages/trufi_core_navigation/lib/src/cubit/navigation_cubit.dart
@@ -79,6 +79,9 @@ class NavigationCubit extends Cubit<NavigationState> {
         nextInstruction: nextInstruction,
         currentLocation: currentLocation,
         isMapFollowingUser: true,
+        // Show the planned trip duration immediately so it matches the route
+        // results, even before the first location fix refines it. See #917.
+        etaToDestination: route.duration,
       ),
     );
 
@@ -303,25 +306,35 @@ class NavigationCubit extends Cubit<NavigationState> {
       nextStop.position.longitude,
     );
 
-    // Estimate time based on average transit speed (30 km/h = 8.33 m/s)
-    // For walking: ~1.4 m/s (5 km/h)
+    // Estimate time to the next stop based on average transit speed
+    // (30 km/h = 8.33 m/s); walking: ~1.4 m/s (5 km/h).
     final speedMs = state.segmentType == NavigationSegmentType.transit
         ? 8.33
         : 1.4;
     final etaSeconds = distanceToNext / speedMs;
 
-    // Estimate total ETA based on remaining stops
-    // Assume average 2 minutes per stop for transit
-    final remainingStopsEta = state.segmentType == NavigationSegmentType.transit
-        ? Duration(minutes: state.remainingStops * 2)
-        : Duration.zero;
+    // Remaining trip time: anchor to the itinerary's planned duration (the
+    // value shown in the route results) and scale it by how many stops are
+    // left, instead of the previous fixed "2 minutes per remaining stop"
+    // guess that inflated long routes to ~1h. See #917.
+    final plannedDuration = state.route?.duration ?? Duration.zero;
+    final rideStops = state.totalStops - 1; // stops after the origin
+    final Duration etaToDestination;
+    if (plannedDuration > Duration.zero && rideStops > 0) {
+      final fraction = (state.remainingStops / rideStops).clamp(0.0, 1.0);
+      etaToDestination = Duration(
+        seconds: (plannedDuration.inSeconds * fraction).round(),
+      );
+    } else {
+      // No planned duration available: fall back to the leg-pace estimate.
+      etaToDestination = Duration(seconds: etaSeconds.round());
+    }
 
     emit(
       state.copyWith(
         distanceToNextStop: distanceToNext,
         etaToNextStop: Duration(seconds: etaSeconds.round()),
-        etaToDestination:
-            Duration(seconds: etaSeconds.round()) + remainingStopsEta,
+        etaToDestination: etaToDestination,
       ),
     );
   }

--- a/packages/trufi_core_navigation/lib/src/cubit/navigation_cubit.dart
+++ b/packages/trufi_core_navigation/lib/src/cubit/navigation_cubit.dart
@@ -79,9 +79,9 @@ class NavigationCubit extends Cubit<NavigationState> {
         nextInstruction: nextInstruction,
         currentLocation: currentLocation,
         isMapFollowingUser: true,
-        // Show the planned trip duration immediately so it matches the route
-        // results, even before the first location fix refines it. See #917.
-        etaToDestination: route.duration,
+        // No etaToDestination seed: NavigationState derives the initial ETA
+        // from route.duration, so it matches the route results without
+        // storing a duplicate. See #917.
       ),
     );
 
@@ -317,13 +317,13 @@ class NavigationCubit extends Cubit<NavigationState> {
     // value shown in the route results) and scale it by how many stops are
     // left, instead of the previous fixed "2 minutes per remaining stop"
     // guess that inflated long routes to ~1h. See #917.
-    final plannedDuration = state.route?.duration ?? Duration.zero;
+    // state.route is non-null here: nextStop above already requires it.
     final rideStops = state.totalStops - 1; // stops after the origin
     final Duration etaToDestination;
-    if (plannedDuration > Duration.zero && rideStops > 0) {
+    if (state.route!.duration > Duration.zero && rideStops > 0) {
       final fraction = (state.remainingStops / rideStops).clamp(0.0, 1.0);
       etaToDestination = Duration(
-        seconds: (plannedDuration.inSeconds * fraction).round(),
+        seconds: (state.route!.duration.inSeconds * fraction).round(),
       );
     } else {
       // No planned duration available: fall back to the leg-pace estimate.

--- a/packages/trufi_core_navigation/lib/src/models/navigation_state.dart
+++ b/packages/trufi_core_navigation/lib/src/models/navigation_state.dart
@@ -179,8 +179,17 @@ class NavigationState extends Equatable {
   /// Estimated time to next stop.
   final Duration? etaToNextStop;
 
+  /// Live ETA computed from location updates, if any. Kept private so the
+  /// public [etaToDestination] stays consistent with the planned route.
+  final Duration? _measuredEtaToDestination;
+
   /// Estimated time to final destination.
-  final Duration? etaToDestination;
+  ///
+  /// Prefers the live estimate computed from location updates; before the
+  /// first GPS fix it falls back to the planned [NavigationRoute.duration]
+  /// (the value shown in the route results). Derived instead of stored so
+  /// the state never holds a duplicate of `route.duration`. See #917.
+  Duration? get etaToDestination => _measuredEtaToDestination ?? route?.duration;
 
   /// Error message if status is error.
   final String? errorMessage;
@@ -213,14 +222,14 @@ class NavigationState extends Equatable {
     this.currentLocation,
     this.distanceToNextStop,
     this.etaToNextStop,
-    this.etaToDestination,
+    Duration? etaToDestination,
     this.errorMessage,
     this.isOffRoute = false,
     this.distanceFromRoute,
     this.isGpsWeak = false,
     this.isMapFollowingUser = true,
     this.isInBackground = false,
-  });
+  }) : _measuredEtaToDestination = etaToDestination;
 
   /// Whether navigation is active.
   bool get isNavigating => status == NavigationStatus.navigating;
@@ -292,7 +301,9 @@ class NavigationState extends Equatable {
       currentLocation: currentLocation ?? this.currentLocation,
       distanceToNextStop: distanceToNextStop ?? this.distanceToNextStop,
       etaToNextStop: etaToNextStop ?? this.etaToNextStop,
-      etaToDestination: etaToDestination ?? this.etaToDestination,
+      // Intentionally the private field: copying through the public getter
+      // would bake the route-duration fallback into storage and duplicate it.
+      etaToDestination: etaToDestination ?? _measuredEtaToDestination,
       errorMessage: errorMessage ?? this.errorMessage,
       isOffRoute: isOffRoute ?? this.isOffRoute,
       distanceFromRoute: distanceFromRoute ?? this.distanceFromRoute,
@@ -327,7 +338,7 @@ class NavigationState extends Equatable {
     currentLocation,
     distanceToNextStop,
     etaToNextStop,
-    etaToDestination,
+    _measuredEtaToDestination,
     errorMessage,
     isOffRoute,
     distanceFromRoute,

--- a/packages/trufi_core_navigation/lib/src/models/navigation_state.dart
+++ b/packages/trufi_core_navigation/lib/src/models/navigation_state.dart
@@ -102,6 +102,11 @@ class NavigationRoute extends Equatable {
   final List<NavigationLeg> legs;
   final String? modeName;
 
+  /// Total planned trip duration from the itinerary (the value shown in the
+  /// route results). Used to keep the navigation ETA consistent with the
+  /// planned route instead of re-estimating it. See #917.
+  final Duration duration;
+
   const NavigationRoute({
     required this.id,
     required this.code,
@@ -114,6 +119,7 @@ class NavigationRoute extends Equatable {
     required this.stops,
     this.legs = const [],
     this.modeName,
+    this.duration = Duration.zero,
   });
 
   String get displayName => shortName ?? name;
@@ -131,6 +137,7 @@ class NavigationRoute extends Equatable {
     stops,
     legs,
     modeName,
+    duration,
   ];
 }
 

--- a/packages/trufi_core_navigation/lib/src/utils/itinerary_converter.dart
+++ b/packages/trufi_core_navigation/lib/src/utils/itinerary_converter.dart
@@ -170,6 +170,7 @@ class ItineraryConverter {
       geometry: allPoints,
       stops: stops,
       legs: navigationLegs,
+      duration: itinerary.duration,
     );
   }
 }


### PR DESCRIPTION
## What & why

After starting guidance, the navigation screen showed an **inflated trip duration** (e.g. `1h 0m` for a ~15 min route) that didn't match the route results.

Root cause: `_updateDistanceAndEta` estimated the total ETA as a fixed **"2 minutes per remaining stop"** (`remainingStops * 2 min`). That guess is unrelated to the planned itinerary and balloons on routes with many stops, while the route results show the real `itinerary.duration`. The navigation flow simply never carried the itinerary's real duration through `ItineraryConverter` → `NavigationRoute`.

Fixes #917.

## Changes

- **`NavigationRoute`** gains a `duration` field (the planned trip duration).
- **`ItineraryConverter`** populates it from `itinerary.duration` — the same value shown in the route results.
- **`NavigationCubit.startNavigation`** seeds `etaToDestination` with the planned duration so it matches the results immediately.
- **`NavigationCubit._updateDistanceAndEta`** now scales the planned duration by the remaining-stop fraction instead of the per-stop guess, with a graceful fallback to the leg-pace estimate when no planned duration is available.

3 files changed (+30 / −9). `flutter analyze`: no issues.

## Verification (Android emulator, real Cochabamba route, offline GTFS routing)

Route **Centro → Aeropuerto**. The route results show **35 min**, and the navigation screen now shows the **same 35 min** — at start and after moving the GPS along the route (segment advanced 107 → 102), instead of an inflated heuristic value.

**1. Route results — 35 min**
![Route results 35 min](https://raw.githubusercontent.com/trufi-association/trufi-core/evidence/917-navigation-duration/evidence/917/1-route-results-35min.png)

**2. Navigation screen — 35 min (matches results)**
![Navigation 35 min](https://raw.githubusercontent.com/trufi-association/trufi-core/evidence/917-navigation-duration/evidence/917/2-navigation-35min.png)

**3. After moving GPS along the route — still 35 min (consistent)**
![Navigation after GPS move 35 min](https://raw.githubusercontent.com/trufi-association/trufi-core/evidence/917-navigation-duration/evidence/917/3-navigation-after-gps-move-35min.png)

## Notes

- No unit test added: the logic lives in a private method driven by `LocationService` location updates, which would require heavy platform-plugin mocking.
- Evidence screenshots live on the `evidence/917-navigation-duration` branch (kept out of this PR's diff); it can be deleted after review.