### PR TITLE
feat(routing): make the itinerary count app-configurable

### DIFF
--- a/packages/trufi_core_planner/lib/src/client/local_planner_client.dart
+++ b/packages/trufi_core_planner/lib/src/client/local_planner_client.dart
@@ -79,6 +79,12 @@ class LocalPlannerClient implements PlannerRoutingClient {
       destination: destination,
       maxWalkDistance: maxWalkDistance,
       maxResults: maxResults,
+      // Scale the per-bucket caps with the requested result count so an
+      // app-level maxItineraries override isn't silently clipped to the
+      // service defaults (5 directs + 5 transfers). At the default
+      // maxResults = 5 this is identical to the previous behavior.
+      maxDirects: maxResults,
+      maxTransferPaths: maxResults,
     );
   }
 

--- a/packages/trufi_core_planner/lib/src/client/remote_planner_client.dart
+++ b/packages/trufi_core_planner/lib/src/client/remote_planner_client.dart
@@ -69,6 +69,10 @@ class RemotePlannerClient implements PlannerRoutingClient {
       body: jsonEncode({
         'from': {'lat': origin.latitude, 'lon': origin.longitude},
         'to': {'lat': destination.latitude, 'lon': destination.longitude},
+        // Forward the requested result count so an app-level override
+        // reaches the server (older servers ignore unknown fields; the
+        // planner server clamps it to its own limits).
+        'maxResults': maxResults,
       }),
     );
 

--- a/packages/trufi_core_routing/lib/src/routing_engine_manager.dart
+++ b/packages/trufi_core_routing/lib/src/routing_engine_manager.dart
@@ -43,14 +43,27 @@ class RoutingEngineManager extends ChangeNotifier {
   int _currentIndex;
   bool _isPreloading = false;
 
+  /// Maximum number of itineraries requested per plan when [fetchPlan] is
+  /// called without an explicit `numItineraries`.
+  ///
+  /// Defaults to 5 (the historical behavior). Apps that want more results
+  /// override it at construction time instead of patching trufi-core:
+  ///
+  /// ```dart
+  /// RoutingEngineManager(engines: [...], maxItineraries: 20)
+  /// ```
+  final int maxItineraries;
+
   RoutingEngineManager({
     required List<IRoutingProvider> engines,
     int defaultIndex = 0,
+    this.maxItineraries = 5,
   }) : assert(engines.isNotEmpty, 'At least one engine is required'),
        assert(
          defaultIndex >= 0 && defaultIndex < engines.length,
          'defaultIndex must be valid',
        ),
+       assert(maxItineraries > 0, 'maxItineraries must be positive'),
        _engines = engines,
        _currentIndex = defaultIndex {
     _loadSavedEngine();
@@ -159,10 +172,13 @@ class RoutingEngineManager extends ChangeNotifier {
   }
 
   /// Fetches a trip plan using the current engine.
+  ///
+  /// When [numItineraries] is omitted, the manager's [maxItineraries]
+  /// (app-configurable via the constructor) is used.
   Future<Plan> fetchPlan({
     required RoutingLocation from,
     required RoutingLocation to,
-    int numItineraries = 5,
+    int? numItineraries,
     String? locale,
     required DateTime dateTime,
     bool arriveBy = false,
@@ -170,7 +186,7 @@ class RoutingEngineManager extends ChangeNotifier {
     return currentEngine.fetchPlan(
       from: from,
       to: to,
-      numItineraries: numItineraries,
+      numItineraries: numItineraries ?? maxItineraries,
       locale: locale,
       dateTime: dateTime,
       arriveBy: arriveBy,

--- a/packages/trufi_core_routing/test/unit/routing_engine_manager_test.dart
+++ b/packages/trufi_core_routing/test/unit/routing_engine_manager_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:trufi_core_routing/trufi_core_routing.dart';
+
+/// Fake provider that records the arguments it receives from the manager.
+class _RecordingProvider extends IRoutingProvider {
+  int? capturedNumItineraries;
+
+  @override
+  String get id => 'recording';
+
+  @override
+  String get name => 'Recording';
+
+  @override
+  String get description => 'Captures fetchPlan arguments';
+
+  @override
+  bool get supportsTransitRoutes => false;
+
+  @override
+  bool get requiresInternet => true;
+
+  @override
+  Future<Plan> fetchPlan({
+    required RoutingLocation from,
+    required RoutingLocation to,
+    int numItineraries = 10,
+    String? locale,
+    required DateTime dateTime,
+    bool arriveBy = false,
+  }) async {
+    capturedNumItineraries = numItineraries;
+    return Plan(itineraries: []);
+  }
+
+  @override
+  Future<List<TransitRoute>> fetchTransitRoutes() async => [];
+
+  @override
+  Future<TransitRoute?> fetchTransitRouteById(String id) async => null;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('RoutingEngineManager fetchPlan', () {
+    test('keeps the historical default of 5 itineraries', () async {
+      final provider = _RecordingProvider();
+      final manager = RoutingEngineManager(engines: [provider]);
+
+      await manager.fetchPlan(
+        from: RoutingLocation(
+          position: const LatLng(-17.39, -66.15),
+          description: 'A',
+        ),
+        to: RoutingLocation(
+          position: const LatLng(-17.40, -66.16),
+          description: 'B',
+        ),
+        dateTime: DateTime(2026, 1, 1, 12),
+      );
+
+      expect(provider.capturedNumItineraries, 5);
+    });
+
+    test('forwards an explicit numItineraries unchanged', () async {
+      final provider = _RecordingProvider();
+      final manager = RoutingEngineManager(engines: [provider]);
+
+      await manager.fetchPlan(
+        from: RoutingLocation(
+          position: const LatLng(-17.39, -66.15),
+          description: 'A',
+        ),
+        to: RoutingLocation(
+          position: const LatLng(-17.40, -66.16),
+          description: 'B',
+        ),
+        numItineraries: 3,
+        dateTime: DateTime(2026, 1, 1, 12),
+      );
+
+      expect(provider.capturedNumItineraries, 3);
+    });
+
+    test('uses the app-level maxItineraries override as the default '
+        '(issue #923: Cochabamba requests 20)', () async {
+      final provider = _RecordingProvider();
+      final manager = RoutingEngineManager(
+        engines: [provider],
+        maxItineraries: 20,
+      );
+
+      await manager.fetchPlan(
+        from: RoutingLocation(
+          position: const LatLng(-17.39, -66.15),
+          description: 'A',
+        ),
+        to: RoutingLocation(
+          position: const LatLng(-17.40, -66.16),
+          description: 'B',
+        ),
+        dateTime: DateTime(2026, 1, 1, 12),
+      );
+
+      expect(provider.capturedNumItineraries, 20);
+    });
+
+    test('an explicit numItineraries wins over maxItineraries', () async {
+      final provider = _RecordingProvider();
+      final manager = RoutingEngineManager(
+        engines: [provider],
+        maxItineraries: 20,
+      );
+
+      await manager.fetchPlan(
+        from: RoutingLocation(
+          position: const LatLng(-17.39, -66.15),
+          description: 'A',
+        ),
+        to: RoutingLocation(
+          position: const LatLng(-17.40, -66.16),
+          description: 'B',
+        ),
+        numItineraries: 3,
+        dateTime: DateTime(2026, 1, 1, 12),
+      );
+
+      expect(provider.capturedNumItineraries, 3);
+    });
+  });
+}


### PR DESCRIPTION
Reworked after review: **trufi-core defaults stay untouched** — this PR only adds the override point plus the plumbing to honor it end-to-end. City apps opt in (Cochabamba will set `maxItineraries: 20` in trufi-app); every other Trufi keeps getting 5.

## Changes

- `RoutingEngineManager` gains **`maxItineraries`** (constructor param, default **5** = historical behavior). `fetchPlan` uses it when the caller doesn't pass an explicit `numItineraries`.
- `RemotePlannerClient` now sends `maxResults` in the `/plan` body so the override reaches trufi-server-planner (which clamps it server-side; older deployments ignore the extra field).
- `LocalPlannerClient` scales the GTFS service per-bucket caps (`maxDirects`/`maxTransferPaths`) with `maxResults` — without this, an app-level override gets silently clipped to 5 directs + 5 transfers. At the default of 5 the behavior is identical to before.
- No defaults changed in providers or `GtfsRoutingService`.

## Verified in trufi-app (Cochabamba, offline GTFS, Android emulator)

Same three dense pairs, only difference is the app passing `maxItineraries: 20`:

| Pair | stock app (default 5) | with app override 20 |
|---|---|---|
| Centro → Av. América | 5 (capped) | **14** |
| Centro → Quillacollo | 5 (capped) | **20** |
| Cala Cala → La Cancha | 5 (capped) | **18** |

(`TrufiPlannerProvider: Found N paths` in logcat; the control run proves the default path is untouched.)

Unit tests: default stays 5, app override honored, explicit `numItineraries` wins (4/4).

Closes #923. Related: #929, trufi-server-planner#4.
