### PR TITLE
fix(otp28): keep long walking routes when walk-only mode is selected

### DIFF
--- a/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
@@ -5,6 +5,7 @@ import 'package:graphql/client.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 
 import '../otp_2_4/graphql_client_factory.dart';
+import '../../models/itinerary.dart';
 import '../../models/plan.dart';
 import '../../models/routing_location.dart';
 import '../../models/stop.dart';
@@ -110,8 +111,11 @@ class Otp28RoutingProvider extends IRoutingProvider {
   bool get requiresInternet => true;
 
   @override
-  Widget? buildPreferencesUI(BuildContext context) =>
-      Otp28Preferences(state: _prefs, showWheelchair: showWheelchairOption, showBicycle: showBicycleOption);
+  Widget? buildPreferencesUI(BuildContext context) => Otp28Preferences(
+    state: _prefs,
+    showWheelchair: showWheelchairOption,
+    showBicycle: showBicycleOption,
+  );
 
   @override
   void resetPreferences() => _prefs.reset();
@@ -210,16 +214,34 @@ class Otp28RoutingProvider extends IRoutingProvider {
 
     final plan = Otp28ResponseParser.parsePlan(result.data!);
 
-    // Filter out walk-only itineraries longer than 1 km — these are not useful
-    // transit results and usually appear when no service is available.
-    if (plan.itineraries != null) {
-      final filtered = plan.itineraries!
-          .where((it) => !(it.isWalkOnly && it.walkDistance > 1000))
-          .toList();
-      return plan.copyWith(itineraries: filtered);
-    }
+    final walkOnlyRequested =
+        !useSimpleQuery &&
+        _prefs.transportModes.length == 1 &&
+        _prefs.transportModes.single == RoutingMode.walk;
 
-    return plan;
+    return plan.copyWith(
+      itineraries: filterLongWalks(
+        plan.itineraries,
+        walkOnlyRequested: walkOnlyRequested,
+      ),
+    );
+  }
+
+  /// Drops walk-only itineraries longer than 1 km — in a transit search
+  /// those usually mean no service was available and only add noise.
+  ///
+  /// When the rider explicitly restricted the search to walking, every
+  /// result is a walk and dropping the long ones would empty the list
+  /// for any non-trivial trip (issue #900), so the filter is skipped.
+  @visibleForTesting
+  static List<Itinerary>? filterLongWalks(
+    List<Itinerary>? itineraries, {
+    required bool walkOnlyRequested,
+  }) {
+    if (itineraries == null || walkOnlyRequested) return itineraries;
+    return itineraries
+        .where((it) => !(it.isWalkOnly && it.walkDistance > 1000))
+        .toList();
   }
 
   // --- Transit routes (same schema as OTP 2.4) ---

--- a/packages/trufi_core_routing/test/unit/otp_28_walk_filter_test.dart
+++ b/packages/trufi_core_routing/test/unit/otp_28_walk_filter_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_routing/trufi_core_routing.dart';
+
+Itinerary _walk(double meters) => Itinerary(
+  legs: [
+    Leg(
+      mode: 'WALK',
+      startTime: DateTime(2026, 1, 1, 12),
+      endTime: DateTime(2026, 1, 1, 13),
+      duration: const Duration(hours: 1),
+      distance: meters,
+      transitLeg: false,
+    ),
+  ],
+  startTime: DateTime(2026, 1, 1, 12),
+  endTime: DateTime(2026, 1, 1, 13),
+  duration: const Duration(hours: 1),
+  walkDistance: meters,
+  walkTime: const Duration(hours: 1),
+);
+
+Itinerary _transit() => Itinerary(
+  legs: [
+    Leg(
+      mode: 'BUS',
+      startTime: DateTime(2026, 1, 1, 12),
+      endTime: DateTime(2026, 1, 1, 13),
+      duration: const Duration(hours: 1),
+      distance: 5000,
+      transitLeg: true,
+    ),
+  ],
+  startTime: DateTime(2026, 1, 1, 12),
+  endTime: DateTime(2026, 1, 1, 13),
+  duration: const Duration(hours: 1),
+  walkDistance: 200,
+  walkTime: const Duration(minutes: 3),
+);
+
+void main() {
+  group('Otp28RoutingProvider.filterLongWalks (issue #900)', () {
+    test('keeps long walks when the rider asked for walk-only routes', () {
+      final result = Otp28RoutingProvider.filterLongWalks([
+        _walk(3992),
+      ], walkOnlyRequested: true);
+      expect(result, hasLength(1));
+    });
+
+    test('still drops long walk noise from transit searches', () {
+      final result = Otp28RoutingProvider.filterLongWalks([
+        _transit(),
+        _walk(3992),
+      ], walkOnlyRequested: false);
+      expect(result, hasLength(1));
+      expect(result!.single.legs.single.transitLeg, isTrue);
+    });
+
+    test('short walks survive either way', () {
+      for (final walkOnly in [true, false]) {
+        final result = Otp28RoutingProvider.filterLongWalks([
+          _walk(800),
+        ], walkOnlyRequested: walkOnly);
+        expect(result, hasLength(1), reason: 'walkOnlyRequested=$walkOnly');
+      }
+    });
+
+    test('null itineraries pass through', () {
+      expect(
+        Otp28RoutingProvider.filterLongWalks(null, walkOnlyRequested: false),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes #900

## Root cause — not an OTP problem

The report blamed OTP 2.8.1, but the server answers correctly: the exact origin/destination from the issue returns a 3.9 km walking itinerary when queried directly (verified against `otp281.trufi.app` with the app's own GraphQL query and variables, byte-for-byte).

The bug is client-side: the OTP 2.8 provider **filters out walk-only itineraries longer than 1 km** after parsing. That's sensible noise reduction for *transit* searches — OTP returns a giant walk itinerary when no service is available, which only adds noise. But the filter also ran when the rider explicitly restricted transport modes to **Walk only**, where every result is by definition a walk — so any walk-only search beyond 1 km showed "no routes" while the server had answered fine.

Instrumented on-device confirmation: `raw itineraries: 1` from the server → `Itineraries found: 0` after the filter.

OTP 1.5 has no such filter, which is why it *appeared* to work there — the inconsistency between versions was entirely this one line.

## Fix

Skip the filter when the requested modes are walk-only. The transit-search behavior is unchanged (long walk noise still dropped). Extracted the filter into a static `filterLongWalks` for testability.

## Verified on device

With the report's coordinates, OTP 2.8.1 engine + Walk only: the app now shows the **52-minute, 4.0 km walking route** (before: no results).

## Tests

`otp_28_walk_filter_test.dart`: long walks kept in walk-only mode, still dropped from transit searches, short walks always survive, null passthrough.