### PR TITLE
fix(home): localize hardcoded strings that leaked into the German UI

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_de.arb
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_de.arb
@@ -117,10 +117,12 @@
   "limitationSlower": "Langsamere Antwort",
   "limitationNoWalkingRoute": "Keine Fußweg-Route auf Karte",
   "estimatedTimesDisclaimer": "Reisezeiten sind geschätzt und können je nach Verkehr variieren",
-
   "liveVehiclesTitle": "Live-Busse",
   "liveVehiclesSubtitle": "Zeige die Live-Position der Busse auf der Karte",
   "liveVehiclesEnable": "Aktivieren",
   "liveVehiclesStateOn": "Ein",
-  "liveVehiclesStateOff": "Aus"
+  "liveVehiclesStateOff": "Aus",
+  "placeOrigin": "Start",
+  "placeDestination": "Ziel",
+  "providerNoOptions": "Der Anbieter \"{provider}\" hat keine konfigurierbaren Optionen."
 }

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_en.arb
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_en.arb
@@ -608,7 +608,6 @@
   "@estimatedTimesDisclaimer": {
     "description": "Disclaimer shown above route results about estimated times"
   },
-
   "liveVehiclesTitle": "Live buses",
   "@liveVehiclesTitle": {
     "description": "Title of the live vehicles section in the map settings sheet"
@@ -628,5 +627,22 @@
   "liveVehiclesStateOff": "Off",
   "@liveVehiclesStateOff": {
     "description": "Secondary label when the live vehicles toggle is disabled"
+  },
+  "placeOrigin": "Origin",
+  "@placeOrigin": {
+    "description": "Fallback name for an origin set without a label (e.g. deep links)"
+  },
+  "placeDestination": "Destination",
+  "@placeDestination": {
+    "description": "Fallback name for a destination set without a label (e.g. deep links)"
+  },
+  "providerNoOptions": "The \"{provider}\" provider has no configurable options.",
+  "@providerNoOptions": {
+    "description": "Shown when the selected routing provider exposes no settings",
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_es.arb
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_es.arb
@@ -117,10 +117,12 @@
   "limitationSlower": "Respuesta más lenta",
   "limitationNoWalkingRoute": "Sin ruta de caminata en mapa",
   "estimatedTimesDisclaimer": "Los tiempos son estimados y pueden variar según el tráfico",
-
   "liveVehiclesTitle": "Buses en tiempo real",
   "liveVehiclesSubtitle": "Mostrar la posición en vivo de los buses sobre el mapa",
   "liveVehiclesEnable": "Activar",
   "liveVehiclesStateOn": "Encendido",
-  "liveVehiclesStateOff": "Apagado"
+  "liveVehiclesStateOff": "Apagado",
+  "placeOrigin": "Origen",
+  "placeDestination": "Destino",
+  "providerNoOptions": "El proveedor \"{provider}\" no tiene opciones configurables."
 }

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations.dart
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations.dart
@@ -834,6 +834,24 @@ abstract class HomeScreenLocalizations {
   /// In en, this message translates to:
   /// **'Off'**
   String get liveVehiclesStateOff;
+
+  /// Fallback name for an origin set without a label (e.g. deep links)
+  ///
+  /// In en, this message translates to:
+  /// **'Origin'**
+  String get placeOrigin;
+
+  /// Fallback name for a destination set without a label (e.g. deep links)
+  ///
+  /// In en, this message translates to:
+  /// **'Destination'**
+  String get placeDestination;
+
+  /// Shown when the selected routing provider exposes no settings
+  ///
+  /// In en, this message translates to:
+  /// **'The \"{provider}\" provider has no configurable options.'**
+  String providerNoOptions(String provider);
 }
 
 class _HomeScreenLocalizationsDelegate

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_de.dart
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_de.dart
@@ -442,4 +442,15 @@ class HomeScreenLocalizationsDe extends HomeScreenLocalizations {
 
   @override
   String get liveVehiclesStateOff => 'Aus';
+
+  @override
+  String get placeOrigin => 'Start';
+
+  @override
+  String get placeDestination => 'Ziel';
+
+  @override
+  String providerNoOptions(String provider) {
+    return 'Der Anbieter \"$provider\" hat keine konfigurierbaren Optionen.';
+  }
 }

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_en.dart
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_en.dart
@@ -441,4 +441,15 @@ class HomeScreenLocalizationsEn extends HomeScreenLocalizations {
 
   @override
   String get liveVehiclesStateOff => 'Off';
+
+  @override
+  String get placeOrigin => 'Origin';
+
+  @override
+  String get placeDestination => 'Destination';
+
+  @override
+  String providerNoOptions(String provider) {
+    return 'The \"$provider\" provider has no configurable options.';
+  }
 }

--- a/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_es.dart
+++ b/packages/screens/trufi_core_home_screen/lib/l10n/home_screen_localizations_es.dart
@@ -442,4 +442,15 @@ class HomeScreenLocalizationsEs extends HomeScreenLocalizations {
 
   @override
   String get liveVehiclesStateOff => 'Apagado';
+
+  @override
+  String get placeOrigin => 'Origen';
+
+  @override
+  String get placeDestination => 'Destino';
+
+  @override
+  String providerNoOptions(String provider) {
+    return 'El proveedor \"$provider\" no tiene opciones configurables.';
+  }
 }

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -292,8 +292,7 @@ class _HomeScreenState extends State<HomeScreen>
     // which can return the route this widget was originally built under
     // even after the user has navigated elsewhere within a ShellRoute).
     final router = GoRouter.of(context);
-    final currentPath =
-        router.routeInformationProvider.value.uri.path;
+    final currentPath = router.routeInformationProvider.value.uri.path;
     if (currentPath != '/') return;
 
     final from = state.fromPlace;
@@ -396,12 +395,16 @@ class _HomeScreenState extends State<HomeScreen>
         }
       }
 
+      // Resolved before the awaits below so no BuildContext use crosses
+      // an async gap.
+      final l10n = HomeScreenLocalizations.of(context);
+
       // Parse origin
       final fromLat = double.tryParse(params['from_lat'] ?? '');
       final fromLng = double.tryParse(params['from_lng'] ?? '');
       if (fromLat != null && fromLng != null) {
         final fromPlace = TrufiLocation(
-          description: params['from_name'] ?? 'Origin',
+          description: params['from_name'] ?? l10n.placeOrigin,
           latitude: fromLat,
           longitude: fromLng,
         );
@@ -414,7 +417,7 @@ class _HomeScreenState extends State<HomeScreen>
       final toLng = double.tryParse(params['to_lng'] ?? '');
       if (toLat != null && toLng != null) {
         final toPlace = TrufiLocation(
-          description: params['to_name'] ?? 'Destination',
+          description: params['to_name'] ?? l10n.placeDestination,
           latitude: toLat,
           longitude: toLng,
         );
@@ -784,10 +787,7 @@ class _HomeScreenState extends State<HomeScreen>
       markers.add(
         TrufiMarker(
           id: 'destination-preview',
-          position: LatLng(
-            state.toPlace!.latitude,
-            state.toPlace!.longitude,
-          ),
+          position: LatLng(state.toPlace!.latitude, state.toPlace!.longitude),
           widget: const _DestinationMarker(),
           size: const Size(32, 32),
           alignment: Alignment.topCenter,
@@ -1005,10 +1005,7 @@ class _HomeScreenState extends State<HomeScreen>
   /// Compute and apply camera position to fit the given points.
   void _fitCameraToPoints(List<LatLng> points) {
     if (_fitCameraUtil == null || _currentCamera == null) return;
-    final newCam = _fitCameraUtil!.cameraForPoints(
-      points,
-      _currentCamera!,
-    );
+    final newCam = _fitCameraUtil!.cameraForPoints(points, _currentCamera!);
     if (newCam != null) {
       setState(() {
         _cameraTarget = newCam;
@@ -1393,30 +1390,36 @@ class _HomeScreenState extends State<HomeScreen>
 
     // My location layer (lowest level)
     if (_myLocationMarkers.isNotEmpty) {
-      layers.add(TrufiLayer(
-        id: 'my-location-layer',
-        markers: _myLocationMarkers,
-        layerLevel: 0,
-      ));
+      layers.add(
+        TrufiLayer(
+          id: 'my-location-layer',
+          markers: _myLocationMarkers,
+          layerLevel: 0,
+        ),
+      );
     }
 
     // Location markers layer (origin/destination preview before route)
     if (_locationMarkers.isNotEmpty) {
-      layers.add(TrufiLayer(
-        id: 'location-markers-layer',
-        markers: _locationMarkers,
-        layerLevel: 2,
-      ));
+      layers.add(
+        TrufiLayer(
+          id: 'location-markers-layer',
+          markers: _locationMarkers,
+          layerLevel: 2,
+        ),
+      );
     }
 
     // Route lines (polylines) sit below live/realtime layers so vehicles
     // render on top of them.
     if (_routeLines.isNotEmpty) {
-      layers.add(TrufiLayer(
-        id: 'route-lines-layer',
-        lines: _routeLines,
-        layerLevel: 1000,
-      ));
+      layers.add(
+        TrufiLayer(
+          id: 'route-lines-layer',
+          lines: _routeLines,
+          layerLevel: 1000,
+        ),
+      );
     }
 
     // POI layers
@@ -1448,11 +1451,13 @@ class _HomeScreenState extends State<HomeScreen>
     // Route markers (origin/destination/boarding/transit labels) stay on top
     // so they aren't hidden by live vehicle markers.
     if (_routeMarkers.isNotEmpty) {
-      layers.add(TrufiLayer(
-        id: 'route-markers-layer',
-        markers: _routeMarkers,
-        layerLevel: 2000,
-      ));
+      layers.add(
+        TrufiLayer(
+          id: 'route-markers-layer',
+          markers: _routeMarkers,
+          layerLevel: 2000,
+        ),
+      );
     }
 
     return layers;
@@ -1480,221 +1485,223 @@ class _HomeScreenState extends State<HomeScreen>
     return Provider<RealtimeVehiclesProvider?>.value(
       value: _realtimeVehiclesProvider,
       child: Scaffold(
-      body: BlocConsumer<RoutePlannerCubit, RoutePlannerState>(
-        listener: (context, state) {
-          _updateLocationMarkers(state);
-          _updateRouteOnMap(state.selectedItinerary);
-          _updateFitCameraPoints(state);
-          _expandSheetIfNeeded(state);
-          // Update URL with current state (web only)
-          _updateUrlWithState(state);
-        },
-        builder: (context, state) {
-          final locationState = SearchLocationState(
-            origin: state.fromPlace != null
-                ? _trufiLocationToSearchLocation(state.fromPlace!)
-                : null,
-            destination: state.toPlace != null
-                ? _trufiLocationToSearchLocation(state.toPlace!)
-                : null,
-          );
+        body: BlocConsumer<RoutePlannerCubit, RoutePlannerState>(
+          listener: (context, state) {
+            _updateLocationMarkers(state);
+            _updateRouteOnMap(state.selectedItinerary);
+            _updateFitCameraPoints(state);
+            _expandSheetIfNeeded(state);
+            // Update URL with current state (web only)
+            _updateUrlWithState(state);
+          },
+          builder: (context, state) {
+            final locationState = SearchLocationState(
+              origin: state.fromPlace != null
+                  ? _trufiLocationToSearchLocation(state.fromPlace!)
+                  : null,
+              destination: state.toPlace != null
+                  ? _trufiLocationToSearchLocation(state.toPlace!)
+                  : null,
+            );
 
-          final hasResults =
-              state.plan != null || state.isLoading || state.hasError;
+            final hasResults =
+                state.plan != null || state.isLoading || state.hasError;
 
-          return LayoutBuilder(
-            builder: (context, constraints) {
-              // Responsive layout: use side panel for wide screens (>=600px)
-              final isWideScreen = constraints.maxWidth >= 600;
-              final sidePanelWidth = _getSidePanelWidth(constraints.maxWidth);
+            return LayoutBuilder(
+              builder: (context, constraints) {
+                // Responsive layout: use side panel for wide screens (>=600px)
+                final isWideScreen = constraints.maxWidth >= 600;
+                final sidePanelWidth = _getSidePanelWidth(constraints.maxWidth);
 
-              // Update viewport with actual map area size (excluding side panel on wide screens)
-              final mapWidth = isWideScreen
-                  ? constraints.maxWidth - sidePanelWidth
-                  : constraints.maxWidth;
-              _fitCameraUtil?.updateViewport(
-                Size(mapWidth, constraints.maxHeight),
-                MediaQuery.of(context).viewPadding,
-              );
+                // Update viewport with actual map area size (excluding side panel on wide screens)
+                final mapWidth = isWideScreen
+                    ? constraints.maxWidth - sidePanelWidth
+                    : constraints.maxWidth;
+                _fitCameraUtil?.updateViewport(
+                  Size(mapWidth, constraints.maxHeight),
+                  MediaQuery.of(context).viewPadding,
+                );
 
-              // Apply pending fit points once viewport is ready
-              if (!_viewportReady) {
-                _viewportReady = true;
-                if (_pendingFitPoints != null &&
-                    _pendingFitPoints!.isNotEmpty) {
-                  // Set initial padding based on screen type
-                  if (isWideScreen) {
-                    _fitCameraUtil?.updatePadding(
-                      const EdgeInsets.all(30),
-                    );
-                  } else {
-                    // Narrow screen: account for search bar and bottom sheet
-                    final sheetHeight = constraints.maxHeight * _sheetMidSize;
-                    _fitCameraUtil?.updatePadding(
-                      EdgeInsets.only(
-                        top: 120, // SearchLocationBar height
-                        bottom: sheetHeight,
-                        left: 30,
-                        right: 30,
-                      ),
-                    );
-                  }
-                  // Use post-frame callback to fit after currentCamera is set
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    if (mounted && _pendingFitPoints != null) {
-                      _fitCameraToPoints(_pendingFitPoints!);
+                // Apply pending fit points once viewport is ready
+                if (!_viewportReady) {
+                  _viewportReady = true;
+                  if (_pendingFitPoints != null &&
+                      _pendingFitPoints!.isNotEmpty) {
+                    // Set initial padding based on screen type
+                    if (isWideScreen) {
+                      _fitCameraUtil?.updatePadding(const EdgeInsets.all(30));
+                    } else {
+                      // Narrow screen: account for search bar and bottom sheet
+                      final sheetHeight = constraints.maxHeight * _sheetMidSize;
+                      _fitCameraUtil?.updatePadding(
+                        EdgeInsets.only(
+                          top: 120, // SearchLocationBar height
+                          bottom: sheetHeight,
+                          left: 30,
+                          right: 30,
+                        ),
+                      );
                     }
+                    // Use post-frame callback to fit after currentCamera is set
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      if (mounted && _pendingFitPoints != null) {
+                        _fitCameraToPoints(_pendingFitPoints!);
+                      }
+                    });
+                  }
+                }
+
+                // Ensure route is rendered when returning from another screen
+                // The BlocConsumer listener only fires on state changes, so if we
+                // navigate away and come back with the same state, we need to
+                // re-render the route manually.
+                final needsRouteRender =
+                    _needsRouteRefresh ||
+                    (state.selectedItinerary != null &&
+                        _routeMarkers.isEmpty &&
+                        _routeLines.isEmpty);
+
+                if (_needsRouteRefresh) {
+                  _needsRouteRefresh = false;
+                  // Reset URL tracking to force URL restoration
+                  _lastUrlFrom = null;
+                  _lastUrlTo = null;
+                  _lastUrlTimeMode = null;
+                  _lastUrlDateTime = null;
+                }
+
+                if (needsRouteRender) {
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    if (!mounted) return;
+                    if (state.selectedItinerary != null) {
+                      // Clear location markers first (they duplicate with route markers)
+                      _updateLocationMarkers(state);
+                      _updateRouteOnMap(state.selectedItinerary);
+                      _updateFitCameraPoints(state);
+                    } else if (state.fromPlace != null ||
+                        state.toPlace != null) {
+                      _updateLocationMarkers(state);
+                    }
+                    // Restore URL with current state
+                    _updateUrlWithState(state);
                   });
                 }
-              }
 
-              // Ensure route is rendered when returning from another screen
-              // The BlocConsumer listener only fires on state changes, so if we
-              // navigate away and come back with the same state, we need to
-              // re-render the route manually.
-              final needsRouteRender =
-                  _needsRouteRefresh ||
-                  (state.selectedItinerary != null &&
-                      _routeMarkers.isEmpty &&
-                      _routeLines.isEmpty);
+                // Update camera padding for side panel layout (panel on LEFT)
+                // Note: The map is already positioned to the right of the side panel,
+                // so we don't need to include sidePanelWidth in the padding.
+                if (isWideScreen) {
+                  _fitCameraUtil?.updatePadding(const EdgeInsets.all(30));
+                }
 
-              if (_needsRouteRefresh) {
-                _needsRouteRefresh = false;
-                // Reset URL tracking to force URL restoration
-                _lastUrlFrom = null;
-                _lastUrlTo = null;
-                _lastUrlTimeMode = null;
-                _lastUrlDateTime = null;
-              }
-
-              if (needsRouteRender) {
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  if (!mounted) return;
-                  if (state.selectedItinerary != null) {
-                    // Clear location markers first (they duplicate with route markers)
-                    _updateLocationMarkers(state);
-                    _updateRouteOnMap(state.selectedItinerary);
-                    _updateFitCameraPoints(state);
-                  } else if (state.fromPlace != null || state.toPlace != null) {
-                    _updateLocationMarkers(state);
-                  }
-                  // Restore URL with current state
-                  _updateUrlWithState(state);
-                });
-              }
-
-              // Update camera padding for side panel layout (panel on LEFT)
-              // Note: The map is already positioned to the right of the side panel,
-              // so we don't need to include sidePanelWidth in the padding.
-              if (isWideScreen) {
-                _fitCameraUtil?.updatePadding(const EdgeInsets.all(30));
-              }
-
-              return Stack(
-                children: [
-                  // Map - adjusts for side panel on LEFT on wide screens
-                  Positioned(
-                    top: 0,
-                    left: isWideScreen ? sidePanelWidth : 0,
-                    bottom: 0,
-                    right: 0,
-                    child: _buildMap(mapEngineManager.currentEngine),
-                  ),
-
-                  // Wide screens: always show left panel with SearchBar
-                  if (isWideScreen)
-                    _buildSidePanel(
-                      state,
-                      theme,
-                      sidePanelWidth,
-                      locationState: locationState,
-                      l10n: l10n,
-                    ),
-
-                  // Narrow screens: SearchBar floats on top of map
-                  if (!isWideScreen)
+                return Stack(
+                  children: [
+                    // Map - adjusts for side panel on LEFT on wide screens
                     Positioned(
                       top: 0,
-                      left: 0,
+                      left: isWideScreen ? sidePanelWidth : 0,
+                      bottom: 0,
                       right: 0,
-                      child: SafeArea(
-                        bottom: false,
-                        child: Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: Column(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              SearchLocationBar(
-                                state: locationState,
-                                configuration: SearchLocationBarConfiguration(
-                                  originHintText: l10n.searchOrigin,
-                                  destinationHintText: l10n.searchDestination,
-                                ),
-                                onSearch: _showSearchScreen,
-                                onOriginSelected: _onOriginSelected,
-                                onDestinationSelected: _onDestinationSelected,
-                                onSwap: _onSwapLocations,
-                                onReset: _onReset,
-                                onClearLocation: _onClearLocation,
-                                onRoutingSettings: _onRoutingSettings,
-                                onMenuPressed: widget.onMenuPressed,
-                              ),
-                              // Departure time chip (visible when
-                              // locations are set, and only when no
-                              // app-level `routingTimeOverride` is
-                              // configured — when set, every request
-                              // resolves against a fixed time of day
-                              // and the picker would mislead).
-                              if (context
-                                          .read<AppConfiguration?>()
-                                          ?.routingTimeOverride ==
-                                      null &&
-                                  (state.fromPlace != null ||
-                                      state.toPlace != null))
-                                Padding(
-                                  padding: const EdgeInsets.only(top: 8),
-                                  child: _DepartureTimeChip(
-                                    onTimeChanged: _fetchPlanIfReady,
+                      child: _buildMap(mapEngineManager.currentEngine),
+                    ),
+
+                    // Wide screens: always show left panel with SearchBar
+                    if (isWideScreen)
+                      _buildSidePanel(
+                        state,
+                        theme,
+                        sidePanelWidth,
+                        locationState: locationState,
+                        l10n: l10n,
+                      ),
+
+                    // Narrow screens: SearchBar floats on top of map
+                    if (!isWideScreen)
+                      Positioned(
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        child: SafeArea(
+                          bottom: false,
+                          child: Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                SearchLocationBar(
+                                  state: locationState,
+                                  configuration: SearchLocationBarConfiguration(
+                                    originHintText: l10n.searchOrigin,
+                                    destinationHintText: l10n.searchDestination,
                                   ),
+                                  onSearch: _showSearchScreen,
+                                  onOriginSelected: _onOriginSelected,
+                                  onDestinationSelected: _onDestinationSelected,
+                                  onSwap: _onSwapLocations,
+                                  onReset: _onReset,
+                                  onClearLocation: _onClearLocation,
+                                  onRoutingSettings: _onRoutingSettings,
+                                  onMenuPressed: widget.onMenuPressed,
                                 ),
-                            ],
+                                // Departure time chip (visible when
+                                // locations are set, and only when no
+                                // app-level `routingTimeOverride` is
+                                // configured — when set, every request
+                                // resolves against a fixed time of day
+                                // and the picker would mislead).
+                                if (context
+                                            .read<AppConfiguration?>()
+                                            ?.routingTimeOverride ==
+                                        null &&
+                                    (state.fromPlace != null ||
+                                        state.toPlace != null))
+                                  Padding(
+                                    padding: const EdgeInsets.only(top: 8),
+                                    child: _DepartureTimeChip(
+                                      onTimeChanged: _fetchPlanIfReady,
+                                    ),
+                                  ),
+                              ],
+                            ),
                           ),
                         ),
                       ),
+
+                    // Floating action buttons (map controls) - always on right side of map
+                    _buildMapControls(
+                      context,
+                      mapEngineManager,
+                      hasResults,
+                      sidePanelOffset: 0, // No offset needed, panel is on left
+                      isWideScreen: isWideScreen,
                     ),
 
-                  // Floating action buttons (map controls) - always on right side of map
-                  _buildMapControls(
-                    context,
-                    mapEngineManager,
-                    hasResults,
-                    sidePanelOffset: 0, // No offset needed, panel is on left
-                    isWideScreen: isWideScreen,
-                  ),
+                    // Narrow screens: bottom sheet for results, fixed panel for errors
+                    // Hide when POI is selected (POI panel takes priority)
+                    if (!isWideScreen &&
+                        hasResults &&
+                        widget.config.poiLayersManager?.selectedPOI == null)
+                      (state.hasError ||
+                              (!state.isLoading &&
+                                  state.plan != null &&
+                                  !state.plan!.hasItineraries))
+                          ? _buildErrorPanel(state, theme)
+                          : _buildBottomSheet(state, theme, constraints),
 
-                  // Narrow screens: bottom sheet for results, fixed panel for errors
-                  // Hide when POI is selected (POI panel takes priority)
-                  if (!isWideScreen &&
-                      hasResults &&
-                      widget.config.poiLayersManager?.selectedPOI == null)
-                    (state.hasError || (!state.isLoading && state.plan != null && !state.plan!.hasItineraries))
-                        ? _buildErrorPanel(state, theme)
-                        : _buildBottomSheet(state, theme, constraints),
-
-                  // POI detail panel (narrow screens only) - shows at bottom
-                  if (!isWideScreen &&
-                      widget.config.poiLayersManager?.selectedPOI != null)
-                    _buildPOIDetailPanel(
-                      widget.config.poiLayersManager!.selectedPOI!,
-                      theme,
-                      isWideScreen: false,
-                    ),
-                ],
-              );
-            },
-          );
-        },
-      ),
+                    // POI detail panel (narrow screens only) - shows at bottom
+                    if (!isWideScreen &&
+                        widget.config.poiLayersManager?.selectedPOI != null)
+                      _buildPOIDetailPanel(
+                        widget.config.poiLayersManager!.selectedPOI!,
+                        theme,
+                        isWideScreen: false,
+                      ),
+                  ],
+                );
+              },
+            );
+          },
+        ),
       ),
     );
   }
@@ -1821,7 +1828,7 @@ class _HomeScreenState extends State<HomeScreen>
             const SizedBox(width: 12),
             Expanded(
               child: Text(
-                'Finding routes...',
+                l10n.findingRoutes,
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.primary,
                 ),
@@ -1926,7 +1933,9 @@ class _HomeScreenState extends State<HomeScreen>
           const SizedBox(width: 8),
           Expanded(
             child: Text(
-              HomeScreenLocalizations.of(context).routesFound(itineraries.length),
+              HomeScreenLocalizations.of(
+                context,
+              ).routesFound(itineraries.length),
               style: theme.textTheme.bodyMedium?.copyWith(
                 fontWeight: FontWeight.w500,
               ),
@@ -2359,7 +2368,9 @@ class _HomeScreenState extends State<HomeScreen>
                   shape: BoxShape.circle,
                 ),
                 child: Icon(
-                  isError ? Icons.error_outline_rounded : Icons.search_off_rounded,
+                  isError
+                      ? Icons.error_outline_rounded
+                      : Icons.search_off_rounded,
                   size: 28,
                   color: isError
                       ? theme.colorScheme.error
@@ -2403,7 +2414,10 @@ class _HomeScreenState extends State<HomeScreen>
     ThemeData theme,
     BoxConstraints constraints,
   ) {
-    _cachedSheetMinSize = (_sheetMinHeightPx / constraints.maxHeight).clamp(0.05, 0.25);
+    _cachedSheetMinSize = (_sheetMinHeightPx / constraints.maxHeight).clamp(
+      0.05,
+      0.25,
+    );
     return TrufiBottomSheet(
       controller: _sheetController,
       initialChildSize: _sheetMidSize,
@@ -2795,8 +2809,9 @@ class _TransitStopMarker extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final onColor =
-        color.computeLuminance() > 0.5 ? Colors.black : Colors.white;
+    final onColor = color.computeLuminance() > 0.5
+        ? Colors.black
+        : Colors.white;
     return Container(
       width: 20,
       height: 20,
@@ -2812,11 +2827,7 @@ class _TransitStopMarker extends StatelessWidget {
           ),
         ],
       ),
-      child: Icon(
-        Icons.directions_bus_rounded,
-        color: onColor,
-        size: 11,
-      ),
+      child: Icon(Icons.directions_bus_rounded, color: onColor, size: 11),
     );
   }
 }

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_detail_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_detail_screen.dart
@@ -682,7 +682,8 @@ class _LegItemState extends State<_LegItem> {
     // from the title. Surfaces the OSM `description` of the trip for
     // feeds where multiple branches share a route_short_name. Skipped
     // when headsign equals the title (already shown above).
-    final routeVariant = (leg.headsign != null &&
+    final routeVariant =
+        (leg.headsign != null &&
             leg.headsign!.isNotEmpty &&
             leg.headsign != routeName)
         ? leg.headsign
@@ -1127,7 +1128,7 @@ class ItineraryDetailScreen extends StatelessWidget {
                 ),
                 const SizedBox(width: 2),
                 Text(
-                  '$totalWalkingMinutes min',
+                  l10n.durationMinutes(totalWalkingMinutes),
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: colorScheme.onSurfaceVariant,
                   ),

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/routing_settings_sheet.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/routing_settings_sheet.dart
@@ -114,7 +114,12 @@ class RoutingSettingsSheet extends StatelessWidget {
           ),
           // Apply button
           Padding(
-            padding: EdgeInsets.fromLTRB(20, 8, 20, 24 + MediaQuery.of(context).padding.bottom),
+            padding: EdgeInsets.fromLTRB(
+              20,
+              8,
+              20,
+              24 + MediaQuery.of(context).padding.bottom,
+            ),
             child: SizedBox(
               width: double.infinity,
               child: FilledButton.icon(
@@ -165,7 +170,7 @@ class _NoOptionsMessage extends StatelessWidget {
           ),
           const SizedBox(height: 16),
           Text(
-            'El proveedor "$providerName" no tiene opciones configurables.',
+            HomeScreenLocalizations.of(context).providerNoOptions(providerName),
             textAlign: TextAlign.center,
             style: theme.textTheme.bodyMedium?.copyWith(
               color: colorScheme.onSurfaceVariant,


### PR DESCRIPTION
First slice of #871.

## Root cause of the mixed-language UI

The ARB files are healthy — an audit found **zero missing keys** in `de`/`es` across all 11 localized packages (the handful of identical values are legitimate German: *Online, Details, System, Feedback…*). The leaks come from **~106 hardcoded string literals in widget code**, in three flavors:

1. `languageCode == 'es' ? 'Spanish' : 'English'` conditionals — German falls through to English.
2. Pure Spanish or English literals in `Text(...)` — shown verbatim in every language.
3. Whole screens with no l10n at all (OTP 1.5/2.4 preference sheets, search screen, map settings).

The full inventory (file:line, string, language) is posted on #871.

## This PR: trufi_core_home_screen

- `'Finding routes...'` → the existing `l10n.findingRoutes` (it was already used correctly elsewhere — plain regression).
- `'$totalWalkingMinutes min'` in the itinerary detail app bar → existing `durationMinutes` (renders **Min** in German).
- Routing-settings empty state was a full Spanish sentence → new `providerNoOptions` key (en/es/de), with the provider name as placeholder.
- Deep-link fallbacks `'Origin'`/`'Destination'` → new `placeOrigin`/`placeDestination` keys (en/es/de: Origin/Origen/Start, Destination/Destino/Ziel), resolved before the awaits so no BuildContext crosses an async gap.

`flutter gen-l10n` regenerated; package tests pass; analyzer clean (the one remaining info, `depend_on_referenced_packages`, is pre-existing).

## Remaining work (follow-up slices per package)

Per the inventory on #871: transport_list (+the es/en conditionals), saved_places, about, fares, ui (init screen + router), navigation (cubit messages + itinerary converter), maps, search_locations, and the OTP preference sheets in routing — the last three need l10n wiring from scratch.