### PR TITLE
fix(transport_list): localize hardcoded strings (#871)

### DIFF
--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_de.arb
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_de.arb
@@ -29,5 +29,21 @@
   "labelStops": "Haltestellen",
   "labelMode": "Verkehrsmittel",
   "noStopsAvailable": "Keine Haltestellen verfügbar",
-  "loadingRoute": "Linie wird geladen..."
+  "loadingRoute": "Linie wird geladen...",
+  "otherAgencies": "Sonstige",
+  "shareRouteMessage": "Teilen: {uri}",
+  "@shareRouteMessage": {
+    "placeholders": {
+      "uri": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultModeBus": "Bus",
+  "mapSettingsTitle": "Karteneinstellungen",
+  "mapTypeLabel": "Kartentyp",
+  "applyChanges": "Änderungen übernehmen",
+  "stopStart": "Start",
+  "stopEnd": "Ende",
+  "stopInfoNotAvailable": "Für diese Linie sind keine Haltestelleninformationen verfügbar"
 }

--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_en.arb
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_en.arb
@@ -38,5 +38,46 @@
   "labelStops": "Stops",
   "labelMode": "Mode",
   "noStopsAvailable": "No stops available",
-  "loadingRoute": "Loading route..."
+  "loadingRoute": "Loading route...",
+  "otherAgencies": "Others",
+  "@otherAgencies": {
+    "description": "Group header for routes whose agency is unknown"
+  },
+  "shareRouteMessage": "Share: {uri}",
+  "@shareRouteMessage": {
+    "description": "Snackbar message shown when sharing a route link",
+    "placeholders": {
+      "uri": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultModeBus": "Bus",
+  "@defaultModeBus": {
+    "description": "Fallback transport mode label when a route has no mode name"
+  },
+  "mapSettingsTitle": "Map Settings",
+  "@mapSettingsTitle": {
+    "description": "App bar title of the map settings screen"
+  },
+  "mapTypeLabel": "Map Type",
+  "@mapTypeLabel": {
+    "description": "Section title for choosing the map type"
+  },
+  "applyChanges": "Apply Changes",
+  "@applyChanges": {
+    "description": "Button label to apply map settings changes"
+  },
+  "stopStart": "Start",
+  "@stopStart": {
+    "description": "Badge label for the first stop of a route"
+  },
+  "stopEnd": "End",
+  "@stopEnd": {
+    "description": "Badge label for the last stop of a route"
+  },
+  "stopInfoNotAvailable": "Stop information is not available for this route",
+  "@stopInfoNotAvailable": {
+    "description": "Explanation shown when a route has no stop data"
+  }
 }

--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_es.arb
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_es.arb
@@ -29,5 +29,21 @@
   "labelStops": "Paradas",
   "labelMode": "Modo",
   "noStopsAvailable": "Sin paradas disponibles",
-  "loadingRoute": "Cargando ruta..."
+  "loadingRoute": "Cargando ruta...",
+  "otherAgencies": "Otros",
+  "shareRouteMessage": "Compartir: {uri}",
+  "@shareRouteMessage": {
+    "placeholders": {
+      "uri": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultModeBus": "Bus",
+  "mapSettingsTitle": "Configuración del mapa",
+  "mapTypeLabel": "Tipo de mapa",
+  "applyChanges": "Aplicar cambios",
+  "stopStart": "Inicio",
+  "stopEnd": "Fin",
+  "stopInfoNotAvailable": "La información de paradas no está disponible para esta ruta"
 }

--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations.dart
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations.dart
@@ -198,6 +198,60 @@ abstract class TransportListLocalizations {
   /// In en, this message translates to:
   /// **'Loading route...'**
   String get loadingRoute;
+
+  /// Group header for routes whose agency is unknown
+  ///
+  /// In en, this message translates to:
+  /// **'Others'**
+  String get otherAgencies;
+
+  /// Snackbar message shown when sharing a route link
+  ///
+  /// In en, this message translates to:
+  /// **'Share: {uri}'**
+  String shareRouteMessage(String uri);
+
+  /// Fallback transport mode label when a route has no mode name
+  ///
+  /// In en, this message translates to:
+  /// **'Bus'**
+  String get defaultModeBus;
+
+  /// App bar title of the map settings screen
+  ///
+  /// In en, this message translates to:
+  /// **'Map Settings'**
+  String get mapSettingsTitle;
+
+  /// Section title for choosing the map type
+  ///
+  /// In en, this message translates to:
+  /// **'Map Type'**
+  String get mapTypeLabel;
+
+  /// Button label to apply map settings changes
+  ///
+  /// In en, this message translates to:
+  /// **'Apply Changes'**
+  String get applyChanges;
+
+  /// Badge label for the first stop of a route
+  ///
+  /// In en, this message translates to:
+  /// **'Start'**
+  String get stopStart;
+
+  /// Badge label for the last stop of a route
+  ///
+  /// In en, this message translates to:
+  /// **'End'**
+  String get stopEnd;
+
+  /// Explanation shown when a route has no stop data
+  ///
+  /// In en, this message translates to:
+  /// **'Stop information is not available for this route'**
+  String get stopInfoNotAvailable;
 }
 
 class _TransportListLocalizationsDelegate

--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations_de.dart
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations_de.dart
@@ -59,4 +59,34 @@ class TransportListLocalizationsDe extends TransportListLocalizations {
 
   @override
   String get loadingRoute => 'Linie wird geladen...';
+
+  @override
+  String get otherAgencies => 'Sonstige';
+
+  @override
+  String shareRouteMessage(String uri) {
+    return 'Teilen: $uri';
+  }
+
+  @override
+  String get defaultModeBus => 'Bus';
+
+  @override
+  String get mapSettingsTitle => 'Karteneinstellungen';
+
+  @override
+  String get mapTypeLabel => 'Kartentyp';
+
+  @override
+  String get applyChanges => 'Änderungen übernehmen';
+
+  @override
+  String get stopStart => 'Start';
+
+  @override
+  String get stopEnd => 'Ende';
+
+  @override
+  String get stopInfoNotAvailable =>
+      'Für diese Linie sind keine Haltestelleninformationen verfügbar';
 }

--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations_en.dart
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations_en.dart
@@ -65,4 +65,34 @@ class TransportListLocalizationsEn extends TransportListLocalizations {
 
   @override
   String get loadingRoute => 'Loading route...';
+
+  @override
+  String get otherAgencies => 'Others';
+
+  @override
+  String shareRouteMessage(String uri) {
+    return 'Share: $uri';
+  }
+
+  @override
+  String get defaultModeBus => 'Bus';
+
+  @override
+  String get mapSettingsTitle => 'Map Settings';
+
+  @override
+  String get mapTypeLabel => 'Map Type';
+
+  @override
+  String get applyChanges => 'Apply Changes';
+
+  @override
+  String get stopStart => 'Start';
+
+  @override
+  String get stopEnd => 'End';
+
+  @override
+  String get stopInfoNotAvailable =>
+      'Stop information is not available for this route';
 }

--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations_es.dart
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations_es.dart
@@ -59,4 +59,34 @@ class TransportListLocalizationsEs extends TransportListLocalizations {
 
   @override
   String get loadingRoute => 'Cargando ruta...';
+
+  @override
+  String get otherAgencies => 'Otros';
+
+  @override
+  String shareRouteMessage(String uri) {
+    return 'Compartir: $uri';
+  }
+
+  @override
+  String get defaultModeBus => 'Bus';
+
+  @override
+  String get mapSettingsTitle => 'Configuración del mapa';
+
+  @override
+  String get mapTypeLabel => 'Tipo de mapa';
+
+  @override
+  String get applyChanges => 'Aplicar cambios';
+
+  @override
+  String get stopStart => 'Inicio';
+
+  @override
+  String get stopEnd => 'Fin';
+
+  @override
+  String get stopInfoNotAvailable =>
+      'La información de paradas no está disponible para esta ruta';
 }

--- a/packages/screens/trufi_core_transport_list/lib/src/transport_detail_screen.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/transport_detail_screen.dart
@@ -177,7 +177,9 @@ class _TransportDetailScreenState extends State<TransportDetailScreen>
         setState(() => _isLoading = false);
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(TransportListLocalizations.of(context).routeLoadError),
+            content: Text(
+              TransportListLocalizations.of(context).routeLoadError,
+            ),
             behavior: SnackBarBehavior.floating,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(10),
@@ -218,7 +220,8 @@ class _TransportDetailScreenState extends State<TransportDetailScreen>
     ColorScheme colorScheme,
   ) {
     final routeColor = _route?.backgroundColor ?? colorScheme.primary;
-    final textColor = _route?.textColor ??
+    final textColor =
+        _route?.textColor ??
         (routeColor.computeLuminance() > 0.5 ? Colors.black87 : Colors.white);
 
     return Positioned(
@@ -448,7 +451,8 @@ class _TransportDetailScreenState extends State<TransportDetailScreen>
     double width,
   ) {
     final routeColor = _route?.backgroundColor ?? colorScheme.primary;
-    final textColor = _route?.textColor ??
+    final textColor =
+        _route?.textColor ??
         (routeColor.computeLuminance() > 0.5 ? Colors.black87 : Colors.white);
 
     return Positioned(
@@ -615,8 +619,10 @@ class _TransportDetailScreenState extends State<TransportDetailScreen>
             // Grabber height in TrufiBottomSheet: 12 top + 4 bar + 8 bottom = 24
             const grabberHeight = 24.0;
             final minSize = _headerMinSize != null
-                ? ((_headerMinSize! + grabberHeight) / screenHeight)
-                    .clamp(0.1, 0.4)
+                ? ((_headerMinSize! + grabberHeight) / screenHeight).clamp(
+                    0.1,
+                    0.4,
+                  )
                 : 0.12;
             final snapSizes = [minSize, 0.35, 0.85];
 
@@ -716,7 +722,9 @@ class _TransportDetailScreenState extends State<TransportDetailScreen>
     );
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text(Localizations.localeOf(context).languageCode == 'es' ? 'Compartir: $uri' : 'Share: $uri'),
+        content: Text(
+          TransportListLocalizations.of(context).shareRouteMessage('$uri'),
+        ),
         behavior: SnackBarBehavior.floating,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
       ),
@@ -851,10 +859,7 @@ class _StopsSheetContentState extends State<_StopsSheetContent> {
         // Pinned header — stays fixed at top, drag on it still expands the sheet
         SliverPersistentHeader(
           pinned: true,
-          delegate: _SliverHeaderDelegate(
-            child: header,
-            height: _headerHeight,
-          ),
+          delegate: _SliverHeaderDelegate(child: header, height: _headerHeight),
         ),
 
         // Stops list
@@ -865,32 +870,28 @@ class _StopsSheetContentState extends State<_StopsSheetContent> {
           )
         else
           SliverList(
-            delegate: SliverChildBuilderDelegate(
-              (context, index) {
-                final stop = stops[index];
-                final isFirst = index == 0;
-                final isLast = index == stops.length - 1;
-                final isSelected = widget.selectedStopIndex == index;
-                final routeColor =
-                    widget.route.backgroundColor ?? colorScheme.primary;
+            delegate: SliverChildBuilderDelegate((context, index) {
+              final stop = stops[index];
+              final isFirst = index == 0;
+              final isLast = index == stops.length - 1;
+              final isSelected = widget.selectedStopIndex == index;
+              final routeColor =
+                  widget.route.backgroundColor ?? colorScheme.primary;
 
-                return _StopTimelineItem(
-                  stop: stop,
-                  isFirst: isFirst,
-                  isLast: isLast,
-                  isSelected: isSelected,
-                  routeColor: _foregroundColor(routeColor),
-                  onTap: widget.onStopTap != null
-                      ? () {
-                          HapticFeedback.selectionClick();
-                          widget.onStopTap!(
-                              index, stop.latitude, stop.longitude);
-                        }
-                      : null,
-                );
-              },
-              childCount: stops.length,
-            ),
+              return _StopTimelineItem(
+                stop: stop,
+                isFirst: isFirst,
+                isLast: isLast,
+                isSelected: isSelected,
+                routeColor: _foregroundColor(routeColor),
+                onTap: widget.onStopTap != null
+                    ? () {
+                        HapticFeedback.selectionClick();
+                        widget.onStopTap!(index, stop.latitude, stop.longitude);
+                      }
+                    : null,
+              );
+            }, childCount: stops.length),
           ),
       ],
     );
@@ -1069,7 +1070,9 @@ class _StopsSheetContentState extends State<_StopsSheetContent> {
                         : Icons.directions_bus_rounded,
                     customIcon: widget.route.modeIcon,
                     label: TransportListLocalizations.of(context).labelMode,
-                    value: widget.route.modeName ?? 'Bus',
+                    value:
+                        widget.route.modeName ??
+                        TransportListLocalizations.of(context).defaultModeBus,
                     color: _foregroundColor(routeColor),
                   ),
                 ),
@@ -1122,10 +1125,7 @@ class _SliverHeaderDelegate extends SliverPersistentHeaderDelegate {
     double shrinkOffset,
     bool overlapsContent,
   ) {
-    return Material(
-      color: Theme.of(context).colorScheme.surface,
-      child: child,
-    );
+    return Material(color: Theme.of(context).colorScheme.surface, child: child);
   }
 
   @override
@@ -1550,7 +1550,9 @@ class _SidePanelStopsContent extends StatelessWidget {
                         : Icons.directions_bus_rounded,
                     customIcon: route.modeIcon,
                     label: TransportListLocalizations.of(context).labelMode,
-                    value: route.modeName ?? 'Bus',
+                    value:
+                        route.modeName ??
+                        TransportListLocalizations.of(context).defaultModeBus,
                     color: routeColor,
                   ),
                 ),
@@ -1887,9 +1889,7 @@ class _RouteMapViewState extends State<_RouteMapView> {
   }
 
   void _reFitCamera() {
-    final refitted = _fitCamera.reFitCamera(
-      _camera ?? _initialCamera!,
-    );
+    final refitted = _fitCamera.reFitCamera(_camera ?? _initialCamera!);
     if (refitted != null) {
       setState(() {
         _camera = refitted;
@@ -1952,9 +1952,15 @@ class _RouteMapViewState extends State<_RouteMapView> {
                       onEngineChanged: (engine) {
                         mapEngineManager.setEngine(engine);
                       },
-                      settingsAppBarTitle: Localizations.localeOf(context).languageCode == 'es' ? 'Configuración del mapa' : 'Map Settings',
-                      settingsSectionTitle: Localizations.localeOf(context).languageCode == 'es' ? 'Tipo de mapa' : 'Map Type',
-                      settingsApplyButtonText: Localizations.localeOf(context).languageCode == 'es' ? 'Aplicar cambios' : 'Apply Changes',
+                      settingsAppBarTitle: TransportListLocalizations.of(
+                        context,
+                      ).mapSettingsTitle,
+                      settingsSectionTitle: TransportListLocalizations.of(
+                        context,
+                      ).mapTypeLabel,
+                      settingsApplyButtonText: TransportListLocalizations.of(
+                        context,
+                      ).applyChanges,
                     ),
                     const SizedBox(height: 8),
                   ],
@@ -1981,9 +1987,7 @@ class _RouteMapViewState extends State<_RouteMapView> {
                             child: Icon(
                               Icons.crop_free_rounded,
                               size: 22,
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.onSurface,
+                              color: Theme.of(context).colorScheme.onSurface,
                             ),
                           ),
                         ),
@@ -2108,8 +2112,7 @@ class _RouteIdentity extends StatelessWidget {
   }
 
   String? get _subtitle {
-    final hasLongName =
-        route.longName != null && route.longName!.isNotEmpty;
+    final hasLongName = route.longName != null && route.longName!.isNotEmpty;
     if (!hasLongName) return null;
     if (route.headsign != null && route.headsign!.isNotEmpty) {
       return route.headsign;

--- a/packages/screens/trufi_core_transport_list/lib/src/transport_list_content.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/transport_list_content.dart
@@ -168,7 +168,11 @@ class _TransportListContentState extends State<TransportListContent>
     }
 
     // Build grouped list: agency headers + route tiles
-    final listItems = _buildGroupedItems(state.filteredRoutes, _searchController.text.isNotEmpty);
+    final listItems = _buildGroupedItems(
+      state.filteredRoutes,
+      _searchController.text.isNotEmpty,
+      localization.otherAgencies,
+    );
 
     return Stack(
       children: [
@@ -254,6 +258,7 @@ class _TransportListContentState extends State<TransportListContent>
   static List<_GroupedListItem> _buildGroupedItems(
     List<TransportRoute> routes,
     bool isSearching,
+    String otherAgenciesLabel,
   ) {
     // During search, show flat list without headers
     if (isSearching) {
@@ -273,10 +278,12 @@ class _TransportListContentState extends State<TransportListContent>
     final items = <_GroupedListItem>[];
     for (final agency in sortedAgencies) {
       final agencyRoutes = grouped[agency]!;
-      items.add(_GroupedListItem.header(
-        agency.isEmpty ? 'Otros' : agency,
-        agencyRoutes.length,
-      ));
+      items.add(
+        _GroupedListItem.header(
+          agency.isEmpty ? otherAgenciesLabel : agency,
+          agencyRoutes.length,
+        ),
+      );
       for (final route in agencyRoutes) {
         items.add(_GroupedListItem.route(route));
       }
@@ -299,8 +306,11 @@ class _GroupedListItem {
     this.route,
   });
 
-  factory _GroupedListItem.header(String name, int count) =>
-      _GroupedListItem._(isHeader: true, headerName: name, headerRouteCount: count);
+  factory _GroupedListItem.header(String name, int count) => _GroupedListItem._(
+    isHeader: true,
+    headerName: name,
+    headerRouteCount: count,
+  );
 
   factory _GroupedListItem.route(TransportRoute route) =>
       _GroupedListItem._(isHeader: false, route: route);

--- a/packages/screens/trufi_core_transport_list/lib/src/widgets/transport_detail_sheet.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/widgets/transport_detail_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../../l10n/transport_list_localizations.dart';
 import '../models/transport_route.dart';
 
 /// Bottom sheet showing transport route stops with modern timeline design
@@ -130,7 +131,13 @@ class _StopTimelineItem extends StatelessWidget {
                                     borderRadius: BorderRadius.circular(6),
                                   ),
                                   child: Text(
-                                    isFirst ? 'Start' : 'End',
+                                    isFirst
+                                        ? TransportListLocalizations.of(
+                                            context,
+                                          ).stopStart
+                                        : TransportListLocalizations.of(
+                                            context,
+                                          ).stopEnd,
                                     style: theme.textTheme.labelSmall?.copyWith(
                                       color: routeColor,
                                       fontWeight: FontWeight.w600,
@@ -316,7 +323,7 @@ class _EmptyStopsState extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             Text(
-              Localizations.localeOf(context).languageCode == 'es' ? 'Sin paradas disponibles' : 'No stops available',
+              TransportListLocalizations.of(context).noStopsAvailable,
               style: theme.textTheme.titleSmall?.copyWith(
                 color: colorScheme.onSurfaceVariant,
                 fontWeight: FontWeight.w500,
@@ -324,7 +331,7 @@ class _EmptyStopsState extends StatelessWidget {
             ),
             const SizedBox(height: 4),
             Text(
-              'Stop information is not available for this route',
+              TransportListLocalizations.of(context).stopInfoNotAvailable,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
               ),


### PR DESCRIPTION
Part of #871 — transport_list slice.

Replaces the 10 hardcoded strings in this package with `TransportListLocalizations` lookups: the Spanish-only `'Otros'` group header, the `languageCode == 'es'` share/map-settings ternaries (German fell through to English), the `'Bus'` default mode label, `Start`/`End` stop markers and the stop-info empty states.

- 9 new keys in en/es/de (`otherAgencies`, `shareRouteMessage` with a `{uri}` placeholder, `defaultModeBus`, `mapSettingsTitle`, `mapTypeLabel`, `applyChanges`, `stopStart`, `stopEnd`, `stopInfoNotAvailable`); reused the existing `noStopsAvailable` key instead of duplicating it.
- No public API changes (the `'Otros'` fix threads the label through a private static helper).
- Whitespace-only hunks are dart-format normalization of the edited files (they predate the tall-style formatter).

Note for merge order: #933 also touches `transport_list_content.dart`; whichever lands second needs a trivial rebase.

Verification: `melos run l10n --no-select` leaves a clean tree (CI's Translation Check replicated locally), `flutter analyze` clean, 3/3 package tests pass.
