### PR TITLE
fix(saved_places): localize hardcoded strings (#871)

### DIFF
--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_de.arb
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_de.arb
@@ -31,5 +31,7 @@
   "locationRequired": "Standort ist erforderlich",
   "locationSelected": "Standort ausgewählt",
   "tapToSelectLocation": "Tippen, um auf der Karte auszuwählen",
-  "change": "Ändern"
+  "change": "Ändern",
+  "errorLoadingPlaces": "Fehler beim Laden der Orte",
+  "retry": "Erneut versuchen"
 }

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_en.arb
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_en.arb
@@ -40,5 +40,7 @@
   "locationRequired": "Location is required",
   "locationSelected": "Location selected",
   "tapToSelectLocation": "Tap to select on map",
-  "change": "Change"
+  "change": "Change",
+  "errorLoadingPlaces": "Error loading places",
+  "retry": "Retry"
 }

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_es.arb
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_es.arb
@@ -31,5 +31,7 @@
   "locationRequired": "La ubicación es requerida",
   "locationSelected": "Ubicación seleccionada",
   "tapToSelectLocation": "Toca para seleccionar en el mapa",
-  "change": "Cambiar"
+  "change": "Cambiar",
+  "errorLoadingPlaces": "Error al cargar lugares",
+  "retry": "Reintentar"
 }

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations.dart
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations.dart
@@ -294,6 +294,18 @@ abstract class SavedPlacesLocalizations {
   /// In en, this message translates to:
   /// **'Change'**
   String get change;
+
+  /// No description provided for @errorLoadingPlaces.
+  ///
+  /// In en, this message translates to:
+  /// **'Error loading places'**
+  String get errorLoadingPlaces;
+
+  /// No description provided for @retry.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get retry;
 }
 
 class _SavedPlacesLocalizationsDelegate

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_de.dart
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_de.dart
@@ -105,4 +105,10 @@ class SavedPlacesLocalizationsDe extends SavedPlacesLocalizations {
 
   @override
   String get change => 'Ändern';
+
+  @override
+  String get errorLoadingPlaces => 'Fehler beim Laden der Orte';
+
+  @override
+  String get retry => 'Erneut versuchen';
 }

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_en.dart
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_en.dart
@@ -105,4 +105,10 @@ class SavedPlacesLocalizationsEn extends SavedPlacesLocalizations {
 
   @override
   String get change => 'Change';
+
+  @override
+  String get errorLoadingPlaces => 'Error loading places';
+
+  @override
+  String get retry => 'Retry';
 }

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_es.dart
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_es.dart
@@ -105,4 +105,10 @@ class SavedPlacesLocalizationsEs extends SavedPlacesLocalizations {
 
   @override
   String get change => 'Cambiar';
+
+  @override
+  String get errorLoadingPlaces => 'Error al cargar lugares';
+
+  @override
+  String get retry => 'Reintentar';
 }

--- a/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_place_tile.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_place_tile.dart
@@ -155,12 +155,12 @@ class SavedPlaceTile extends StatelessWidget {
     }
   }
 
-  String _getDisplayName(SavedPlacesLocalizations? localization) {
+  String _getDisplayName(SavedPlacesLocalizations localization) {
     if (place.type == SavedPlaceType.home && !place.name.contains('_')) {
-      return localization?.home ?? 'Home';
+      return localization.home;
     }
     if (place.type == SavedPlaceType.work && !place.name.contains('_')) {
-      return localization?.work ?? 'Work';
+      return localization.work;
     }
     return place.name;
   }
@@ -213,9 +213,13 @@ class _FavoriteButton extends StatelessWidget {
 class _MoreOptionsButton extends StatelessWidget {
   final VoidCallback? onEdit;
   final VoidCallback? onDelete;
-  final SavedPlacesLocalizations? localization;
+  final SavedPlacesLocalizations localization;
 
-  const _MoreOptionsButton({this.onEdit, this.onDelete, this.localization});
+  const _MoreOptionsButton({
+    this.onEdit,
+    this.onDelete,
+    required this.localization,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -265,7 +269,7 @@ class _MoreOptionsButton extends StatelessWidget {
                   ),
                   const SizedBox(width: 12),
                   Text(
-                    localization?.editPlace ?? 'Edit',
+                    localization.editPlace,
                     style: theme.textTheme.bodyMedium?.copyWith(
                       fontWeight: FontWeight.w500,
                     ),
@@ -294,7 +298,7 @@ class _MoreOptionsButton extends StatelessWidget {
                   ),
                   const SizedBox(width: 12),
                   Text(
-                    localization?.removePlace ?? 'Remove',
+                    localization.removePlace,
                     style: theme.textTheme.bodyMedium?.copyWith(
                       color: colorScheme.error,
                       fontWeight: FontWeight.w500,

--- a/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_places_list.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_places_list.dart
@@ -65,7 +65,9 @@ class _SavedPlacesListState extends State<SavedPlacesList>
 
         if (state.status == SavedPlacesStatus.error) {
           return _ErrorState(
-            message: state.errorMessage ?? (Localizations.localeOf(context).languageCode == 'es' ? 'Error al cargar lugares' : 'Error loading places'),
+            message:
+                state.errorMessage ??
+                SavedPlacesLocalizations.of(context).errorLoadingPlaces,
             onRetry: () => context.read<SavedPlacesCubit>().initialize(),
           );
         }
@@ -688,7 +690,7 @@ class _ErrorState extends StatelessWidget {
               FilledButton.icon(
                 onPressed: onRetry,
                 icon: const Icon(Icons.refresh_rounded, size: 18),
-                label: Text(Localizations.localeOf(context).languageCode == 'es' ? 'Reintentar' : 'Retry'),
+                label: Text(SavedPlacesLocalizations.of(context).retry),
                 style: FilledButton.styleFrom(
                   padding: const EdgeInsets.symmetric(
                     horizontal: 24,


### PR DESCRIPTION
Part of #871 — saved_places slice.

Fixes the 6 hardcoded strings in this package. Interesting find: the four tile literals (`'Home'`, `'Work'`, `'Edit'`, `'Remove'`) were dead English fallbacks — `SavedPlacesLocalizations.of(context)` is non-nullable (`nullable-getter: false`) but two private members were typed nullable, keeping `?? 'Home'`-style fallbacks alive. Made those private members non-nullable and reused the existing `home`/`work`/`editPlace`/`removePlace` keys, so rendered text is unchanged.

- New keys `errorLoadingPlaces` and `retry` in en/es/de replace the `languageCode == 'es'` ternaries in the list error state.
- No public API changes (all edited members are library-private).

Known follow-up (pre-existing, outside this slice): `SavedPlacesCubit` stores raw `e.toString()` in `state.errorMessage` and the list shows it verbatim on real load failures — that path still surfaces an unlocalized exception string.

Verification: Translation Check replicated locally (clean tree after `melos run l10n --no-select`), `flutter analyze` clean, 10/10 package tests pass.
