### PR TITLE
fix(ui): localize init screen and router strings (#871)

### DIFF
--- a/packages/trufi_core_ui/lib/l10n/core_de.arb
+++ b/packages/trufi_core_ui/lib/l10n/core_de.arb
@@ -19,5 +19,13 @@
   "actionGoHome": "Zur Startseite",
   "titleError": "Fehler",
   "unreadCount": "{count} ungelesen",
-  "markAllAsRead": "Alle als gelesen markieren"
+  "markAllAsRead": "Alle als gelesen markieren",
+  "initStepStarting": "Wird gestartet",
+  "initStepInitializing": "Wird initialisiert",
+  "initStepLoadingMaps": "Karten werden geladen",
+  "initStepLoadingRoutes": "Routen werden geladen",
+  "initStepAlmostReady": "Fast fertig",
+  "errorUnableToStart": "Start nicht möglich",
+  "errorUnexpected": "Ein unerwarteter Fehler ist aufgetreten",
+  "poweredByTrufi": "Powered by Trufi Association"
 }

--- a/packages/trufi_core_ui/lib/l10n/core_en.arb
+++ b/packages/trufi_core_ui/lib/l10n/core_en.arb
@@ -100,5 +100,45 @@
   "markAllAsRead": "Mark all as read",
   "@markAllAsRead": {
     "description": "Button to mark all notifications as read"
+  },
+
+  "initStepStarting": "Starting",
+  "@initStepStarting": {
+    "description": "Init screen step: the app is starting"
+  },
+
+  "initStepInitializing": "Initializing",
+  "@initStepInitializing": {
+    "description": "Init screen step: initializing app services"
+  },
+
+  "initStepLoadingMaps": "Loading maps",
+  "@initStepLoadingMaps": {
+    "description": "Init screen step: loading map engines"
+  },
+
+  "initStepLoadingRoutes": "Loading routes",
+  "@initStepLoadingRoutes": {
+    "description": "Init screen step: loading routing engines"
+  },
+
+  "initStepAlmostReady": "Almost ready",
+  "@initStepAlmostReady": {
+    "description": "Init screen step: preparing screens"
+  },
+
+  "errorUnableToStart": "Unable to start",
+  "@errorUnableToStart": {
+    "description": "Title shown when app initialization fails"
+  },
+
+  "errorUnexpected": "An unexpected error occurred",
+  "@errorUnexpected": {
+    "description": "Fallback message when an error has no details"
+  },
+
+  "poweredByTrufi": "Powered by Trufi Association",
+  "@poweredByTrufi": {
+    "description": "Brand tagline in the drawer footer; keep identical in all languages"
   }
 }

--- a/packages/trufi_core_ui/lib/l10n/core_es.arb
+++ b/packages/trufi_core_ui/lib/l10n/core_es.arb
@@ -19,5 +19,13 @@
   "actionGoHome": "Ir al inicio",
   "titleError": "Error",
   "unreadCount": "{count} sin leer",
-  "markAllAsRead": "Marcar todo como leído"
+  "markAllAsRead": "Marcar todo como leído",
+  "initStepStarting": "Iniciando",
+  "initStepInitializing": "Inicializando",
+  "initStepLoadingMaps": "Cargando mapas",
+  "initStepLoadingRoutes": "Cargando rutas",
+  "initStepAlmostReady": "Casi listo",
+  "errorUnableToStart": "No se pudo iniciar",
+  "errorUnexpected": "Ocurrió un error inesperado",
+  "poweredByTrufi": "Powered by Trufi Association"
 }

--- a/packages/trufi_core_ui/lib/src/app_initializer/app_initializer.dart
+++ b/packages/trufi_core_ui/lib/src/app_initializer/app_initializer.dart
@@ -3,8 +3,10 @@ import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:trufi_core_maps/trufi_core_maps.dart' show MapEngineManager;
 import 'package:trufi_core_routing/trufi_core_routing.dart'
     show RoutingEngineManager;
-import 'package:trufi_core_utils/trufi_core_utils.dart' show OverlayManager;
+import 'package:trufi_core_utils/trufi_core_utils.dart'
+    show LocaleManager, OverlayManager;
 
+import '../l10n/core_localizations.dart';
 import 'default_init_screen.dart';
 
 /// Widget that initializes screens and managers before showing the app.
@@ -143,9 +145,15 @@ class _AppInitializerState extends State<AppInitializer> {
           onRetry: retry,
         );
 
+    // This MaterialApp lives OUTSIDE the main _TrufiMaterialApp, so it must
+    // register its own localizations and resolve the locale from the
+    // LocaleManager provided above it for the init screen to be localized.
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       theme: widget.theme,
+      locale: LocaleManager.watch(context).currentLocale,
+      supportedLocales: CoreLocalizations.supportedLocales,
+      localizationsDelegates: CoreLocalizations.localizationsDelegates,
       home: builder(
         context,
         _hasError ? null : _currentStep,

--- a/packages/trufi_core_ui/lib/src/app_initializer/default_init_screen.dart
+++ b/packages/trufi_core_ui/lib/src/app_initializer/default_init_screen.dart
@@ -3,6 +3,8 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 
+import '../l10n/core_localizations.dart';
+
 /// Beautiful default initialization screen with animations.
 class DefaultInitScreen extends StatefulWidget {
   final AppInitStep? currentStep;
@@ -19,7 +21,7 @@ class DefaultInitScreen extends StatefulWidget {
   final Widget? topWidget;
 
   /// Optional function to override the display text for each init step.
-  /// If null, English defaults are used.
+  /// If null, localized defaults are used.
   final String Function(AppInitStep step)? stepTextBuilder;
 
   const DefaultInitScreen({
@@ -83,16 +85,22 @@ class _DefaultInitScreenState extends State<DefaultInitScreen>
     return _steps.indexOf(widget.currentStep!);
   }
 
+  /// Resolves [CoreLocalizations], falling back to English when this screen
+  /// is mounted without the CoreLocalizations delegate registered.
+  CoreLocalizations get _l10n =>
+      Localizations.of<CoreLocalizations>(context, CoreLocalizations) ??
+      lookupCoreLocalizations(const Locale('en'));
+
   String _stepToDisplayText(AppInitStep step) {
     if (widget.stepTextBuilder != null) {
       return widget.stepTextBuilder!(step);
     }
     return switch (step) {
-      AppInitStep.starting => Localizations.localeOf(context).languageCode == 'es' ? 'Iniciando' : 'Starting',
-      AppInitStep.initializingOverlays => Localizations.localeOf(context).languageCode == 'es' ? 'Inicializando' : 'Initializing',
-      AppInitStep.loadingMaps => Localizations.localeOf(context).languageCode == 'es' ? 'Cargando mapas' : 'Loading maps',
-      AppInitStep.loadingRoutes => Localizations.localeOf(context).languageCode == 'es' ? 'Cargando rutas' : 'Loading routes',
-      AppInitStep.preparingScreens => 'Almost ready',
+      AppInitStep.starting => _l10n.initStepStarting,
+      AppInitStep.initializingOverlays => _l10n.initStepInitializing,
+      AppInitStep.loadingMaps => _l10n.initStepLoadingMaps,
+      AppInitStep.loadingRoutes => _l10n.initStepLoadingRoutes,
+      AppInitStep.preparingScreens => _l10n.initStepAlmostReady,
     };
   }
 
@@ -265,7 +273,7 @@ class _DefaultInitScreenState extends State<DefaultInitScreen>
           child: Text(
             widget.currentStep != null
                 ? _stepToDisplayText(widget.currentStep!)
-                : Localizations.localeOf(context).languageCode == 'es' ? 'Cargando...' : 'Loading...',
+                : _l10n.appLoading,
             key: ValueKey(widget.currentStep),
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
               color: colorScheme.onSurface.withValues(alpha: 0.8),
@@ -384,7 +392,7 @@ class _DefaultInitScreenState extends State<DefaultInitScreen>
 
         // Error title
         Text(
-          'Unable to start',
+          _l10n.errorUnableToStart,
           style: Theme.of(
             context,
           ).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
@@ -399,7 +407,7 @@ class _DefaultInitScreenState extends State<DefaultInitScreen>
             borderRadius: BorderRadius.circular(12),
           ),
           child: Text(
-            widget.errorMessage ?? 'An unexpected error occurred',
+            widget.errorMessage ?? _l10n.errorUnexpected,
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               color: colorScheme.onSurface.withValues(alpha: 0.8),
@@ -412,7 +420,7 @@ class _DefaultInitScreenState extends State<DefaultInitScreen>
         FilledButton.icon(
           onPressed: widget.onRetry,
           icon: const Icon(Icons.refresh_rounded),
-          label: Text(Localizations.localeOf(context).languageCode == 'es' ? 'Reintentar' : 'Try again'),
+          label: Text(_l10n.actionRetry),
           style: FilledButton.styleFrom(
             padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
             shape: RoundedRectangleBorder(

--- a/packages/trufi_core_ui/lib/src/l10n/core_localizations.dart
+++ b/packages/trufi_core_ui/lib/src/l10n/core_localizations.dart
@@ -213,6 +213,54 @@ abstract class CoreLocalizations {
   /// In en, this message translates to:
   /// **'Mark all as read'**
   String get markAllAsRead;
+
+  /// Init screen step: the app is starting
+  ///
+  /// In en, this message translates to:
+  /// **'Starting'**
+  String get initStepStarting;
+
+  /// Init screen step: initializing app services
+  ///
+  /// In en, this message translates to:
+  /// **'Initializing'**
+  String get initStepInitializing;
+
+  /// Init screen step: loading map engines
+  ///
+  /// In en, this message translates to:
+  /// **'Loading maps'**
+  String get initStepLoadingMaps;
+
+  /// Init screen step: loading routing engines
+  ///
+  /// In en, this message translates to:
+  /// **'Loading routes'**
+  String get initStepLoadingRoutes;
+
+  /// Init screen step: preparing screens
+  ///
+  /// In en, this message translates to:
+  /// **'Almost ready'**
+  String get initStepAlmostReady;
+
+  /// Title shown when app initialization fails
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to start'**
+  String get errorUnableToStart;
+
+  /// Fallback message when an error has no details
+  ///
+  /// In en, this message translates to:
+  /// **'An unexpected error occurred'**
+  String get errorUnexpected;
+
+  /// Brand tagline in the drawer footer; keep identical in all languages
+  ///
+  /// In en, this message translates to:
+  /// **'Powered by Trufi Association'**
+  String get poweredByTrufi;
 }
 
 class _CoreLocalizationsDelegate

--- a/packages/trufi_core_ui/lib/src/l10n/core_localizations_de.dart
+++ b/packages/trufi_core_ui/lib/src/l10n/core_localizations_de.dart
@@ -67,4 +67,28 @@ class CoreLocalizationsDe extends CoreLocalizations {
 
   @override
   String get markAllAsRead => 'Alle als gelesen markieren';
+
+  @override
+  String get initStepStarting => 'Wird gestartet';
+
+  @override
+  String get initStepInitializing => 'Wird initialisiert';
+
+  @override
+  String get initStepLoadingMaps => 'Karten werden geladen';
+
+  @override
+  String get initStepLoadingRoutes => 'Routen werden geladen';
+
+  @override
+  String get initStepAlmostReady => 'Fast fertig';
+
+  @override
+  String get errorUnableToStart => 'Start nicht möglich';
+
+  @override
+  String get errorUnexpected => 'Ein unerwarteter Fehler ist aufgetreten';
+
+  @override
+  String get poweredByTrufi => 'Powered by Trufi Association';
 }

--- a/packages/trufi_core_ui/lib/src/l10n/core_localizations_en.dart
+++ b/packages/trufi_core_ui/lib/src/l10n/core_localizations_en.dart
@@ -66,4 +66,28 @@ class CoreLocalizationsEn extends CoreLocalizations {
 
   @override
   String get markAllAsRead => 'Mark all as read';
+
+  @override
+  String get initStepStarting => 'Starting';
+
+  @override
+  String get initStepInitializing => 'Initializing';
+
+  @override
+  String get initStepLoadingMaps => 'Loading maps';
+
+  @override
+  String get initStepLoadingRoutes => 'Loading routes';
+
+  @override
+  String get initStepAlmostReady => 'Almost ready';
+
+  @override
+  String get errorUnableToStart => 'Unable to start';
+
+  @override
+  String get errorUnexpected => 'An unexpected error occurred';
+
+  @override
+  String get poweredByTrufi => 'Powered by Trufi Association';
 }

--- a/packages/trufi_core_ui/lib/src/l10n/core_localizations_es.dart
+++ b/packages/trufi_core_ui/lib/src/l10n/core_localizations_es.dart
@@ -66,4 +66,28 @@ class CoreLocalizationsEs extends CoreLocalizations {
 
   @override
   String get markAllAsRead => 'Marcar todo como leído';
+
+  @override
+  String get initStepStarting => 'Iniciando';
+
+  @override
+  String get initStepInitializing => 'Inicializando';
+
+  @override
+  String get initStepLoadingMaps => 'Cargando mapas';
+
+  @override
+  String get initStepLoadingRoutes => 'Cargando rutas';
+
+  @override
+  String get initStepAlmostReady => 'Casi listo';
+
+  @override
+  String get errorUnableToStart => 'No se pudo iniciar';
+
+  @override
+  String get errorUnexpected => 'Ocurrió un error inesperado';
+
+  @override
+  String get poweredByTrufi => 'Powered by Trufi Association';
 }

--- a/packages/trufi_core_ui/lib/src/router/app_router.dart
+++ b/packages/trufi_core_ui/lib/src/router/app_router.dart
@@ -6,6 +6,8 @@ import 'package:trufi_core_utils/trufi_core_utils.dart'
     show PackageInfoPlatform;
 import 'package:url_launcher/url_launcher.dart';
 
+import '../l10n/core_localizations.dart';
+
 /// Application router using GoRouter with dynamic screen support
 class AppRouter {
   final List<TrufiScreen> screens;
@@ -181,7 +183,7 @@ class AppShell extends StatelessWidget {
                 // Placeholder para acciones adicionales si se necesitan
                 IconButton(
                   icon: const Icon(Icons.info_outline),
-                  tooltip: 'About',
+                  tooltip: CoreLocalizations.of(context).navAbout,
                   onPressed: () {
                     final aboutScreen = screens.firstWhere(
                       (s) => s.id == 'about',
@@ -575,7 +577,7 @@ class _DrawerFooter extends StatelessWidget {
           const SizedBox(height: 12),
           // Powered by text
           Text(
-            'Powered by Trufi Association',
+            CoreLocalizations.of(context).poweredByTrufi,
             style: theme.textTheme.bodySmall?.copyWith(
               color: colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
               fontSize: 11,
@@ -623,26 +625,16 @@ class ErrorScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = CoreLocalizations.of(context);
     return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          Localizations.localeOf(context).languageCode == 'es'
-              ? 'Error'
-              : 'Error',
-        ),
-      ),
+      appBar: AppBar(title: Text(l10n.titleError)),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             const Icon(Icons.error_outline, size: 64, color: Colors.red),
             const SizedBox(height: 16),
-            Text(
-              Localizations.localeOf(context).languageCode == 'es'
-                  ? 'Página no encontrada'
-                  : 'Page not found',
-              style: TextStyle(fontSize: 24),
-            ),
+            Text(l10n.errorPageNotFound, style: TextStyle(fontSize: 24)),
             const SizedBox(height: 8),
             if (error != null)
               Text(
@@ -652,11 +644,7 @@ class ErrorScreen extends StatelessWidget {
             const SizedBox(height: 24),
             ElevatedButton(
               onPressed: () => context.go('/'),
-              child: Text(
-                Localizations.localeOf(context).languageCode == 'es'
-                    ? 'Ir al inicio'
-                    : 'Go Home',
-              ),
+              child: Text(l10n.actionGoHome),
             ),
           ],
         ),


### PR DESCRIPTION
Part of #871 — trufi_core_ui slice (init screen + router), 14 strings.

This one uncovered a real bug beyond the literals: `DefaultInitScreen` renders inside `AppInitializer`'s **inner** `MaterialApp`, which had no delegates, no locale and default `supportedLocales` — so even the existing `languageCode == 'es'` ternaries could never fire on the splash. The inner MaterialApp now gets `LocaleManager`'s locale plus `CoreLocalizations.localizationsDelegates`, and `DefaultInitScreen` resolves l10n defensively (English fallback if the delegate is absent, since it is publicly exported).

- 8 new keys (`initStepStarting/Initializing/LoadingMaps/LoadingRoutes/AlmostReady`, `errorUnableToStart`, `errorUnexpected`, `poweredByTrufi`); reused `appLoading`, `actionRetry`, `navAbout`, `titleError`, `errorPageNotFound`, `actionGoHome`.
- `poweredByTrufi` keeps the identical brand tagline in all three locales (apps can override).
- Two wording notes for review: the retry button reuses `actionRetry`, so en changes `'Try again'` → `'Retry'` (es already matched exactly); and for app locales outside {de,en,es} the splash now falls back to the first supported locale (`de`) instead of hardcoded English — if that matters we can add a `localeResolutionCallback` in a follow-up.

Verification: Translation Check replicated locally, `flutter analyze` clean (package has no test dir).
