### PR TITLE
fix(navigation): localize cubit and converter strings (#871)

### DIFF
--- a/packages/trufi_core_navigation/lib/l10n/navigation_de.arb
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_de.arb
@@ -26,5 +26,6 @@
   "navLocationDisabled": "Standortdienste sind deaktiviert. Bitte aktivieren Sie diese.",
   "navOrigin": "Startpunkt",
   "navTransfer": "Umstieg",
-  "navDestination": "Ziel"
+  "navDestination": "Ziel",
+  "navRoute": "Route"
 }

--- a/packages/trufi_core_navigation/lib/l10n/navigation_en.arb
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_en.arb
@@ -59,5 +59,7 @@
   "navTransfer": "Transfer",
   "@navTransfer": { "description": "Label for a transfer point between routes" },
   "navDestination": "Destination",
-  "@navDestination": { "description": "Label for the route destination point" }
+  "@navDestination": { "description": "Label for the route destination point" },
+  "navRoute": "Route",
+  "@navRoute": { "description": "Fallback name for a route without a name" }
 }

--- a/packages/trufi_core_navigation/lib/l10n/navigation_es.arb
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_es.arb
@@ -26,5 +26,6 @@
   "navLocationDisabled": "Los servicios de ubicación están deshabilitados. Habilítalos.",
   "navOrigin": "Origen",
   "navTransfer": "Transbordo",
-  "navDestination": "Destino"
+  "navDestination": "Destino",
+  "navRoute": "Ruta"
 }

--- a/packages/trufi_core_navigation/lib/l10n/navigation_localizations.dart
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_localizations.dart
@@ -264,6 +264,12 @@ abstract class NavigationLocalizations {
   /// In en, this message translates to:
   /// **'Destination'**
   String get navDestination;
+
+  /// Fallback name for a route without a name
+  ///
+  /// In en, this message translates to:
+  /// **'Route'**
+  String get navRoute;
 }
 
 class _NavigationLocalizationsDelegate

--- a/packages/trufi_core_navigation/lib/l10n/navigation_localizations_de.dart
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_localizations_de.dart
@@ -96,4 +96,7 @@ class NavigationLocalizationsDe extends NavigationLocalizations {
 
   @override
   String get navDestination => 'Ziel';
+
+  @override
+  String get navRoute => 'Route';
 }

--- a/packages/trufi_core_navigation/lib/l10n/navigation_localizations_en.dart
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_localizations_en.dart
@@ -95,4 +95,7 @@ class NavigationLocalizationsEn extends NavigationLocalizations {
 
   @override
   String get navDestination => 'Destination';
+
+  @override
+  String get navRoute => 'Route';
 }

--- a/packages/trufi_core_navigation/lib/l10n/navigation_localizations_es.dart
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_localizations_es.dart
@@ -96,4 +96,7 @@ class NavigationLocalizationsEs extends NavigationLocalizations {
 
   @override
   String get navDestination => 'Destino';
+
+  @override
+  String get navRoute => 'Ruta';
 }

--- a/packages/trufi_core_navigation/lib/src/cubit/navigation_cubit.dart
+++ b/packages/trufi_core_navigation/lib/src/cubit/navigation_cubit.dart
@@ -28,7 +28,7 @@ class NavigationCubit extends Cubit<NavigationState> {
       emit(
         state.copyWith(
           status: NavigationStatus.error,
-          errorMessage: _getPermissionErrorMessage(permissionStatus),
+          errorType: _getPermissionError(permissionStatus),
         ),
       );
       return;
@@ -43,7 +43,7 @@ class NavigationCubit extends Cubit<NavigationState> {
       emit(
         state.copyWith(
           status: NavigationStatus.error,
-          errorMessage: 'Could not start location tracking',
+          errorType: NavigationError.trackingStartFailed,
         ),
       );
       return;
@@ -282,7 +282,7 @@ class NavigationCubit extends Cubit<NavigationState> {
         remainingStops: 0,
         currentInstruction: NavigationInstruction(
           type: InstructionType.arriveDestination,
-          primaryText: 'You have arrived',
+          primaryTextKey: InstructionTextKey.youHaveArrived,
           stopName: route?.stops.lastOrNull?.name,
         ),
         nextInstruction: null,
@@ -447,9 +447,9 @@ class NavigationCubit extends Cubit<NavigationState> {
     int stopIndex,
   ) {
     if (stopIndex >= route.stops.length) {
-      return NavigationInstruction(
+      return const NavigationInstruction(
         type: InstructionType.arriveDestination,
-        primaryText: 'Final destination',
+        primaryTextKey: InstructionTextKey.finalDestination,
       );
     }
 
@@ -461,14 +461,14 @@ class NavigationCubit extends Cubit<NavigationState> {
     );
   }
 
-  String _getPermissionErrorMessage(LocationPermissionStatus status) {
+  NavigationError? _getPermissionError(LocationPermissionStatus status) {
     return switch (status) {
-      LocationPermissionStatus.denied => 'Location permission denied',
+      LocationPermissionStatus.denied => NavigationError.permissionDenied,
       LocationPermissionStatus.deniedForever =>
-        'Location permission permanently denied. Please enable in settings.',
+        NavigationError.permissionDeniedForever,
       LocationPermissionStatus.serviceDisabled =>
-        'Location services are disabled. Please enable them.',
-      LocationPermissionStatus.granted => '',
+        NavigationError.serviceDisabled,
+      LocationPermissionStatus.granted => null,
     };
   }
 

--- a/packages/trufi_core_navigation/lib/src/models/navigation_instruction.dart
+++ b/packages/trufi_core_navigation/lib/src/models/navigation_instruction.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:latlong2/latlong.dart';
 
+import '../../l10n/navigation_localizations.dart';
+
 /// Type of navigation instruction.
 enum InstructionType {
   // Transit instructions
@@ -42,13 +44,35 @@ enum InstructionType {
   depart,
 }
 
+/// Localizable text key for instruction texts that are produced in layers
+/// without a [BuildContext] (e.g. the navigation cubit).
+///
+/// Resolved to a localized string at the widget layer via
+/// [NavigationInstruction.resolvedPrimaryText].
+enum InstructionTextKey {
+  /// "You have arrived" — shown when the destination is reached.
+  youHaveArrived,
+
+  /// "Final destination" — preview label for the last stop.
+  finalDestination,
+}
+
 /// A navigation instruction to display to the user.
 class NavigationInstruction {
   /// The type of instruction.
   final InstructionType type;
 
   /// Primary text to display (e.g., "Turn left onto Main Street").
+  ///
+  /// Widgets should render [resolvedPrimaryText] instead of reading this
+  /// field directly, so that [primaryTextKey] based texts get localized.
   final String primaryText;
+
+  /// Localizable key for the primary text.
+  ///
+  /// When set, it takes precedence over [primaryText] in
+  /// [resolvedPrimaryText]. Used by layers without a [BuildContext].
+  final InstructionTextKey? primaryTextKey;
 
   /// Secondary text (e.g., "in 50m").
   final String? secondaryText;
@@ -79,7 +103,8 @@ class NavigationInstruction {
 
   const NavigationInstruction({
     required this.type,
-    required this.primaryText,
+    this.primaryText = '',
+    this.primaryTextKey,
     this.secondaryText,
     this.stopName,
     this.distance,
@@ -90,6 +115,16 @@ class NavigationInstruction {
     this.routeShortName,
     this.modeIcon,
   });
+
+  /// The primary text to render, resolving [primaryTextKey] to a localized
+  /// string when set and falling back to [primaryText] otherwise.
+  String resolvedPrimaryText(NavigationLocalizations localizations) {
+    return switch (primaryTextKey) {
+      InstructionTextKey.youHaveArrived => localizations.navArrivedShort,
+      InstructionTextKey.finalDestination => localizations.navFinalDestination,
+      null => primaryText,
+    };
+  }
 
   /// Get the appropriate icon for this instruction type.
   IconData get icon {
@@ -128,6 +163,7 @@ class NavigationInstruction {
   NavigationInstruction copyWith({
     InstructionType? type,
     String? primaryText,
+    InstructionTextKey? primaryTextKey,
     String? secondaryText,
     String? stopName,
     double? distance,
@@ -141,6 +177,7 @@ class NavigationInstruction {
     return NavigationInstruction(
       type: type ?? this.type,
       primaryText: primaryText ?? this.primaryText,
+      primaryTextKey: primaryTextKey ?? this.primaryTextKey,
       secondaryText: secondaryText ?? this.secondaryText,
       stopName: stopName ?? this.stopName,
       distance: distance ?? this.distance,

--- a/packages/trufi_core_navigation/lib/src/models/navigation_state.dart
+++ b/packages/trufi_core_navigation/lib/src/models/navigation_state.dart
@@ -2,6 +2,7 @@ import 'package:equatable/equatable.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:trufi_core_utils/trufi_core_utils.dart';
 
+import '../../l10n/navigation_localizations.dart';
 import 'navigation_instruction.dart';
 
 /// Status of the navigation session.
@@ -32,6 +33,40 @@ enum NavigationSegmentType {
 
   /// Walking between stops or to destination.
   walking,
+}
+
+/// Machine-readable navigation error.
+///
+/// Carried in [NavigationState.errorType] by [NavigationCubit], which has no
+/// [BuildContext], and resolved to localized text at the widget layer via
+/// [NavigationErrorLocalization.localizedMessage].
+enum NavigationError {
+  /// Location tracking could not be started.
+  trackingStartFailed,
+
+  /// Location permission was denied.
+  permissionDenied,
+
+  /// Location permission was permanently denied.
+  permissionDeniedForever,
+
+  /// Location services are disabled on the device.
+  serviceDisabled,
+}
+
+/// Resolves a [NavigationError] to a localized, user-visible message.
+extension NavigationErrorLocalization on NavigationError {
+  /// The localized message for this error.
+  String localizedMessage(NavigationLocalizations localizations) {
+    return switch (this) {
+      NavigationError.trackingStartFailed =>
+        localizations.navCouldNotStartTracking,
+      NavigationError.permissionDenied => localizations.navPermissionDenied,
+      NavigationError.permissionDeniedForever =>
+        localizations.navPermissionPermanentlyDenied,
+      NavigationError.serviceDisabled => localizations.navLocationDisabled,
+    };
+  }
 }
 
 /// Represents a stop in navigation context.
@@ -176,7 +211,16 @@ class NavigationState extends Equatable {
   final Duration? etaToDestination;
 
   /// Error message if status is error.
+  ///
+  /// Prefer [errorType] for errors emitted by the cubit; this free-form
+  /// message remains for externally supplied error texts.
   final String? errorMessage;
+
+  /// Machine-readable error if status is error.
+  ///
+  /// Resolved to a localized message at the widget layer via
+  /// [NavigationErrorLocalization.localizedMessage].
+  final NavigationError? errorType;
 
   /// Whether user is off the route.
   final bool isOffRoute;
@@ -208,6 +252,7 @@ class NavigationState extends Equatable {
     this.etaToNextStop,
     this.etaToDestination,
     this.errorMessage,
+    this.errorType,
     this.isOffRoute = false,
     this.distanceFromRoute,
     this.isGpsWeak = false,
@@ -266,6 +311,7 @@ class NavigationState extends Equatable {
     Duration? etaToNextStop,
     Duration? etaToDestination,
     String? errorMessage,
+    NavigationError? errorType,
     bool? isOffRoute,
     double? distanceFromRoute,
     bool? isGpsWeak,
@@ -287,6 +333,7 @@ class NavigationState extends Equatable {
       etaToNextStop: etaToNextStop ?? this.etaToNextStop,
       etaToDestination: etaToDestination ?? this.etaToDestination,
       errorMessage: errorMessage ?? this.errorMessage,
+      errorType: errorType ?? this.errorType,
       isOffRoute: isOffRoute ?? this.isOffRoute,
       distanceFromRoute: distanceFromRoute ?? this.distanceFromRoute,
       isGpsWeak: isGpsWeak ?? this.isGpsWeak,
@@ -322,6 +369,7 @@ class NavigationState extends Equatable {
     etaToNextStop,
     etaToDestination,
     errorMessage,
+    errorType,
     isOffRoute,
     distanceFromRoute,
     isGpsWeak,

--- a/packages/trufi_core_navigation/lib/src/presentation/navigation_screen.dart
+++ b/packages/trufi_core_navigation/lib/src/presentation/navigation_screen.dart
@@ -28,7 +28,8 @@ class NavigationScreen extends StatefulWidget {
     BuildContext context,
     NavigationState state,
     List<TrufiLayer> navigationLayers,
-  ) mapBuilder;
+  )
+  mapBuilder;
 
   /// Location service to use for tracking.
   final LocationService locationService;
@@ -56,7 +57,8 @@ class NavigationScreen extends StatefulWidget {
       BuildContext context,
       NavigationState state,
       List<TrufiLayer> navigationLayers,
-    ) mapBuilder,
+    )
+    mapBuilder,
     required LocationService locationService,
     NavigationConfig config = const NavigationConfig(),
     Widget? modeIcon,
@@ -73,15 +75,13 @@ class NavigationScreen extends StatefulWidget {
             ),
         transitionsBuilder: (context, animation, secondaryAnimation, child) {
           return SlideTransition(
-            position: Tween<Offset>(
-              begin: const Offset(0, 1),
-              end: Offset.zero,
-            ).animate(
-              CurvedAnimation(
-                parent: animation,
-                curve: Curves.easeOutCubic,
-              ),
-            ),
+            position: Tween<Offset>(begin: const Offset(0, 1), end: Offset.zero)
+                .animate(
+                  CurvedAnimation(
+                    parent: animation,
+                    curve: Curves.easeOutCubic,
+                  ),
+                ),
             child: child,
           );
         },
@@ -99,7 +99,14 @@ class NavigationScreen extends StatefulWidget {
     NavigationConfig config = const NavigationConfig(),
     Widget? modeIcon,
   }) {
-    final route = ItineraryConverter.toNavigationRoute(itinerary);
+    final l10n = NavigationLocalizations.of(context);
+    final route = ItineraryConverter.toNavigationRoute(
+      itinerary,
+      originLabel: l10n.navOrigin,
+      transferLabel: l10n.navTransfer,
+      destinationLabel: l10n.navDestination,
+      routeLabel: l10n.navRoute,
+    );
     final currentLocation = locationService.currentLocation;
     final fallbackCenter = route.geometry.isNotEmpty
         ? route.geometry.first
@@ -232,11 +239,17 @@ class _NavigationScreenState extends State<NavigationScreen>
         );
 
       case NavigationStatus.error:
+        final l10n = NavigationLocalizations.of(context);
         return NavigationErrorPanel(
-          errorMessage: state.errorMessage ?? NavigationLocalizations.of(context).navError,
+          errorMessage:
+              state.errorType?.localizedMessage(l10n) ??
+              state.errorMessage ??
+              l10n.navError,
           onRetry: () => _cubit.startNavigation(widget.route),
           onClose: () => Navigator.of(context).pop(),
-          onOpenSettings: state.errorMessage?.contains('settings') == true
+          onOpenSettings:
+              state.errorType == NavigationError.permissionDeniedForever ||
+                  state.errorMessage?.contains('settings') == true
               ? () => widget.locationService.openAppSettings()
               : null,
         );

--- a/packages/trufi_core_navigation/lib/src/presentation/widgets/navigation_instruction_card.dart
+++ b/packages/trufi_core_navigation/lib/src/presentation/widgets/navigation_instruction_card.dart
@@ -78,7 +78,9 @@ class NavigationInstructionCard extends StatelessWidget {
                     children: [
                       // Primary text (stop name)
                       Text(
-                        instruction.primaryText,
+                        instruction.resolvedPrimaryText(
+                          NavigationLocalizations.of(context),
+                        ),
                         style: theme.textTheme.titleMedium?.copyWith(
                           fontWeight: FontWeight.bold,
                           color: colorScheme.onSurface,
@@ -323,7 +325,9 @@ class NavigationInstructionCard extends StatelessWidget {
           ),
           Expanded(
             child: Text(
-              nextInstruction!.primaryText,
+              nextInstruction!.resolvedPrimaryText(
+                NavigationLocalizations.of(context),
+              ),
               style: theme.textTheme.bodySmall?.copyWith(
                 color: colorScheme.onSurface,
                 fontWeight: FontWeight.w500,

--- a/packages/trufi_core_navigation/lib/src/utils/itinerary_converter.dart
+++ b/packages/trufi_core_navigation/lib/src/utils/itinerary_converter.dart
@@ -15,7 +15,19 @@ class ItineraryConverter {
   /// - Transit leg information (route name, color, short name)
   /// - Intermediate stops from transit legs
   /// - Leg segments for proper rendering with colors and styles
-  static NavigationRoute toNavigationRoute(routing.Itinerary itinerary) {
+  ///
+  /// [originLabel], [transferLabel], [destinationLabel] and [routeLabel] are
+  /// used as fallback names for unnamed places and routes. Callers with a
+  /// `BuildContext` should pass localized values (see
+  /// `NavigationLocalizations`); the English defaults only exist for
+  /// backward compatibility.
+  static NavigationRoute toNavigationRoute(
+    routing.Itinerary itinerary, {
+    String originLabel = 'Origin',
+    String transferLabel = 'Transfer',
+    String destinationLabel = 'Destination',
+    String routeLabel = 'Route',
+  }) {
     // Get all points from all legs for geometry
     final allPoints = <LatLng>[];
     final navigationLegs = <NavigationLeg>[];
@@ -71,7 +83,7 @@ class ItineraryConverter {
         stops.add(
           NavigationStop(
             id: 'stop-$stopIndex',
-            name: fromPlace.name.isNotEmpty ? fromPlace.name : 'Origin',
+            name: fromPlace.name.isNotEmpty ? fromPlace.name : originLabel,
             position: LatLng(fromPlace.lat, fromPlace.lon),
           ),
         );
@@ -80,7 +92,7 @@ class ItineraryConverter {
         stops.add(
           NavigationStop(
             id: 'stop-$stopIndex',
-            name: 'Origin',
+            name: originLabel,
             position: firstLeg.decodedPoints.first,
           ),
         );
@@ -114,7 +126,7 @@ class ItineraryConverter {
           stops.add(
             NavigationStop(
               id: 'stop-$stopIndex',
-              name: toPlace.name.isNotEmpty ? toPlace.name : 'Transfer',
+              name: toPlace.name.isNotEmpty ? toPlace.name : transferLabel,
               position: LatLng(toPlace.lat, toPlace.lon),
             ),
           );
@@ -123,7 +135,7 @@ class ItineraryConverter {
           stops.add(
             NavigationStop(
               id: 'stop-$stopIndex',
-              name: 'Transfer',
+              name: transferLabel,
               position: leg.decodedPoints.last,
             ),
           );
@@ -140,7 +152,7 @@ class ItineraryConverter {
         stops.add(
           NavigationStop(
             id: 'stop-$stopIndex',
-            name: toPlace.name.isNotEmpty ? toPlace.name : 'Destination',
+            name: toPlace.name.isNotEmpty ? toPlace.name : destinationLabel,
             position: LatLng(toPlace.lat, toPlace.lon),
           ),
         );
@@ -148,7 +160,7 @@ class ItineraryConverter {
         stops.add(
           NavigationStop(
             id: 'stop-$stopIndex',
-            name: 'Destination',
+            name: destinationLabel,
             position: lastLeg.decodedPoints.last,
           ),
         );
@@ -164,7 +176,7 @@ class ItineraryConverter {
     return NavigationRoute(
       id: 'route-${DateTime.now().millisecondsSinceEpoch}',
       code: transitLeg.shortName ?? 'ROUTE',
-      name: transitLeg.route?.longName ?? transitLeg.shortName ?? 'Route',
+      name: transitLeg.route?.longName ?? transitLeg.shortName ?? routeLabel,
       shortName: transitLeg.shortName,
       backgroundColor: backgroundColor,
       geometry: allPoints,

--- a/packages/trufi_core_navigation/test/localized_text_resolution_test.dart
+++ b/packages/trufi_core_navigation/test/localized_text_resolution_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_navigation/l10n/navigation_localizations_de.dart';
+import 'package:trufi_core_navigation/l10n/navigation_localizations_en.dart';
+import 'package:trufi_core_navigation/l10n/navigation_localizations_es.dart';
+import 'package:trufi_core_navigation/trufi_core_navigation.dart';
+
+void main() {
+  final en = NavigationLocalizationsEn();
+  final es = NavigationLocalizationsEs();
+  final de = NavigationLocalizationsDe();
+
+  group('NavigationError.localizedMessage', () {
+    test('resolves every error to the English message', () {
+      expect(
+        NavigationError.trackingStartFailed.localizedMessage(en),
+        'Could not start location tracking',
+      );
+      expect(
+        NavigationError.permissionDenied.localizedMessage(en),
+        'Location permission denied',
+      );
+      expect(
+        NavigationError.permissionDeniedForever.localizedMessage(en),
+        'Location permission permanently denied. Please enable in settings.',
+      );
+      expect(
+        NavigationError.serviceDisabled.localizedMessage(en),
+        'Location services are disabled. Please enable them.',
+      );
+    });
+
+    test('resolves to German messages for German users', () {
+      expect(
+        NavigationError.permissionDenied.localizedMessage(de),
+        'Standortberechtigung verweigert',
+      );
+      expect(
+        NavigationError.trackingStartFailed.localizedMessage(de),
+        'Standortverfolgung konnte nicht gestartet werden',
+      );
+    });
+
+    test('resolves to Spanish messages', () {
+      expect(
+        NavigationError.permissionDenied.localizedMessage(es),
+        'Permiso de ubicación denegado',
+      );
+    });
+  });
+
+  group('NavigationInstruction.resolvedPrimaryText', () {
+    test('resolves primaryTextKey per locale', () {
+      const instruction = NavigationInstruction(
+        type: InstructionType.arriveDestination,
+        primaryTextKey: InstructionTextKey.youHaveArrived,
+      );
+
+      expect(instruction.resolvedPrimaryText(en), 'You have arrived');
+      expect(instruction.resolvedPrimaryText(es), 'Has llegado');
+      expect(instruction.resolvedPrimaryText(de), 'Sie sind angekommen');
+    });
+
+    test('resolves finalDestination key per locale', () {
+      const instruction = NavigationInstruction(
+        type: InstructionType.arriveDestination,
+        primaryTextKey: InstructionTextKey.finalDestination,
+      );
+
+      expect(instruction.resolvedPrimaryText(en), 'Final destination');
+      expect(instruction.resolvedPrimaryText(es), 'Destino final');
+      expect(instruction.resolvedPrimaryText(de), 'Endziel');
+    });
+
+    test('falls back to primaryText when no key is set', () {
+      const instruction = NavigationInstruction(
+        type: InstructionType.arriveStop,
+        primaryText: 'Plaza Colón',
+      );
+
+      expect(instruction.resolvedPrimaryText(en), 'Plaza Colón');
+      expect(instruction.resolvedPrimaryText(de), 'Plaza Colón');
+    });
+
+    test('primaryTextKey takes precedence over primaryText', () {
+      const instruction = NavigationInstruction(
+        type: InstructionType.arriveDestination,
+        primaryText: 'You have arrived',
+        primaryTextKey: InstructionTextKey.youHaveArrived,
+      );
+
+      expect(instruction.resolvedPrimaryText(de), 'Sie sind angekommen');
+    });
+  });
+}


### PR DESCRIPTION
Part of #871 — navigation slice, 13 strings across `NavigationCubit` and `ItineraryConverter` (neither has a `BuildContext`).

Best find of the batch: **9 of the 10 needed ARB keys already existed in en/es/de with real German translations — they were just never wired up.** Only `navRoute` is new.

Since the strings live in context-less code, they are now resolved at render time instead of being baked into state:

- `NavigationState` gains a `NavigationError` enum + optional `errorType`; the UI maps it to `NavigationLocalizations` at build time. The "open settings" action is now keyed off `errorType == permissionDeniedForever` instead of the fragile `errorMessage.contains('settings')` string match (legacy fallback kept for externally supplied messages).
- `NavigationInstruction` gains an optional `InstructionTextKey` (`youHaveArrived`, `finalDestination`) resolved at the widget layer — instructions re-localize on locale change and never persist English in state.
- `ItineraryConverter.toNavigationRoute` gains optional `originLabel`/`transferLabel`/`destinationLabel`/`routeLabel` params (English defaults preserve behavior for external callers; `NavigationScreen.showFromItinerary` passes localized values).

All API changes are additive; existing call sites compile unchanged. Added 7 pure-Dart unit tests (package previously had none).

Known follow-up (out of this slice's inventory): `'Exit at …'` / `'N stops'` / `'… remaining'` in `_buildTransitInstruction` are still hardcoded — their keys (`navExitAt`, `navOneStop`, `navStops`) also already exist unwired.

Verification: Translation Check replicated locally, `flutter analyze` clean, 7/7 tests pass.
