### PR TITLE
fix(routing): localize OTP 1.5/2.4 preference sheets (#871)

### DIFF
--- a/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_preferences.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_preferences.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../l10n/routing_localizations.dart';
+
 /// Simplified walk speed levels for UI.
 enum WalkSpeedLevel {
   slow,
@@ -187,7 +189,11 @@ class Otp15Preferences extends StatelessWidget {
   final Otp15PreferencesState state;
   final bool showWheelchair;
 
-  const Otp15Preferences({super.key, required this.state, this.showWheelchair = true});
+  const Otp15Preferences({
+    super.key,
+    required this.state,
+    this.showWheelchair = true,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -238,13 +244,17 @@ class _AccessibilitySection extends StatelessWidget {
               size: 24,
             ),
             const SizedBox(width: 12),
-            const Expanded(child: Text('Wheelchair accessible')),
+            Expanded(
+              child: Text(
+                RoutingLocalizations.of(context).prefsWheelchairAccessible,
+              ),
+            ),
           ],
         ),
         subtitle: Text(
           state.wheelchair
-              ? 'Routes avoid stairs and steep slopes'
-              : 'Include all routes',
+              ? RoutingLocalizations.of(context).prefsWheelchairOn
+              : RoutingLocalizations.of(context).prefsWheelchairOff,
           style: theme.textTheme.bodySmall?.copyWith(
             color: colorScheme.onSurfaceVariant,
           ),
@@ -282,7 +292,7 @@ class _WalkSpeedSection extends StatelessWidget {
             ),
             const SizedBox(width: 8),
             Text(
-              'Walking speed',
+              RoutingLocalizations.of(context).prefsWalkingSpeed,
               style: theme.textTheme.titleSmall?.copyWith(
                 fontWeight: FontWeight.w600,
               ),
@@ -299,7 +309,7 @@ class _WalkSpeedSection extends StatelessWidget {
                   right: level != WalkSpeedLevel.fast ? 8 : 0,
                 ),
                 child: _SpeedChip(
-                  label: _speedLabel(level),
+                  label: _speedLabel(context, level),
                   icon: _speedIcon(level),
                   isSelected: isSelected,
                   onTap: () {
@@ -315,14 +325,15 @@ class _WalkSpeedSection extends StatelessWidget {
     );
   }
 
-  static String _speedLabel(WalkSpeedLevel level) {
+  static String _speedLabel(BuildContext context, WalkSpeedLevel level) {
+    final l10n = RoutingLocalizations.of(context);
     switch (level) {
       case WalkSpeedLevel.slow:
-        return 'Slow';
+        return l10n.prefsSpeedSlow;
       case WalkSpeedLevel.normal:
-        return 'Normal';
+        return l10n.prefsSpeedNormal;
       case WalkSpeedLevel.fast:
-        return 'Fast';
+        return l10n.prefsSpeedFast;
     }
   }
 
@@ -427,7 +438,7 @@ class _MaxWalkDistanceSection extends StatelessWidget {
             ),
             const SizedBox(width: 8),
             Text(
-              'Maximum walking distance',
+              RoutingLocalizations.of(context).prefsMaxWalkDistance,
               style: theme.textTheme.titleSmall?.copyWith(
                 fontWeight: FontWeight.w600,
               ),
@@ -472,7 +483,7 @@ class _DistanceChip extends StatelessWidget {
     final colorScheme = theme.colorScheme;
 
     final label = distance == null
-        ? 'No limit'
+        ? RoutingLocalizations.of(context).prefsNoLimit
         : distance! >= 1000
         ? '${(distance! / 1000).toStringAsFixed(1)} km'
         : '${distance!.toInt()} m';
@@ -530,7 +541,7 @@ class _TransportModesSection extends StatelessWidget {
             Icon(Icons.commute_rounded, color: colorScheme.primary, size: 20),
             const SizedBox(width: 8),
             Text(
-              'Transport modes',
+              RoutingLocalizations.of(context).prefsTransportModes,
               style: theme.textTheme.titleSmall?.copyWith(
                 fontWeight: FontWeight.w600,
               ),
@@ -544,7 +555,7 @@ class _TransportModesSection extends StatelessWidget {
           children: [
             _TransportModeChip(
               icon: Icons.directions_bus_rounded,
-              label: 'Transit',
+              label: RoutingLocalizations.of(context).prefsModeTransit,
               isSelected: state.transportModes.contains(RoutingMode.transit),
               onTap: () {
                 HapticFeedback.selectionClick();
@@ -553,7 +564,7 @@ class _TransportModesSection extends StatelessWidget {
             ),
             _TransportModeChip(
               icon: Icons.directions_walk_rounded,
-              label: 'Walk',
+              label: RoutingLocalizations.of(context).prefsModeWalk,
               isSelected: state.transportModes.contains(RoutingMode.walk),
               onTap: () {
                 HapticFeedback.selectionClick();
@@ -562,7 +573,7 @@ class _TransportModesSection extends StatelessWidget {
             ),
             _TransportModeChip(
               icon: Icons.directions_bike_rounded,
-              label: 'Bicycle',
+              label: RoutingLocalizations.of(context).prefsModeBicycle,
               isSelected: state.transportModes.contains(RoutingMode.bicycle),
               onTap: () {
                 HapticFeedback.selectionClick();

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_preferences.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_preferences.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../l10n/routing_localizations.dart';
+
 /// Simplified walk speed levels for UI.
 enum WalkSpeedLevel {
   slow,
@@ -235,13 +237,17 @@ class _AccessibilitySection extends StatelessWidget {
               size: 24,
             ),
             const SizedBox(width: 12),
-            const Expanded(child: Text('Wheelchair accessible')),
+            Expanded(
+              child: Text(
+                RoutingLocalizations.of(context).prefsWheelchairAccessible,
+              ),
+            ),
           ],
         ),
         subtitle: Text(
           state.wheelchair
-              ? 'Routes avoid stairs and steep slopes'
-              : 'Include all routes',
+              ? RoutingLocalizations.of(context).prefsWheelchairOn
+              : RoutingLocalizations.of(context).prefsWheelchairOff,
           style: theme.textTheme.bodySmall?.copyWith(
             color: colorScheme.onSurfaceVariant,
           ),
@@ -279,7 +285,7 @@ class _WalkSpeedSection extends StatelessWidget {
             ),
             const SizedBox(width: 8),
             Text(
-              'Walking speed',
+              RoutingLocalizations.of(context).prefsWalkingSpeed,
               style: theme.textTheme.titleSmall?.copyWith(
                 fontWeight: FontWeight.w600,
               ),
@@ -296,7 +302,7 @@ class _WalkSpeedSection extends StatelessWidget {
                   right: level != WalkSpeedLevel.fast ? 8 : 0,
                 ),
                 child: _SpeedChip(
-                  label: _speedLabel(level),
+                  label: _speedLabel(context, level),
                   icon: _speedIcon(level),
                   isSelected: isSelected,
                   onTap: () {
@@ -312,14 +318,15 @@ class _WalkSpeedSection extends StatelessWidget {
     );
   }
 
-  static String _speedLabel(WalkSpeedLevel level) {
+  static String _speedLabel(BuildContext context, WalkSpeedLevel level) {
+    final l10n = RoutingLocalizations.of(context);
     switch (level) {
       case WalkSpeedLevel.slow:
-        return 'Slow';
+        return l10n.prefsSpeedSlow;
       case WalkSpeedLevel.normal:
-        return 'Normal';
+        return l10n.prefsSpeedNormal;
       case WalkSpeedLevel.fast:
-        return 'Fast';
+        return l10n.prefsSpeedFast;
     }
   }
 
@@ -424,7 +431,7 @@ class _MaxWalkDistanceSection extends StatelessWidget {
             ),
             const SizedBox(width: 8),
             Text(
-              'Maximum walking distance',
+              RoutingLocalizations.of(context).prefsMaxWalkDistance,
               style: theme.textTheme.titleSmall?.copyWith(
                 fontWeight: FontWeight.w600,
               ),
@@ -469,7 +476,7 @@ class _DistanceChip extends StatelessWidget {
     final colorScheme = theme.colorScheme;
 
     final label = distance == null
-        ? 'No limit'
+        ? RoutingLocalizations.of(context).prefsNoLimit
         : distance! >= 1000
         ? '${(distance! / 1000).toStringAsFixed(1)} km'
         : '${distance!.toInt()} m';
@@ -527,7 +534,7 @@ class _TransportModesSection extends StatelessWidget {
             Icon(Icons.commute_rounded, color: colorScheme.primary, size: 20),
             const SizedBox(width: 8),
             Text(
-              'Transport modes',
+              RoutingLocalizations.of(context).prefsTransportModes,
               style: theme.textTheme.titleSmall?.copyWith(
                 fontWeight: FontWeight.w600,
               ),
@@ -541,7 +548,7 @@ class _TransportModesSection extends StatelessWidget {
           children: [
             _TransportModeChip(
               icon: Icons.directions_bus_rounded,
-              label: 'Transit',
+              label: RoutingLocalizations.of(context).prefsModeTransit,
               isSelected: state.transportModes.contains(RoutingMode.transit),
               onTap: () {
                 HapticFeedback.selectionClick();
@@ -550,7 +557,7 @@ class _TransportModesSection extends StatelessWidget {
             ),
             _TransportModeChip(
               icon: Icons.directions_walk_rounded,
-              label: 'Walk',
+              label: RoutingLocalizations.of(context).prefsModeWalk,
               isSelected: state.transportModes.contains(RoutingMode.walk),
               onTap: () {
                 HapticFeedback.selectionClick();
@@ -559,7 +566,7 @@ class _TransportModesSection extends StatelessWidget {
             ),
             _TransportModeChip(
               icon: Icons.directions_bike_rounded,
-              label: 'Bicycle',
+              label: RoutingLocalizations.of(context).prefsModeBicycle,
               isSelected: state.transportModes.contains(RoutingMode.bicycle),
               onTap: () {
                 HapticFeedback.selectionClick();


### PR DESCRIPTION
Part of #871 — OTP 1.5 / OTP 2.4 preference sheets, 13 strings × 2 files = 26 call sites.

Zero new ARB keys: all 13 `prefs*` keys (`prefsWheelchairAccessible`, `prefsWalkingSpeed`, `prefsSpeedSlow/Normal/Fast`, `prefsMaxWalkDistance`, `prefsNoLimit`, `prefsTransportModes`, `prefsModeTransit/Walk/Bicycle`, …) already existed in `routing_{en,es,de}.arb` — they were added for the OTP 2.8 sheet and never used by the 1.5/2.4 sheets. This PR mirrors the 2.8 sheet's code exactly, so the three sheets are now consistent. No ARB or generated-file changes → small diff.

Minor pre-existing nit spotted in review (not touched here): es `prefsModeTransit` is `"Tránsito"`; `"Transporte público"` would read more naturally in Latin American Spanish. Worth a tiny follow-up ARB tweak affecting all three sheets at once.

Verification: Translation Check replicated locally (zero regen diff, as expected), `flutter analyze` clean, test suite identical pass/fail profile to clean main (all failures are the known live-network/binding ones).
