### PR TITLE
feat(maps,search_locations): add l10n infrastructure and localize strings (#871)

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/src/home_screen_trufi_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/home_screen_trufi_screen.dart
@@ -6,6 +6,9 @@ import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:trufi_core_poi_layers/trufi_core_poi_layers.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart' as routing;
 import 'package:trufi_core_navigation/trufi_core_navigation.dart';
+import 'package:trufi_core_maps/trufi_core_maps.dart' show MapsLocalizations;
+import 'package:trufi_core_search_locations/trufi_core_search_locations.dart'
+    show SearchLocationsLocalizations;
 import 'package:trufi_core_utils/trufi_core_utils.dart';
 
 import '../l10n/home_screen_localizations.dart';
@@ -103,6 +106,8 @@ class HomeScreenTrufiScreen extends TrufiScreen {
     if (config.poiLayersManager != null) POILayersLocalizations.delegate,
     routing.RoutingLocalizations.delegate,
     NavigationLocalizations.delegate,
+    MapsLocalizations.delegate,
+    SearchLocationsLocalizations.delegate,
   ];
 
   @override

--- a/packages/screens/trufi_core_saved_places/lib/src/saved_places_trufi_screen.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/saved_places_trufi_screen.dart
@@ -53,6 +53,7 @@ class SavedPlacesTrufiScreen extends TrufiScreen {
   @override
   List<LocalizationsDelegate> get localizationsDelegates => [
     ...SavedPlacesLocalizations.localizationsDelegates,
+    MapsLocalizations.delegate,
   ];
 
   @override

--- a/packages/screens/trufi_core_settings/lib/settings_screen.dart
+++ b/packages/screens/trufi_core_settings/lib/settings_screen.dart
@@ -23,6 +23,7 @@ class SettingsTrufiScreen extends TrufiScreen {
   @override
   List<LocalizationsDelegate> get localizationsDelegates => [
     SettingsLocalizations.delegate,
+    MapsLocalizations.delegate,
   ];
 
   @override

--- a/packages/screens/trufi_core_transport_list/lib/src/transport_list_trufi_screen.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/transport_list_trufi_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/single_child_widget.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
+import 'package:trufi_core_maps/trufi_core_maps.dart' show MapsLocalizations;
 import 'package:trufi_core_routing/trufi_core_routing.dart';
 
 import '../l10n/transport_list_localizations.dart';
@@ -23,7 +24,7 @@ import 'transport_list_data_provider.dart';
 /// - `/routes/:id` - shows route detail for the given pattern ID (path parameter)
 class TransportListTrufiScreen extends TrufiScreen {
   final TransportListDataProvider Function(BuildContext context)?
-      dataProviderBuilder;
+  dataProviderBuilder;
 
   TransportListTrufiScreen({this.dataProviderBuilder});
 
@@ -35,9 +36,8 @@ class TransportListTrufiScreen extends TrufiScreen {
 
   @override
   Widget Function(BuildContext context) get builder =>
-      (_) => _TransportListScreenWidget(
-            dataProviderBuilder: dataProviderBuilder,
-          );
+      (_) =>
+          _TransportListScreenWidget(dataProviderBuilder: dataProviderBuilder);
 
   @override
   List<TrufiSubRoute> get subRoutes => [
@@ -73,6 +73,7 @@ class TransportListTrufiScreen extends TrufiScreen {
   @override
   List<LocalizationsDelegate> get localizationsDelegates => [
     ...TransportListLocalizations.localizationsDelegates,
+    MapsLocalizations.delegate,
   ];
 
   @override
@@ -97,7 +98,7 @@ class TransportListTrufiScreen extends TrufiScreen {
 
 class _TransportListScreenWidget extends StatefulWidget {
   final TransportListDataProvider Function(BuildContext context)?
-      dataProviderBuilder;
+  dataProviderBuilder;
 
   const _TransportListScreenWidget({this.dataProviderBuilder});
 

--- a/packages/trufi_core_maps/README.md
+++ b/packages/trufi_core_maps/README.md
@@ -9,6 +9,7 @@ The core idea is a **declarative data flow**: you pass layers, markers, and line
 ## Contents
 
 - [Quick Start](#quick-start)
+- [Localization](#localization)
 - [Core Concepts](#core-concepts)
 - [Map Engines](#map-engines)
 - [Data Types](#data-types)
@@ -63,6 +64,39 @@ class MyMapScreen extends StatelessWidget {
   }
 }
 ```
+
+---
+
+## Localization
+
+**Breaking change (since the l10n migration):** widgets that render text
+(`MapTypeButton`, `ChooseOnMapScreen`, `MapOnlineOfflineToggle`, the map type
+settings screen, and engine `localizedName`/`localizedDescription`) resolve
+their default strings through `MapsLocalizations.of(context)`. There is no
+implicit English fallback — if the delegate is not registered, these widgets
+throw a null-check error at build time.
+
+Apps built with `TrufiApp` get the delegate automatically (screens merge it
+into the `MaterialApp`). If you embed these widgets in your own `MaterialApp`,
+register the delegate yourself:
+
+```dart
+MaterialApp(
+  localizationsDelegates: MapsLocalizations.localizationsDelegates,
+  supportedLocales: MapsLocalizations.supportedLocales,
+  // ...
+)
+```
+
+Supported locales: `en`, `es`, `de`. Widgets that accept explicit strings
+(e.g. `MapTypeButton(tooltip: ...)`, `ChooseOnMapConfiguration(title: ...)`)
+still use them verbatim and skip the lookup, but the delegate is required
+whenever any text field is left `null`.
+
+The same applies to `trufi_core_search_locations`: register
+`SearchLocationsLocalizations.delegate` (plus `MapsLocalizations.delegate` if
+you use `ChooseOnMapScreen`) before embedding `SearchLocationBar` or
+`LocationSearchScreen` outside `TrufiApp`.
 
 ---
 

--- a/packages/trufi_core_maps/example/lib/main.dart
+++ b/packages/trufi_core_maps/example/lib/main.dart
@@ -45,6 +45,8 @@ class MyApp extends StatelessWidget {
       child: MaterialApp(
         title: 'Trufi Maps - Performance Demo',
         debugShowCheckedModeBanner: false,
+        localizationsDelegates: MapsLocalizations.localizationsDelegates,
+        supportedLocales: MapsLocalizations.supportedLocales,
         theme: ThemeData(
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
           useMaterial3: true,
@@ -282,8 +284,7 @@ class _PerformanceDemoPageState extends State<PerformanceDemoPage> {
                   fps: _fps,
                   isAnimating: _isAnimating,
                   hasData: _animatedMarkersLayer.vehicleCount > 0,
-                  onMarkerCountChanged: (v) =>
-                      setState(() => _markerCount = v),
+                  onMarkerCountChanged: (v) => setState(() => _markerCount = v),
                   onLineCountChanged: (v) => setState(() => _lineCount = v),
                   onFpsChanged: (v) => setState(() => _fps = v),
                   onStart: _applySettings,

--- a/packages/trufi_core_maps/example/pubspec.lock
+++ b/packages/trufi_core_maps/example/pubspec.lock
@@ -222,6 +222,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_map:
     dependency: "direct main"
     description:

--- a/packages/trufi_core_maps/l10n.yaml
+++ b/packages/trufi_core_maps/l10n.yaml
@@ -1,0 +1,5 @@
+arb-dir: lib/l10n
+template-arb-file: maps_en.arb
+output-localization-file: maps_localizations.dart
+output-class: MapsLocalizations
+nullable-getter: false

--- a/packages/trufi_core_maps/lib/l10n/maps_de.arb
+++ b/packages/trufi_core_maps/lib/l10n/maps_de.arb
@@ -1,0 +1,18 @@
+{
+  "@@locale": "de",
+  "online": "Online",
+  "offline": "Offline",
+  "mapSettings": "Karteneinstellungen",
+  "mapType": "Kartentyp",
+  "chooseMapStyle": "Wähle deinen bevorzugten Kartenstil",
+  "changeMapType": "Kartentyp ändern",
+  "chooseOnMap": "Auf der Karte wählen",
+  "confirmLocation": "Standort bestätigen",
+  "offlineMapName": "Offline-Karte",
+  "offlineMapDescription": "Vollständig offline nutzbare Karte",
+  "errorLoadingOfflineMap": "Fehler beim Laden der Offline-Karte",
+  "retry": "Erneut versuchen",
+  "vectorMapDescription": "Vektorkarte mit modernem Design und besserer Leistung",
+  "lightVectorMapDescription": "Helle Vektorkarte",
+  "darkVectorMapDescription": "Dunkle Vektorkarte"
+}

--- a/packages/trufi_core_maps/lib/l10n/maps_en.arb
+++ b/packages/trufi_core_maps/lib/l10n/maps_en.arb
@@ -1,0 +1,63 @@
+{
+  "@@locale": "en",
+  "online": "Online",
+  "@online": {
+    "description": "Label for the online maps segment in the online/offline toggle"
+  },
+  "offline": "Offline",
+  "@offline": {
+    "description": "Label for the offline maps segment in the online/offline toggle"
+  },
+  "mapSettings": "Map Settings",
+  "@mapSettings": {
+    "description": "Default title for the map type settings screen header"
+  },
+  "mapType": "Map Type",
+  "@mapType": {
+    "description": "Default section title above the map type list"
+  },
+  "chooseMapStyle": "Choose your preferred map style",
+  "@chooseMapStyle": {
+    "description": "Subtitle under the map type section title"
+  },
+  "changeMapType": "Change map type",
+  "@changeMapType": {
+    "description": "Default tooltip for the map type button"
+  },
+  "chooseOnMap": "Choose on Map",
+  "@chooseOnMap": {
+    "description": "Default title for the choose-on-map screen"
+  },
+  "confirmLocation": "Confirm Location",
+  "@confirmLocation": {
+    "description": "Default label for the confirm button on the choose-on-map screen"
+  },
+  "offlineMapName": "Offline Map",
+  "@offlineMapName": {
+    "description": "Default display name for the offline map engine"
+  },
+  "offlineMapDescription": "Fully offline map",
+  "@offlineMapDescription": {
+    "description": "Default description for the offline map engine"
+  },
+  "errorLoadingOfflineMap": "Error loading offline map",
+  "@errorLoadingOfflineMap": {
+    "description": "Error title shown when the offline map fails to load"
+  },
+  "retry": "Retry",
+  "@retry": {
+    "description": "Label for the retry button after an offline map load failure"
+  },
+  "vectorMapDescription": "Vector map with modern styling and better performance",
+  "@vectorMapDescription": {
+    "description": "Default description for the MapLibre vector map engine"
+  },
+  "lightVectorMapDescription": "Light vector map",
+  "@lightVectorMapDescription": {
+    "description": "Description for the default light (Liberty) map style"
+  },
+  "darkVectorMapDescription": "Dark vector map",
+  "@darkVectorMapDescription": {
+    "description": "Description for the default dark map style"
+  }
+}

--- a/packages/trufi_core_maps/lib/l10n/maps_es.arb
+++ b/packages/trufi_core_maps/lib/l10n/maps_es.arb
@@ -1,0 +1,18 @@
+{
+  "@@locale": "es",
+  "online": "En línea",
+  "offline": "Sin conexión",
+  "mapSettings": "Configuración del mapa",
+  "mapType": "Tipo de mapa",
+  "chooseMapStyle": "Elige tu estilo de mapa preferido",
+  "changeMapType": "Cambiar tipo de mapa",
+  "chooseOnMap": "Elegir en el mapa",
+  "confirmLocation": "Confirmar ubicación",
+  "offlineMapName": "Mapa offline",
+  "offlineMapDescription": "Mapa completamente offline",
+  "errorLoadingOfflineMap": "Error al cargar el mapa offline",
+  "retry": "Reintentar",
+  "vectorMapDescription": "Mapa vectorial con estilo moderno y mejor rendimiento",
+  "lightVectorMapDescription": "Mapa vectorial claro",
+  "darkVectorMapDescription": "Mapa vectorial oscuro"
+}

--- a/packages/trufi_core_maps/lib/l10n/maps_localizations.dart
+++ b/packages/trufi_core_maps/lib/l10n/maps_localizations.dart
@@ -1,0 +1,230 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'maps_localizations_de.dart';
+import 'maps_localizations_en.dart';
+import 'maps_localizations_es.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of MapsLocalizations
+/// returned by `MapsLocalizations.of(context)`.
+///
+/// Applications need to include `MapsLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/maps_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: MapsLocalizations.localizationsDelegates,
+///   supportedLocales: MapsLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the MapsLocalizations.supportedLocales
+/// property.
+abstract class MapsLocalizations {
+  MapsLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static MapsLocalizations of(BuildContext context) {
+    return Localizations.of<MapsLocalizations>(context, MapsLocalizations)!;
+  }
+
+  static const LocalizationsDelegate<MapsLocalizations> delegate =
+      _MapsLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('de'),
+    Locale('en'),
+    Locale('es'),
+  ];
+
+  /// Label for the online maps segment in the online/offline toggle
+  ///
+  /// In en, this message translates to:
+  /// **'Online'**
+  String get online;
+
+  /// Label for the offline maps segment in the online/offline toggle
+  ///
+  /// In en, this message translates to:
+  /// **'Offline'**
+  String get offline;
+
+  /// Default title for the map type settings screen header
+  ///
+  /// In en, this message translates to:
+  /// **'Map Settings'**
+  String get mapSettings;
+
+  /// Default section title above the map type list
+  ///
+  /// In en, this message translates to:
+  /// **'Map Type'**
+  String get mapType;
+
+  /// Subtitle under the map type section title
+  ///
+  /// In en, this message translates to:
+  /// **'Choose your preferred map style'**
+  String get chooseMapStyle;
+
+  /// Default tooltip for the map type button
+  ///
+  /// In en, this message translates to:
+  /// **'Change map type'**
+  String get changeMapType;
+
+  /// Default title for the choose-on-map screen
+  ///
+  /// In en, this message translates to:
+  /// **'Choose on Map'**
+  String get chooseOnMap;
+
+  /// Default label for the confirm button on the choose-on-map screen
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm Location'**
+  String get confirmLocation;
+
+  /// Default display name for the offline map engine
+  ///
+  /// In en, this message translates to:
+  /// **'Offline Map'**
+  String get offlineMapName;
+
+  /// Default description for the offline map engine
+  ///
+  /// In en, this message translates to:
+  /// **'Fully offline map'**
+  String get offlineMapDescription;
+
+  /// Error title shown when the offline map fails to load
+  ///
+  /// In en, this message translates to:
+  /// **'Error loading offline map'**
+  String get errorLoadingOfflineMap;
+
+  /// Label for the retry button after an offline map load failure
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get retry;
+
+  /// Default description for the MapLibre vector map engine
+  ///
+  /// In en, this message translates to:
+  /// **'Vector map with modern styling and better performance'**
+  String get vectorMapDescription;
+
+  /// Description for the default light (Liberty) map style
+  ///
+  /// In en, this message translates to:
+  /// **'Light vector map'**
+  String get lightVectorMapDescription;
+
+  /// Description for the default dark map style
+  ///
+  /// In en, this message translates to:
+  /// **'Dark vector map'**
+  String get darkVectorMapDescription;
+}
+
+class _MapsLocalizationsDelegate
+    extends LocalizationsDelegate<MapsLocalizations> {
+  const _MapsLocalizationsDelegate();
+
+  @override
+  Future<MapsLocalizations> load(Locale locale) {
+    return SynchronousFuture<MapsLocalizations>(
+      lookupMapsLocalizations(locale),
+    );
+  }
+
+  @override
+  bool isSupported(Locale locale) =>
+      <String>['de', 'en', 'es'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_MapsLocalizationsDelegate old) => false;
+}
+
+MapsLocalizations lookupMapsLocalizations(Locale locale) {
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'de':
+      return MapsLocalizationsDe();
+    case 'en':
+      return MapsLocalizationsEn();
+    case 'es':
+      return MapsLocalizationsEs();
+  }
+
+  throw FlutterError(
+    'MapsLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
+}

--- a/packages/trufi_core_maps/lib/l10n/maps_localizations_de.dart
+++ b/packages/trufi_core_maps/lib/l10n/maps_localizations_de.dart
@@ -1,0 +1,56 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'maps_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for German (`de`).
+class MapsLocalizationsDe extends MapsLocalizations {
+  MapsLocalizationsDe([String locale = 'de']) : super(locale);
+
+  @override
+  String get online => 'Online';
+
+  @override
+  String get offline => 'Offline';
+
+  @override
+  String get mapSettings => 'Karteneinstellungen';
+
+  @override
+  String get mapType => 'Kartentyp';
+
+  @override
+  String get chooseMapStyle => 'Wähle deinen bevorzugten Kartenstil';
+
+  @override
+  String get changeMapType => 'Kartentyp ändern';
+
+  @override
+  String get chooseOnMap => 'Auf der Karte wählen';
+
+  @override
+  String get confirmLocation => 'Standort bestätigen';
+
+  @override
+  String get offlineMapName => 'Offline-Karte';
+
+  @override
+  String get offlineMapDescription => 'Vollständig offline nutzbare Karte';
+
+  @override
+  String get errorLoadingOfflineMap => 'Fehler beim Laden der Offline-Karte';
+
+  @override
+  String get retry => 'Erneut versuchen';
+
+  @override
+  String get vectorMapDescription =>
+      'Vektorkarte mit modernem Design und besserer Leistung';
+
+  @override
+  String get lightVectorMapDescription => 'Helle Vektorkarte';
+
+  @override
+  String get darkVectorMapDescription => 'Dunkle Vektorkarte';
+}

--- a/packages/trufi_core_maps/lib/l10n/maps_localizations_en.dart
+++ b/packages/trufi_core_maps/lib/l10n/maps_localizations_en.dart
@@ -1,0 +1,56 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'maps_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class MapsLocalizationsEn extends MapsLocalizations {
+  MapsLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get online => 'Online';
+
+  @override
+  String get offline => 'Offline';
+
+  @override
+  String get mapSettings => 'Map Settings';
+
+  @override
+  String get mapType => 'Map Type';
+
+  @override
+  String get chooseMapStyle => 'Choose your preferred map style';
+
+  @override
+  String get changeMapType => 'Change map type';
+
+  @override
+  String get chooseOnMap => 'Choose on Map';
+
+  @override
+  String get confirmLocation => 'Confirm Location';
+
+  @override
+  String get offlineMapName => 'Offline Map';
+
+  @override
+  String get offlineMapDescription => 'Fully offline map';
+
+  @override
+  String get errorLoadingOfflineMap => 'Error loading offline map';
+
+  @override
+  String get retry => 'Retry';
+
+  @override
+  String get vectorMapDescription =>
+      'Vector map with modern styling and better performance';
+
+  @override
+  String get lightVectorMapDescription => 'Light vector map';
+
+  @override
+  String get darkVectorMapDescription => 'Dark vector map';
+}

--- a/packages/trufi_core_maps/lib/l10n/maps_localizations_es.dart
+++ b/packages/trufi_core_maps/lib/l10n/maps_localizations_es.dart
@@ -1,0 +1,56 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'maps_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Spanish Castilian (`es`).
+class MapsLocalizationsEs extends MapsLocalizations {
+  MapsLocalizationsEs([String locale = 'es']) : super(locale);
+
+  @override
+  String get online => 'En línea';
+
+  @override
+  String get offline => 'Sin conexión';
+
+  @override
+  String get mapSettings => 'Configuración del mapa';
+
+  @override
+  String get mapType => 'Tipo de mapa';
+
+  @override
+  String get chooseMapStyle => 'Elige tu estilo de mapa preferido';
+
+  @override
+  String get changeMapType => 'Cambiar tipo de mapa';
+
+  @override
+  String get chooseOnMap => 'Elegir en el mapa';
+
+  @override
+  String get confirmLocation => 'Confirmar ubicación';
+
+  @override
+  String get offlineMapName => 'Mapa offline';
+
+  @override
+  String get offlineMapDescription => 'Mapa completamente offline';
+
+  @override
+  String get errorLoadingOfflineMap => 'Error al cargar el mapa offline';
+
+  @override
+  String get retry => 'Reintentar';
+
+  @override
+  String get vectorMapDescription =>
+      'Mapa vectorial con estilo moderno y mejor rendimiento';
+
+  @override
+  String get lightVectorMapDescription => 'Mapa vectorial claro';
+
+  @override
+  String get darkVectorMapDescription => 'Mapa vectorial oscuro';
+}

--- a/packages/trufi_core_maps/lib/src/configuration/map_engine/default_map_engines.dart
+++ b/packages/trufi_core_maps/lib/src/configuration/map_engine/default_map_engines.dart
@@ -1,5 +1,14 @@
+import 'package:flutter/widgets.dart';
+
+import '../../../l10n/maps_localizations.dart';
 import 'maplibre_engine.dart';
 import 'trufi_map_engine.dart';
+
+String _libertyDescription(BuildContext context) =>
+    MapsLocalizations.of(context).lightVectorMapDescription;
+
+String _darkDescription(BuildContext context) =>
+    MapsLocalizations.of(context).darkVectorMapDescription;
 
 /// Default map engines for Trufi apps.
 ///
@@ -11,12 +20,12 @@ const List<ITrufiMapEngine> defaultMapEngines = [
     engineId: 'maplibre_liberty',
     styleString: 'https://tiles.openfreemap.org/styles/liberty',
     displayName: 'Liberty',
-    displayDescription: 'Mapa vectorial claro',
+    descriptionBuilder: _libertyDescription,
   ),
   MapLibreEngine(
     engineId: 'maplibre_dark',
     styleString: 'https://tiles.openfreemap.org/styles/dark',
     displayName: 'Dark',
-    displayDescription: 'Mapa vectorial oscuro',
+    descriptionBuilder: _darkDescription,
   ),
 ];

--- a/packages/trufi_core_maps/lib/src/configuration/map_engine/maplibre_engine.dart
+++ b/packages/trufi_core_maps/lib/src/configuration/map_engine/maplibre_engine.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:latlong2/latlong.dart';
 
+import '../../../l10n/maps_localizations.dart';
 import '../../domain/controller/map_controller.dart';
 import '../../domain/entities/camera.dart';
 import '../../domain/entities/widget_marker.dart';
@@ -56,7 +57,9 @@ class MapLibreEngine implements ITrufiMapEngine {
 
   @override
   String localizedDescription(BuildContext context) =>
-      descriptionBuilder?.call(context) ?? description;
+      descriptionBuilder?.call(context) ??
+      displayDescription ??
+      MapsLocalizations.of(context).vectorMapDescription;
 
   @override
   Widget? get previewWidget =>

--- a/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
+++ b/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:path_provider/path_provider.dart';
 
+import '../../../l10n/maps_localizations.dart';
 import '../../domain/controller/map_controller.dart';
 import '../../domain/entities/camera.dart';
 import '../../domain/entities/widget_marker.dart';
@@ -62,15 +63,19 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
   String get name => displayName ?? 'Offline Map';
 
   @override
-  String get description => displayDescription ?? 'Mapa completamente offline';
+  String get description => displayDescription ?? 'Fully offline map';
 
   @override
   String localizedName(BuildContext context) =>
-      nameBuilder?.call(context) ?? name;
+      nameBuilder?.call(context) ??
+      displayName ??
+      MapsLocalizations.of(context).offlineMapName;
 
   @override
   String localizedDescription(BuildContext context) =>
-      descriptionBuilder?.call(context) ?? description;
+      descriptionBuilder?.call(context) ??
+      displayDescription ??
+      MapsLocalizations.of(context).offlineMapDescription;
 
   @override
   Widget? get previewWidget =>
@@ -311,6 +316,7 @@ class _OfflineMapWrapperState extends State<_OfflineMapWrapper> {
     }
 
     if (_error != null) {
+      final l10n = MapsLocalizations.of(context);
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(16),
@@ -320,8 +326,8 @@ class _OfflineMapWrapperState extends State<_OfflineMapWrapper> {
               const Icon(Icons.error_outline, size: 48, color: Colors.red),
               const SizedBox(height: 16),
               Text(
-                Localizations.localeOf(context).languageCode == 'es' ? 'Error al cargar el mapa offline' : 'Error loading offline map',
-                style: TextStyle(fontWeight: FontWeight.bold),
+                l10n.errorLoadingOfflineMap,
+                style: const TextStyle(fontWeight: FontWeight.bold),
               ),
               const SizedBox(height: 8),
               Text(
@@ -338,7 +344,7 @@ class _OfflineMapWrapperState extends State<_OfflineMapWrapper> {
                   });
                   _ensureInitialized();
                 },
-                child: Text(Localizations.localeOf(context).languageCode == 'es' ? 'Reintentar' : 'Retry'),
+                child: Text(l10n.retry),
               ),
             ],
           ),

--- a/packages/trufi_core_maps/lib/src/presentation/widgets/choose_on_map_screen.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/widgets/choose_on_map_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:latlong2/latlong.dart';
 
+import '../../../l10n/maps_localizations.dart';
 import '../../configuration/map_engine/map_engine_manager.dart';
 import '../../configuration/map_engine/trufi_map_engine.dart';
 import '../../domain/entities/camera.dart';
@@ -20,8 +21,11 @@ class MapLocationResult {
 }
 
 class ChooseOnMapConfiguration {
-  final String title;
-  final String confirmButtonText;
+  /// Title shown in the header. If null, a localized default is used.
+  final String? title;
+
+  /// Label for the confirm button. If null, a localized default is used.
+  final String? confirmButtonText;
   final Widget? centerMarker;
   final bool showCoordinates;
   final double? initialLatitude;
@@ -30,8 +34,8 @@ class ChooseOnMapConfiguration {
   final bool showMapTypeButton;
 
   const ChooseOnMapConfiguration({
-    this.title = 'Choose on Map',
-    this.confirmButtonText = 'Confirm Location',
+    this.title,
+    this.confirmButtonText,
     this.centerMarker,
     this.showCoordinates = true,
     this.initialLatitude,
@@ -63,6 +67,13 @@ class ChooseOnMapConfiguration {
   }
 }
 
+/// Full-screen map picker that returns the coordinates under the crosshair.
+///
+/// When [ChooseOnMapConfiguration.title] or
+/// [ChooseOnMapConfiguration.confirmButtonText] are null they resolve through
+/// [MapsLocalizations]: the enclosing app must register
+/// [MapsLocalizations.delegate] (`TrufiApp` does this automatically) or the
+/// lookup throws at build time.
 class ChooseOnMapScreen extends StatefulWidget {
   final ChooseOnMapConfiguration configuration;
 
@@ -173,7 +184,8 @@ class _ChooseOnMapScreenState extends State<ChooseOnMapScreen> {
                             vertical: 12,
                           ),
                           child: Text(
-                            widget.configuration.title,
+                            widget.configuration.title ??
+                                MapsLocalizations.of(context).chooseOnMap,
                             style: theme.textTheme.titleMedium?.copyWith(
                               fontWeight: FontWeight.w600,
                               color: colorScheme.onSurface,
@@ -264,7 +276,10 @@ class _ChooseOnMapScreenState extends State<ChooseOnMapScreen> {
                     );
                   },
                   icon: const Icon(Icons.check_rounded, size: 22),
-                  label: Text(widget.configuration.confirmButtonText == 'Confirm Location' && Localizations.localeOf(context).languageCode == 'es' ? 'Confirmar ubicación' : widget.configuration.confirmButtonText),
+                  label: Text(
+                    widget.configuration.confirmButtonText ??
+                        MapsLocalizations.of(context).confirmLocation,
+                  ),
                   style: FilledButton.styleFrom(
                     padding: const EdgeInsets.symmetric(vertical: 16),
                     shape: RoundedRectangleBorder(

--- a/packages/trufi_core_maps/lib/src/presentation/widgets/map_selection_widgets.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/widgets/map_selection_widgets.dart
@@ -1,10 +1,16 @@
 import 'package:flutter/material.dart';
 
+import '../../../l10n/maps_localizations.dart';
+
 /// Shared widget for toggling between online and offline maps.
 ///
 /// This widget provides a consistent UI across different screens
 /// (onboarding, settings, map type selection) for switching between
 /// online and offline map types.
+///
+/// The labels resolve through [MapsLocalizations]: the enclosing app must
+/// register [MapsLocalizations.delegate] (`TrufiApp` does this automatically)
+/// or the lookup throws at build time.
 class MapOnlineOfflineToggle extends StatelessWidget {
   /// Whether to show online maps (true) or offline maps (false).
   final bool showOnline;
@@ -27,17 +33,18 @@ class MapOnlineOfflineToggle extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final l10n = MapsLocalizations.of(context);
 
     return SegmentedButton<bool>(
       segments: [
         ButtonSegment<bool>(
           value: true,
-          label: const Text('Online'),
+          label: Text(l10n.online),
           icon: Icon(Icons.cloud_outlined, size: compact ? 18 : 20),
         ),
         ButtonSegment<bool>(
           value: false,
-          label: const Text('Offline'),
+          label: Text(l10n.offline),
           icon: Icon(Icons.offline_bolt_outlined, size: compact ? 18 : 20),
         ),
       ],

--- a/packages/trufi_core_maps/lib/src/presentation/widgets/map_type_button.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/widgets/map_type_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../l10n/maps_localizations.dart';
 import '../../configuration/map_engine/trufi_map_engine.dart';
 import 'map_type_option.dart';
 import 'map_type_settings_screen.dart';
@@ -58,6 +59,10 @@ import 'map_type_settings_screen.dart';
 ///   ),
 /// )
 /// ```
+///
+/// When [tooltip] is null it resolves through [MapsLocalizations]: the
+/// enclosing app must register [MapsLocalizations.delegate] (`TrufiApp` does
+/// this automatically) or the lookup throws at build time.
 class MapTypeButton extends StatelessWidget {
   /// Currently selected map index.
   final int currentMapIndex;
@@ -295,7 +300,7 @@ class _MapTypeButtonBase extends StatelessWidget {
       elevation: 4,
       borderRadius: BorderRadius.circular(borderRadius),
       child: Tooltip(
-        message: tooltip ?? (Localizations.localeOf(context).languageCode == 'es' ? 'Cambiar tipo de mapa' : 'Change map type'),
+        message: tooltip ?? MapsLocalizations.of(context).changeMapType,
         child: IconButton(
           iconSize: iconSize,
           icon: Icon(icon, color: effectiveIconColor),

--- a/packages/trufi_core_maps/lib/src/presentation/widgets/map_type_settings_screen.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/widgets/map_type_settings_screen.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../../../l10n/maps_localizations.dart';
 import 'map_type_option.dart';
 import 'map_selection_widgets.dart';
 
 /// Full-screen settings screen for selecting map type and optional POI layers.
+///
+/// Text defaults resolve through [MapsLocalizations]: the enclosing app must
+/// register [MapsLocalizations.delegate] (`TrufiApp` does this automatically)
+/// or the lookup throws at build time.
 class MapTypeSettingsScreen extends StatefulWidget {
   /// Currently selected map index.
   final int currentMapIndex;
@@ -125,7 +130,9 @@ class _MapTypeSettingsScreenState extends State<MapTypeSettingsScreen>
             _buildAnimatedItem(
               index: 0,
               child: _MapSettingsHeader(
-                title: widget.appBarTitle ?? (Localizations.localeOf(context).languageCode == 'es' ? 'Configuración del mapa' : 'Map Settings'),
+                title:
+                    widget.appBarTitle ??
+                    MapsLocalizations.of(context).mapSettings,
                 onClose: () => Navigator.of(context).pop(),
               ),
             ),
@@ -139,7 +146,9 @@ class _MapTypeSettingsScreenState extends State<MapTypeSettingsScreen>
                   _buildAnimatedItem(
                     index: 1,
                     child: _MapTypeHeroSection(
-                      title: widget.sectionTitle ?? (Localizations.localeOf(context).languageCode == 'es' ? 'Tipo de mapa' : 'Map Type'),
+                      title:
+                          widget.sectionTitle ??
+                          MapsLocalizations.of(context).mapType,
                     ),
                   ),
 
@@ -284,9 +293,7 @@ class _MapTypeHeroSection extends StatelessWidget {
           ),
           const SizedBox(height: 2),
           Text(
-            Localizations.localeOf(context).languageCode == 'es'
-                ? 'Elige tu estilo de mapa preferido'
-                : 'Choose your preferred map style',
+            MapsLocalizations.of(context).chooseMapStyle,
             style: theme.textTheme.bodySmall?.copyWith(
               color: colorScheme.onSurfaceVariant,
             ),

--- a/packages/trufi_core_maps/lib/trufi_core_maps.dart
+++ b/packages/trufi_core_maps/lib/trufi_core_maps.dart
@@ -97,3 +97,8 @@ export 'src/data/spatial/marker_index.dart';
 export 'src/data/utils/image_tool.dart';
 export 'src/data/utils/color_utils.dart';
 export 'src/data/utils/sorted_list.dart';
+
+// ============================================
+// LOCALIZATIONS
+// ============================================
+export 'l10n/maps_localizations.dart';

--- a/packages/trufi_core_maps/pubspec.yaml
+++ b/packages/trufi_core_maps/pubspec.yaml
@@ -12,6 +12,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.20.2
   cached_network_image: ^3.4.1
   dio: ^5.9.0
   equatable: ^2.0.8
@@ -32,3 +35,4 @@ dev_dependencies:
   flutter_lints: ^6.0.0
 
 flutter:
+  generate: true

--- a/packages/trufi_core_maps/test/maps_localizations_test.dart
+++ b/packages/trufi_core_maps/test/maps_localizations_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_maps/trufi_core_maps.dart';
+
+void main() {
+  group('MapsLocalizations delegate registration', () {
+    testWidgets('MapOnlineOfflineToggle renders English defaults '
+        'when the delegate is registered', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: MapsLocalizations.localizationsDelegates,
+          supportedLocales: MapsLocalizations.supportedLocales,
+          home: Scaffold(
+            body: MapOnlineOfflineToggle(showOnline: true, onToggle: (_) {}),
+          ),
+        ),
+      );
+
+      expect(find.text('Online'), findsOneWidget);
+      expect(find.text('Offline'), findsOneWidget);
+    });
+
+    testWidgets('MapOnlineOfflineToggle renders Spanish labels '
+        'for a Spanish locale', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('es'),
+          localizationsDelegates: MapsLocalizations.localizationsDelegates,
+          supportedLocales: MapsLocalizations.supportedLocales,
+          home: Scaffold(
+            body: MapOnlineOfflineToggle(showOnline: true, onToggle: (_) {}),
+          ),
+        ),
+      );
+
+      expect(find.text('En línea'), findsOneWidget);
+      expect(find.text('Sin conexión'), findsOneWidget);
+    });
+
+    testWidgets('widgets throw when the delegate is missing '
+        '(documented breaking change: no implicit English fallback)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MapOnlineOfflineToggle(showOnline: true, onToggle: (_) {}),
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isA<TypeError>());
+    });
+  });
+}

--- a/packages/trufi_core_poi_layers/example/lib/main.dart
+++ b/packages/trufi_core_poi_layers/example/lib/main.dart
@@ -54,7 +54,10 @@ class POILayersExampleApp extends StatelessWidget {
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
           useMaterial3: true,
         ),
-        localizationsDelegates: POILayersLocalizations.localizationsDelegates,
+        localizationsDelegates: [
+          MapsLocalizations.delegate,
+          ...POILayersLocalizations.localizationsDelegates,
+        ],
         supportedLocales: POILayersLocalizations.supportedLocales,
         home: const POILayersDemoPage(),
       ),

--- a/packages/trufi_core_search_locations/example/lib/main.dart
+++ b/packages/trufi_core_search_locations/example/lib/main.dart
@@ -22,6 +22,11 @@ class MyApp extends StatelessWidget {
       ),
       child: MaterialApp(
         title: 'Search Locations Example',
+        localizationsDelegates: const [
+          SearchLocationsLocalizations.delegate,
+          ...MapsLocalizations.localizationsDelegates,
+        ],
+        supportedLocales: SearchLocationsLocalizations.supportedLocales,
         theme: ThemeData(
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
           useMaterial3: true,

--- a/packages/trufi_core_search_locations/example/pubspec.lock
+++ b/packages/trufi_core_search_locations/example/pubspec.lock
@@ -206,6 +206,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_svg:
     dependency: transitive
     description:

--- a/packages/trufi_core_search_locations/l10n.yaml
+++ b/packages/trufi_core_search_locations/l10n.yaml
@@ -1,0 +1,5 @@
+arb-dir: lib/l10n
+template-arb-file: search_locations_en.arb
+output-localization-file: search_locations_localizations.dart
+output-class: SearchLocationsLocalizations
+nullable-getter: false

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_de.arb
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_de.arb
@@ -1,0 +1,12 @@
+{
+  "@@locale": "de",
+  "selectOrigin": "Startort auswählen",
+  "selectDestination": "Zielort auswählen",
+  "searchOrigin": "Startort suchen...",
+  "searchDestination": "Zielort suchen...",
+  "yourLocation": "Dein Standort",
+  "chooseOnMap": "Auf der Karte wählen",
+  "yourPlaces": "DEINE ORTE",
+  "searchResults": "SUCHERGEBNISSE",
+  "noResultsFound": "Keine Ergebnisse gefunden"
+}

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_en.arb
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_en.arb
@@ -1,0 +1,39 @@
+{
+  "@@locale": "en",
+  "selectOrigin": "Select origin",
+  "@selectOrigin": {
+    "description": "Default hint text for the origin field in the search location bar"
+  },
+  "selectDestination": "Select destination",
+  "@selectDestination": {
+    "description": "Default hint text for the destination field in the search location bar"
+  },
+  "searchOrigin": "Search origin...",
+  "@searchOrigin": {
+    "description": "Default hint text for the origin search field on the location search screen"
+  },
+  "searchDestination": "Search destination...",
+  "@searchDestination": {
+    "description": "Default hint text for the destination search field on the location search screen"
+  },
+  "yourLocation": "Your Location",
+  "@yourLocation": {
+    "description": "Label for the quick action that uses the device's current location"
+  },
+  "chooseOnMap": "Choose on Map",
+  "@chooseOnMap": {
+    "description": "Label for the quick action that opens the map picker"
+  },
+  "yourPlaces": "YOUR PLACES",
+  "@yourPlaces": {
+    "description": "Uppercase section title above the saved places list"
+  },
+  "searchResults": "SEARCH RESULTS",
+  "@searchResults": {
+    "description": "Uppercase section title above the search results list"
+  },
+  "noResultsFound": "No results found",
+  "@noResultsFound": {
+    "description": "Message shown when a search returns no results"
+  }
+}

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_es.arb
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_es.arb
@@ -1,0 +1,12 @@
+{
+  "@@locale": "es",
+  "selectOrigin": "Seleccionar origen",
+  "selectDestination": "Seleccionar destino",
+  "searchOrigin": "Buscar origen...",
+  "searchDestination": "Buscar destino...",
+  "yourLocation": "Tu ubicación",
+  "chooseOnMap": "Elegir en el mapa",
+  "yourPlaces": "TUS LUGARES",
+  "searchResults": "RESULTADOS DE BÚSQUEDA",
+  "noResultsFound": "No se encontraron resultados"
+}

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations.dart
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'search_locations_localizations_de.dart';
+import 'search_locations_localizations_en.dart';
+import 'search_locations_localizations_es.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of SearchLocationsLocalizations
+/// returned by `SearchLocationsLocalizations.of(context)`.
+///
+/// Applications need to include `SearchLocationsLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/search_locations_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: SearchLocationsLocalizations.localizationsDelegates,
+///   supportedLocales: SearchLocationsLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the SearchLocationsLocalizations.supportedLocales
+/// property.
+abstract class SearchLocationsLocalizations {
+  SearchLocationsLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static SearchLocationsLocalizations of(BuildContext context) {
+    return Localizations.of<SearchLocationsLocalizations>(
+      context,
+      SearchLocationsLocalizations,
+    )!;
+  }
+
+  static const LocalizationsDelegate<SearchLocationsLocalizations> delegate =
+      _SearchLocationsLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('de'),
+    Locale('en'),
+    Locale('es'),
+  ];
+
+  /// Default hint text for the origin field in the search location bar
+  ///
+  /// In en, this message translates to:
+  /// **'Select origin'**
+  String get selectOrigin;
+
+  /// Default hint text for the destination field in the search location bar
+  ///
+  /// In en, this message translates to:
+  /// **'Select destination'**
+  String get selectDestination;
+
+  /// Default hint text for the origin search field on the location search screen
+  ///
+  /// In en, this message translates to:
+  /// **'Search origin...'**
+  String get searchOrigin;
+
+  /// Default hint text for the destination search field on the location search screen
+  ///
+  /// In en, this message translates to:
+  /// **'Search destination...'**
+  String get searchDestination;
+
+  /// Label for the quick action that uses the device's current location
+  ///
+  /// In en, this message translates to:
+  /// **'Your Location'**
+  String get yourLocation;
+
+  /// Label for the quick action that opens the map picker
+  ///
+  /// In en, this message translates to:
+  /// **'Choose on Map'**
+  String get chooseOnMap;
+
+  /// Uppercase section title above the saved places list
+  ///
+  /// In en, this message translates to:
+  /// **'YOUR PLACES'**
+  String get yourPlaces;
+
+  /// Uppercase section title above the search results list
+  ///
+  /// In en, this message translates to:
+  /// **'SEARCH RESULTS'**
+  String get searchResults;
+
+  /// Message shown when a search returns no results
+  ///
+  /// In en, this message translates to:
+  /// **'No results found'**
+  String get noResultsFound;
+}
+
+class _SearchLocationsLocalizationsDelegate
+    extends LocalizationsDelegate<SearchLocationsLocalizations> {
+  const _SearchLocationsLocalizationsDelegate();
+
+  @override
+  Future<SearchLocationsLocalizations> load(Locale locale) {
+    return SynchronousFuture<SearchLocationsLocalizations>(
+      lookupSearchLocationsLocalizations(locale),
+    );
+  }
+
+  @override
+  bool isSupported(Locale locale) =>
+      <String>['de', 'en', 'es'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_SearchLocationsLocalizationsDelegate old) => false;
+}
+
+SearchLocationsLocalizations lookupSearchLocationsLocalizations(Locale locale) {
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'de':
+      return SearchLocationsLocalizationsDe();
+    case 'en':
+      return SearchLocationsLocalizationsEn();
+    case 'es':
+      return SearchLocationsLocalizationsEs();
+  }
+
+  throw FlutterError(
+    'SearchLocationsLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
+}

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_de.dart
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_de.dart
@@ -1,0 +1,37 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'search_locations_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for German (`de`).
+class SearchLocationsLocalizationsDe extends SearchLocationsLocalizations {
+  SearchLocationsLocalizationsDe([String locale = 'de']) : super(locale);
+
+  @override
+  String get selectOrigin => 'Startort auswählen';
+
+  @override
+  String get selectDestination => 'Zielort auswählen';
+
+  @override
+  String get searchOrigin => 'Startort suchen...';
+
+  @override
+  String get searchDestination => 'Zielort suchen...';
+
+  @override
+  String get yourLocation => 'Dein Standort';
+
+  @override
+  String get chooseOnMap => 'Auf der Karte wählen';
+
+  @override
+  String get yourPlaces => 'DEINE ORTE';
+
+  @override
+  String get searchResults => 'SUCHERGEBNISSE';
+
+  @override
+  String get noResultsFound => 'Keine Ergebnisse gefunden';
+}

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_en.dart
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_en.dart
@@ -1,0 +1,37 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'search_locations_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class SearchLocationsLocalizationsEn extends SearchLocationsLocalizations {
+  SearchLocationsLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get selectOrigin => 'Select origin';
+
+  @override
+  String get selectDestination => 'Select destination';
+
+  @override
+  String get searchOrigin => 'Search origin...';
+
+  @override
+  String get searchDestination => 'Search destination...';
+
+  @override
+  String get yourLocation => 'Your Location';
+
+  @override
+  String get chooseOnMap => 'Choose on Map';
+
+  @override
+  String get yourPlaces => 'YOUR PLACES';
+
+  @override
+  String get searchResults => 'SEARCH RESULTS';
+
+  @override
+  String get noResultsFound => 'No results found';
+}

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_es.dart
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_es.dart
@@ -1,0 +1,37 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'search_locations_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Spanish Castilian (`es`).
+class SearchLocationsLocalizationsEs extends SearchLocationsLocalizations {
+  SearchLocationsLocalizationsEs([String locale = 'es']) : super(locale);
+
+  @override
+  String get selectOrigin => 'Seleccionar origen';
+
+  @override
+  String get selectDestination => 'Seleccionar destino';
+
+  @override
+  String get searchOrigin => 'Buscar origen...';
+
+  @override
+  String get searchDestination => 'Buscar destino...';
+
+  @override
+  String get yourLocation => 'Tu ubicación';
+
+  @override
+  String get chooseOnMap => 'Elegir en el mapa';
+
+  @override
+  String get yourPlaces => 'TUS LUGARES';
+
+  @override
+  String get searchResults => 'RESULTADOS DE BÚSQUEDA';
+
+  @override
+  String get noResultsFound => 'No se encontraron resultados';
+}

--- a/packages/trufi_core_search_locations/lib/src/models/search_location_bar_configuration.dart
+++ b/packages/trufi_core_search_locations/lib/src/models/search_location_bar_configuration.dart
@@ -5,10 +5,12 @@ import 'search_location.dart';
 /// Configuration for the search location bar appearance and behavior.
 class SearchLocationBarConfiguration {
   /// Hint text shown when origin field is empty.
-  final String originHintText;
+  /// If null, a localized default is used.
+  final String? originHintText;
 
   /// Hint text shown when destination field is empty.
-  final String destinationHintText;
+  /// If null, a localized default is used.
+  final String? destinationHintText;
 
   /// Widget shown as leading icon for the origin field.
   final Widget? originLeadingWidget;
@@ -26,8 +28,8 @@ class SearchLocationBarConfiguration {
   final EdgeInsets padding;
 
   const SearchLocationBarConfiguration({
-    this.originHintText = 'Select origin',
-    this.destinationHintText = 'Select destination',
+    this.originHintText,
+    this.destinationHintText,
     this.originLeadingWidget,
     this.destinationLeadingWidget,
     this.fieldBorderRadius = const BorderRadius.all(Radius.circular(8.0)),

--- a/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
+++ b/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
@@ -2,31 +2,34 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 
+import '../../l10n/search_locations_localizations.dart';
 import '../models/search_location.dart';
 import '../services/search_location_service.dart';
 
 /// Configuration for [LocationSearchScreen].
+///
+/// Text fields fall back to localized defaults when null.
 class LocationSearchScreenConfiguration {
   /// Hint text for origin search.
-  final String originHintText;
+  final String? originHintText;
 
   /// Hint text for destination search.
-  final String destinationHintText;
+  final String? destinationHintText;
 
   /// Text for "Your Location" option.
-  final String yourLocationText;
+  final String? yourLocationText;
 
   /// Text for "Choose on Map" option.
-  final String chooseOnMapText;
+  final String? chooseOnMapText;
 
   /// Title for "Your Places" section.
-  final String yourPlacesTitle;
+  final String? yourPlacesTitle;
 
   /// Title for "Search Results" section.
-  final String searchResultsTitle;
+  final String? searchResultsTitle;
 
   /// Text shown when no results are found.
-  final String noResultsText;
+  final String? noResultsText;
 
   /// Icon for "Your Location" option.
   final IconData yourLocationIcon;
@@ -38,13 +41,13 @@ class LocationSearchScreenConfiguration {
   final IconData Function(String id)? placeIconBuilder;
 
   const LocationSearchScreenConfiguration({
-    this.originHintText = 'Search origin...',
-    this.destinationHintText = 'Search destination...',
-    this.yourLocationText = 'Your Location',
-    this.chooseOnMapText = 'Choose on Map',
-    this.yourPlacesTitle = 'YOUR PLACES',
-    this.searchResultsTitle = 'SEARCH RESULTS',
-    this.noResultsText = 'No results found',
+    this.originHintText,
+    this.destinationHintText,
+    this.yourLocationText,
+    this.chooseOnMapText,
+    this.yourPlacesTitle,
+    this.searchResultsTitle,
+    this.noResultsText,
     this.yourLocationIcon = Icons.gps_fixed,
     this.chooseOnMapIcon = Icons.map,
     this.placeIconBuilder,
@@ -54,6 +57,10 @@ class LocationSearchScreenConfiguration {
 /// A search screen with Your Location, Choose on Map, Your Places, and search results.
 ///
 /// Returns a [SearchLocation] when a location is selected.
+///
+/// Text defaults resolve through [SearchLocationsLocalizations]: the
+/// enclosing app must register [SearchLocationsLocalizations.delegate]
+/// (`TrufiApp` does this automatically) or the lookup throws at build time.
 class LocationSearchScreen extends StatefulWidget {
   /// Whether searching for origin (true) or destination (false).
   final bool isOrigin;
@@ -222,6 +229,7 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final config = widget.configuration;
+    final l10n = SearchLocationsLocalizations.of(context);
 
     return Scaffold(
       backgroundColor: colorScheme.surface,
@@ -235,8 +243,8 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
                 controller: _searchController,
                 focusNode: _searchFocusNode,
                 hintText: widget.isOrigin
-                    ? config.originHintText
-                    : config.destinationHintText,
+                    ? (config.originHintText ?? l10n.searchOrigin)
+                    : (config.destinationHintText ?? l10n.searchDestination),
                 query: _query,
                 onChanged: (value) {
                   setState(() {
@@ -298,8 +306,10 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
                                 }
                               }
                             : null,
-                        yourLocationText: config.yourLocationText,
-                        chooseOnMapText: config.chooseOnMapText,
+                        yourLocationText:
+                            config.yourLocationText ?? l10n.yourLocation,
+                        chooseOnMapText:
+                            config.chooseOnMapText ?? l10n.chooseOnMap,
                         yourLocationIcon: config.yourLocationIcon,
                         chooseOnMapIcon: config.chooseOnMapIcon,
                       ),
@@ -311,7 +321,9 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
                   if (_query.isEmpty && _myPlaces.isNotEmpty) ...[
                     _buildAnimatedItem(
                       index: 2,
-                      child: _SectionTitle(title: config.yourPlacesTitle),
+                      child: _SectionTitle(
+                        title: config.yourPlacesTitle ?? l10n.yourPlaces,
+                      ),
                     ),
                     const SizedBox(height: 8),
                     _buildAnimatedItem(
@@ -330,7 +342,9 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
 
                   // Search Results
                   if (_query.isNotEmpty) ...[
-                    _SectionTitle(title: config.searchResultsTitle),
+                    _SectionTitle(
+                      title: config.searchResultsTitle ?? l10n.searchResults,
+                    ),
                     const SizedBox(height: 8),
                     if (_isSearching)
                       const Padding(
@@ -338,7 +352,9 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
                         child: Center(child: CircularProgressIndicator()),
                       )
                     else if (_searchResults.isEmpty)
-                      _EmptySearchResults(text: config.noResultsText)
+                      _EmptySearchResults(
+                        text: config.noResultsText ?? l10n.noResultsFound,
+                      )
                     else
                       ...List.generate(_searchResults.length, (index) {
                         final location = _searchResults[index];
@@ -624,7 +640,9 @@ class _QuickActionItem extends StatelessWidget {
                           height: 20,
                           child: CircularProgressIndicator(
                             strokeWidth: 2.2,
-                            valueColor: AlwaysStoppedAnimation<Color>(iconColor),
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              iconColor,
+                            ),
                           ),
                         ),
                       )

--- a/packages/trufi_core_search_locations/lib/src/widgets/search_location_bar.dart
+++ b/packages/trufi_core_search_locations/lib/src/widgets/search_location_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../../l10n/search_locations_localizations.dart';
 import '../models/search_location_bar_configuration.dart';
 import '../models/search_location_state.dart';
 
@@ -12,6 +13,11 @@ import '../models/search_location_state.dart';
 /// - Visual connection between origin and destination
 /// - Responsive layout for portrait/landscape
 /// - Haptic feedback on interactions
+///
+/// When the configuration hint texts are null they resolve through
+/// [SearchLocationsLocalizations]: the enclosing app must register
+/// [SearchLocationsLocalizations.delegate] (`TrufiApp` does this
+/// automatically) or the lookup throws at build time.
 class SearchLocationBar extends StatelessWidget {
   /// The current state containing origin and destination.
   final SearchLocationState state;
@@ -148,7 +154,9 @@ class SearchLocationBar extends StatelessWidget {
                     // Origin field with clear button
                     _LocationFieldWithClear(
                       isOrigin: true,
-                      hintText: configuration.originHintText,
+                      hintText:
+                          configuration.originHintText ??
+                          SearchLocationsLocalizations.of(context).selectOrigin,
                       value: state.origin,
                       onTap: () => _handleSearch(context, isOrigin: true),
                       onClear: onClearLocation != null
@@ -163,7 +171,11 @@ class SearchLocationBar extends StatelessWidget {
                     // Destination field with clear button
                     _LocationFieldWithClear(
                       isOrigin: false,
-                      hintText: configuration.destinationHintText,
+                      hintText:
+                          configuration.destinationHintText ??
+                          SearchLocationsLocalizations.of(
+                            context,
+                          ).selectDestination,
                       value: state.destination,
                       onTap: () => _handleSearch(context, isOrigin: false),
                       onClear: onClearLocation != null
@@ -259,7 +271,9 @@ class SearchLocationBar extends StatelessWidget {
         Expanded(
           child: _LocationFieldModernWithClear(
             isOrigin: true,
-            hintText: configuration.originHintText,
+            hintText:
+                configuration.originHintText ??
+                SearchLocationsLocalizations.of(context).selectOrigin,
             value: state.origin,
             onTap: () => _handleSearch(context, isOrigin: true),
             onClear: onClearLocation != null && state.origin != null
@@ -299,7 +313,9 @@ class SearchLocationBar extends StatelessWidget {
         Expanded(
           child: _LocationFieldModernWithClear(
             isOrigin: false,
-            hintText: configuration.destinationHintText,
+            hintText:
+                configuration.destinationHintText ??
+                SearchLocationsLocalizations.of(context).selectDestination,
             value: state.destination,
             onTap: () => _handleSearch(context, isOrigin: false),
             onClear: onClearLocation != null && state.destination != null

--- a/packages/trufi_core_search_locations/lib/trufi_core_search_locations.dart
+++ b/packages/trufi_core_search_locations/lib/trufi_core_search_locations.dart
@@ -57,3 +57,6 @@ export 'src/saved_places/repository/search_locations_repository_impl.dart';
 
 // Saved Places - Cubit
 export 'src/saved_places/cubit/search_locations_cubit.dart';
+
+// Localizations
+export 'l10n/search_locations_localizations.dart';

--- a/packages/trufi_core_search_locations/pubspec.yaml
+++ b/packages/trufi_core_search_locations/pubspec.yaml
@@ -12,6 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   equatable: ^2.0.8
   flutter_bloc: ^9.1.1
   http: ^1.6.0
@@ -27,3 +29,6 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^6.0.0
   mocktail: ^1.0.4
+
+flutter:
+  generate: true

--- a/packages/trufi_core_search_locations/test/unit/search_location_bar_configuration_test.dart
+++ b/packages/trufi_core_search_locations/test/unit/search_location_bar_configuration_test.dart
@@ -8,8 +8,9 @@ void main() {
     test('creates instance with default values', () {
       const config = SearchLocationBarConfiguration();
 
-      expect(config.originHintText, 'Select origin');
-      expect(config.destinationHintText, 'Select destination');
+      // Hint texts default to null; widgets resolve localized defaults.
+      expect(config.originHintText, isNull);
+      expect(config.destinationHintText, isNull);
       expect(config.originLeadingWidget, isNull);
       expect(config.destinationLeadingWidget, isNull);
       expect(
@@ -52,7 +53,7 @@ void main() {
       );
 
       expect(config.originHintText, 'Custom Origin');
-      expect(config.destinationHintText, 'Select destination');
+      expect(config.destinationHintText, isNull);
       expect(config.fieldHeight, 50.0);
       expect(config.padding, const EdgeInsets.all(5.0));
     });

--- a/packages/trufi_core_search_locations/test/unit/search_locations_localizations_test.dart
+++ b/packages/trufi_core_search_locations/test/unit/search_locations_localizations_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_search_locations/trufi_core_search_locations.dart';
+
+void main() {
+  Widget buildBar() => Scaffold(
+    body: SearchLocationBar(
+      state: const SearchLocationState(),
+      onSearch: ({required bool isOrigin}) async => null,
+      onOriginSelected: (_) {},
+      onDestinationSelected: (_) {},
+    ),
+  );
+
+  group('SearchLocationsLocalizations delegate registration', () {
+    testWidgets('SearchLocationBar renders English defaults '
+        'when the delegate is registered', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates:
+              SearchLocationsLocalizations.localizationsDelegates,
+          supportedLocales: SearchLocationsLocalizations.supportedLocales,
+          home: buildBar(),
+        ),
+      );
+
+      expect(find.text('Select origin'), findsOneWidget);
+      expect(find.text('Select destination'), findsOneWidget);
+    });
+
+    testWidgets('SearchLocationBar renders Spanish hints '
+        'for a Spanish locale', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('es'),
+          localizationsDelegates:
+              SearchLocationsLocalizations.localizationsDelegates,
+          supportedLocales: SearchLocationsLocalizations.supportedLocales,
+          home: buildBar(),
+        ),
+      );
+
+      expect(find.text('Seleccionar origen'), findsOneWidget);
+      expect(find.text('Seleccionar destino'), findsOneWidget);
+    });
+
+    testWidgets('widgets throw when the delegate is missing '
+        '(documented breaking change: no implicit English fallback)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(MaterialApp(home: buildBar()));
+
+      expect(tester.takeException(), isA<TypeError>());
+    });
+  });
+}


### PR DESCRIPTION
Part of #871 — the "screens with no l10n at all" slice: bootstraps localization infrastructure for `trufi_core_maps` and `trufi_core_search_locations` from scratch and localizes 25 strings (map settings, choose-on-map, engine names/descriptions, the whole search screen).

Infrastructure (mirrors `trufi_core_routing`):
- `l10n.yaml` + `maps_{en,es,de}.arb` / `search_locations_{en,es,de}.arb`, `flutter_localizations` + `generate: true` in both pubspecs, generated classes committed, `MapsLocalizations`/`SearchLocationsLocalizations` exported from the package barrels, tracked example `pubspec.lock`s updated.
- Delegates registered where they flow into apps: `HomeScreenTrufiScreen` (maps + search) and `TransportListTrufiScreen` (maps), plus the three affected example apps (maps, search_locations, poi_layers).

Pattern for context-less config/data classes: text fields become nullable (`ChooseOnMapConfiguration`, `SearchLocationBarConfiguration`, `LocationSearchScreenConfiguration`) and widgets resolve `null` via l10n; map engines get a `builder → displayName → l10n` fallback chain, which also fixes the Spanish-only `'Mapa vectorial claro/oscuro'`/`'Mapa completamente offline'` leaking into every locale. One documented skip: `'Vector (MapLibre)'` is a technical/brand label.

**Documented breaking edge**: widgets that resolve omitted text via these localizations now require the corresponding delegate when embedded in a standalone `MaterialApp` (TrufiApp-based apps are unaffected — delegates arrive via screen registration). Called out in the new README "Localization" section and in dartdoc on each affected widget; guarded by 6 new widget tests (en render, es render, and the delegate-less failure mode for both packages).

Verification: Translation Check replicated locally, `flutter analyze` clean in both packages, both examples, poi_layers example, home_screen and transport_list; maps 27/27, search_locations 63 passing with failures confined to the pre-existing live-network test files (byte-identical to main).
