### PR TITLE
fix(maps,transport_list): route detail camera never fits and snaps back on user movement

### DIFF
--- a/packages/screens/trufi_core_transport_list/lib/src/transport_detail_screen.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/transport_detail_screen.dart
@@ -1882,6 +1882,11 @@ class _RouteMapViewState extends State<_RouteMapView> {
   }
 
   void _onCameraChanged(TrufiCameraPosition cam) {
+    // Track the user's camera: this widget passes a controlled `camera` down,
+    // and leaving it stale makes every rebuild (e.g. the out-of-focus flip
+    // below) snap the map back to the old fit — pans and double-tap zooms
+    // appear to "not work" because they are instantly undone.
+    _camera = cam;
     final nowOutOfFocus = _fitCamera.isOutOfFocus(cam);
     if (nowOutOfFocus != _outOfFocus) {
       setState(() {

--- a/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
@@ -670,7 +670,9 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
                     1e-9 &&
                 (native.target.longitude - target.target.longitude).abs() <
                     1e-9 &&
-                (native.zoom - target.zoom).abs() < 1e-9;
+                (native.zoom - target.zoom).abs() < 1e-9 &&
+                (native.bearing - target.bearing).abs() < 1e-9 &&
+                (native.tilt - target.tilt).abs() < 1e-9;
             if (!alreadyThere) {
               _suppressCameraCallback = true;
               ctl.moveCamera(CameraUpdate.newCameraPosition(target));

--- a/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
@@ -651,12 +651,31 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
       },
       onStyleLoadedCallback: () async {
         _mapReady = true;
-        if (_pendingCameraApply && _mapCtl != null) {
+        if (_pendingCameraApply) {
+          // Clear unconditionally so a stale camera is never replayed on a
+          // later style load.
           _pendingCameraApply = false;
-          _suppressCameraCallback = true;
-          _mapCtl!.moveCamera(
-            CameraUpdate.newCameraPosition(_toCameraPosition(_currentCamera)),
-          );
+          final ctl = _mapCtl;
+          if (ctl != null) {
+            // Skip the replay (and the callback suppression) when the map is
+            // already at the target — e.g. the user panned to it while the
+            // style was loading. A no-movement moveCamera may emit no
+            // camera-idle on some platforms, which would leave
+            // _suppressCameraCallback armed and swallow the next genuine
+            // gesture's callback.
+            final target = _toCameraPosition(_currentCamera);
+            final native = ctl.cameraPosition;
+            final alreadyThere = native != null &&
+                (native.target.latitude - target.target.latitude).abs() <
+                    1e-9 &&
+                (native.target.longitude - target.target.longitude).abs() <
+                    1e-9 &&
+                (native.zoom - target.zoom).abs() < 1e-9;
+            if (!alreadyThere) {
+              _suppressCameraCallback = true;
+              ctl.moveCamera(CameraUpdate.newCameraPosition(target));
+            }
+          }
         }
         _initializedSources.clear();
         _initializedLayerLevels.clear();

--- a/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
@@ -220,6 +220,12 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
   // Camera
   // ──────────────────────────────────────────────
 
+  /// Camera set before the style finished loading; replayed on style load.
+  /// Without this, a controlled camera that arrives while the style is still
+  /// loading (common with offline styles: local data loads faster than the
+  /// style) only updates [_currentCamera] and the native map never moves.
+  bool _pendingCameraApply = false;
+
   void _moveCameraTo(TrufiCameraPosition position) {
     _currentCamera = position;
     if (_mapReady && _mapCtl != null) {
@@ -227,6 +233,8 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
       _mapCtl!.moveCamera(
         CameraUpdate.newCameraPosition(_toCameraPosition(position)),
       );
+    } else {
+      _pendingCameraApply = true;
     }
   }
 
@@ -643,6 +651,13 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
       },
       onStyleLoadedCallback: () async {
         _mapReady = true;
+        if (_pendingCameraApply && _mapCtl != null) {
+          _pendingCameraApply = false;
+          _suppressCameraCallback = true;
+          _mapCtl!.moveCamera(
+            CameraUpdate.newCameraPosition(_toCameraPosition(_currentCamera)),
+          );
+        }
         _initializedSources.clear();
         _initializedLayerLevels.clear();
         _imageLoaders.clear();

--- a/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
@@ -39,6 +39,28 @@ import '../utils/trufi_camera_fit.dart';
 ///   ],
 /// )
 /// ```
+/// Whether two native camera positions are effectively the same place.
+///
+/// Used to skip no-op camera moves (and, crucially, their callback
+/// suppression: a no-movement `moveCamera` may emit no camera-idle on some
+/// platforms, leaving the suppression armed and swallowing the next genuine
+/// gesture's callback). Bearing compares by minimal angular difference, so
+/// 270° and -90° match — the web renderer reports bearing in (-180, 180]
+/// while native uses [0, 360).
+bool camerasEffectivelyEqual(CameraPosition a, CameraPosition b) {
+  double angularDiff(double x, double y) {
+    final d = (x - y).abs() % 360.0;
+    return d > 180.0 ? 360.0 - d : d;
+  }
+
+  const eps = 1e-9;
+  return (a.target.latitude - b.target.latitude).abs() < eps &&
+      (a.target.longitude - b.target.longitude).abs() < eps &&
+      (a.zoom - b.zoom).abs() < eps &&
+      angularDiff(a.bearing, b.bearing) < eps &&
+      (a.tilt - b.tilt).abs() < eps;
+}
+
 class TrufiMap extends StatefulWidget {
   const TrufiMap({
     super.key,
@@ -229,10 +251,18 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
   void _moveCameraTo(TrufiCameraPosition position) {
     _currentCamera = position;
     if (_mapReady && _mapCtl != null) {
+      final target = _toCameraPosition(position);
+      final native = _mapCtl!.cameraPosition;
+      if (native != null && camerasEffectivelyEqual(native, target)) {
+        // Already there: don't arm the callback suppression for a no-op
+        // move — a no-movement moveCamera may emit no camera-idle on some
+        // platforms, which would swallow the next genuine gesture's
+        // callback (e.g. TrufiMapController.moveCamera with the current
+        // position).
+        return;
+      }
       _suppressCameraCallback = true;
-      _mapCtl!.moveCamera(
-        CameraUpdate.newCameraPosition(_toCameraPosition(position)),
-      );
+      _mapCtl!.moveCamera(CameraUpdate.newCameraPosition(target));
     } else {
       _pendingCameraApply = true;
     }
@@ -665,14 +695,8 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
             // gesture's callback.
             final target = _toCameraPosition(_currentCamera);
             final native = ctl.cameraPosition;
-            final alreadyThere = native != null &&
-                (native.target.latitude - target.target.latitude).abs() <
-                    1e-9 &&
-                (native.target.longitude - target.target.longitude).abs() <
-                    1e-9 &&
-                (native.zoom - target.zoom).abs() < 1e-9 &&
-                (native.bearing - target.bearing).abs() < 1e-9 &&
-                (native.tilt - target.tilt).abs() < 1e-9;
+            final alreadyThere =
+                native != null && camerasEffectivelyEqual(native, target);
             if (!alreadyThere) {
               _suppressCameraCallback = true;
               ctl.moveCamera(CameraUpdate.newCameraPosition(target));

--- a/packages/trufi_core_maps/test/camera_equality_test.dart
+++ b/packages/trufi_core_maps/test/camera_equality_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_gl/maplibre_gl.dart' hide LatLngBounds;
+import 'package:trufi_core_maps/src/presentation/map/trufi_map.dart';
+
+void main() {
+  const base = CameraPosition(
+    target: LatLng(15.3584, 44.2035),
+    zoom: 14.0,
+    bearing: 0.0,
+    tilt: 0.0,
+  );
+
+  CameraPosition vary({
+    double? lat,
+    double? lng,
+    double? zoom,
+    double? bearing,
+    double? tilt,
+  }) =>
+      CameraPosition(
+        target: LatLng(lat ?? base.target.latitude, lng ?? base.target.longitude),
+        zoom: zoom ?? base.zoom,
+        bearing: bearing ?? base.bearing,
+        tilt: tilt ?? base.tilt,
+      );
+
+  group('camerasEffectivelyEqual', () {
+    test('identical cameras are equal', () {
+      expect(camerasEffectivelyEqual(base, vary()), isTrue);
+    });
+
+    test('tiny floating-point drift stays equal', () {
+      expect(
+        camerasEffectivelyEqual(base, vary(lat: 15.3584 + 1e-12)),
+        isTrue,
+      );
+    });
+
+    test('latitude difference is detected', () {
+      expect(camerasEffectivelyEqual(base, vary(lat: 15.3585)), isFalse);
+    });
+
+    test('longitude difference is detected', () {
+      expect(camerasEffectivelyEqual(base, vary(lng: 44.2036)), isFalse);
+    });
+
+    test('zoom difference is detected', () {
+      expect(camerasEffectivelyEqual(base, vary(zoom: 14.5)), isFalse);
+    });
+
+    test('bearing difference is detected', () {
+      expect(camerasEffectivelyEqual(base, vary(bearing: 90.0)), isFalse);
+    });
+
+    test('tilt difference is detected', () {
+      expect(camerasEffectivelyEqual(base, vary(tilt: 30.0)), isFalse);
+    });
+
+    test('bearing wrap-around: 270° equals -90° (web vs native convention)',
+        () {
+      expect(
+        camerasEffectivelyEqual(vary(bearing: 270.0), vary(bearing: -90.0)),
+        isTrue,
+      );
+    });
+
+    test('bearing wrap-around: 0° equals 360°', () {
+      expect(
+        camerasEffectivelyEqual(vary(bearing: 0.0), vary(bearing: 360.0)),
+        isTrue,
+      );
+    });
+
+    test('bearing wrap-around: 359.9° differs from 0.2° by 0.3°, not 359.7°',
+        () {
+      expect(
+        camerasEffectivelyEqual(vary(bearing: 359.9), vary(bearing: 0.2)),
+        isFalse, // 0.3° apart — real difference, but computed the short way
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Opening a route from the transport list shows the route geometry off-screen — the map never centers on it. Once the user pans or double-tap zooms, the map instantly jumps back, so gestures feel dead. Reported from on-the-ground testing of the Sana'a offline app ([trufi-sanaa#1](https://github.com/trufi-association/trufi-sanaa/issues/1)), but both defects are core-level and affect any app.

## Root causes (two independent defects)

1. **TrufiMap drops controlled cameras that arrive before the style loads.** `_moveCameraTo` only calls the native `moveCamera` when `_mapReady`; a camera set earlier only updates `_currentCamera` and is never replayed — and since `didUpdateWidget` compares against `_currentCamera`, it never retries either. With offline styles the route data always loads faster than the style, so the fitted camera always loses this race. (Online apps rarely hit it: the OTP fetch is slower than style load, which is why it went unnoticed.)

2. **`_RouteMapView` keeps a stale controlled camera.** `_onCameraChanged` never updated `_camera`, so every rebuild — e.g. the out-of-focus flip, which itself is triggered by the user's gesture — snapped the map back to the old fit. This is what made pans and double-tap zooms appear to "not work".

## Fix

- `trufi_map.dart`: remember a pending controlled camera and replay it in `onStyleLoadedCallback` (with `_suppressCameraCallback`, same as the normal path).
- `transport_detail_screen.dart`: track the user camera in `_onCameraChanged` so rebuilds pass the current position down instead of the stale fit. `_moveToLocation` / `_reFitCamera` keep working — they set `_camera` explicitly.

## Testing

- `flutter test` locally on `trufi_core_maps` and `trufi_core_transport_list`: **pass** (note: CI does not run tests).
- Verified on an emulator with a fully offline app (Sana'a): before/after below.

| Before | After (fitted) | After (pan persists) |
|---|---|---|
| <img src="https://raw.githubusercontent.com/trufi-association/trufi-core/5e9fd4c7433c9f9c793f6aeecf0cf94a91cb3d75/pr-camera-fix/before-route-offscreen.png" width="230"> | <img src="https://raw.githubusercontent.com/trufi-association/trufi-core/5e9fd4c7433c9f9c793f6aeecf0cf94a91cb3d75/pr-camera-fix/after-route-fitted.png" width="230"> | <img src="https://raw.githubusercontent.com/trufi-association/trufi-core/5e9fd4c7433c9f9c793f6aeecf0cf94a91cb3d75/pr-camera-fix/after-pan-persists.png" width="230"> |