### PR TITLE
fix(home_screen): keep the viewport when switching map engines

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -1047,12 +1047,22 @@ class _HomeScreenState extends State<HomeScreen>
     }
   }
 
+  /// Moves the camera and records the destination in [_currentCamera].
+  /// Programmatic moves suppress the map's onCameraChanged callback, so
+  /// without this the recorded viewport goes stale and an engine switch
+  /// right after (e.g. my-location → change map style) snaps back to the
+  /// previous view (#902).
+  void _moveCameraTracked(TrufiCameraPosition position) {
+    _currentCamera = position;
+    _mapController?.moveCamera(position);
+  }
+
   Future<void> _onMyLocationPressed() async {
     // If already tracking, just center the map on current location
     if (_locationService.isTracking) {
       final location = _locationService.currentLocation;
       if (location != null) {
-        _mapController?.moveCamera(
+        _moveCameraTracked(
           TrufiCameraPosition(
             target: LatLng(location.latitude, location.longitude),
             zoom: 16,
@@ -1080,7 +1090,7 @@ class _HomeScreenState extends State<HomeScreen>
         // immediate feedback while the accurate fix is still being acquired.
         final lastKnown = await _locationService.getLastKnownLocation();
         if (lastKnown != null && mounted) {
-          _mapController?.moveCamera(
+          _moveCameraTracked(
             TrufiCameraPosition(
               target: LatLng(lastKnown.latitude, lastKnown.longitude),
               zoom: 16,
@@ -1095,7 +1105,7 @@ class _HomeScreenState extends State<HomeScreen>
         if (started && mounted) {
           final location = _locationService.currentLocation;
           if (location != null) {
-            _mapController?.moveCamera(
+            _moveCameraTracked(
               TrufiCameraPosition(
                 target: LatLng(location.latitude, location.longitude),
                 zoom: 16,

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -1488,7 +1488,10 @@ class _HomeScreenState extends State<HomeScreen>
   Widget _buildMap(ITrufiMapEngine engine) {
     return engine.buildMap(
       controller: _mapController,
-      initialCamera: _initialCamera!,
+      // A new engine builds a fresh map widget, so start it at the last
+      // reported viewport — otherwise switching map style resets the
+      // camera to the default city view (#902).
+      initialCamera: _currentCamera ?? _initialCamera!,
       camera: _cameraTarget,
       onCameraChanged: _onCameraChanged,
       onMapClick: _onMapClick,


### PR DESCRIPTION
Fixes #902.

## Problem

Changing the map style on the home screen resets the camera to the default city view. Each style in the map-type selector is a separate engine, and `setEngine` rebuilds the map with a brand-new widget — which started at the static `_initialCamera` (default center/zoom) instead of where the user actually was.

Reproduced on v5.20.0 (so the camera-lifecycle fixes from #946 don't cover this case — they act within a single map's life, not across engine swaps).

## Fix

One line in `_buildMap`: start the new engine's map at `_currentCamera` (the last camera reported by `onCameraChanged`, already tracked by the screen) and fall back to `_initialCamera` on first build.

Scope note: the transport detail screen is not affected (it drives the camera in controlled mode, which already carries across engine swaps), and `choose_on_map` can't reach an engine switch while open — so this is intentionally home-screen-only.

## Testing

- `flutter test` across all packages: green except `trufi_core_routing`, `trufi_core_search_locations`, `trufi_core_utils` — verified failing identically on clean `main` (preexisting: network-dependent integration tests, scoring test, placeholder files).
- Emulator before/after evidence in the review comment below.
