### PR TITLE
fix(maps): use hybrid composition on Android to stop platform-view crash

### DIFF
--- a/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
@@ -2,7 +2,8 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'dart:math' show Point;
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart'
+    show kIsWeb, defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:maplibre_gl/maplibre_gl.dart' hide LatLngBounds;
@@ -140,6 +141,14 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
   @override
   void initState() {
     super.initState();
+    // Render the native map with hybrid composition. Despite its docs, the
+    // plugin's actual default is Virtual Display, whose resize-after-dispose
+    // race kills the app with an NPE in VirtualDisplayController when map
+    // views are created and destroyed repeatedly — e.g. picking locations
+    // on the map or from search over and over (#948/#949).
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
+      MapLibreMap.useHybridComposition = true;
+    }
     _currentCamera = widget.camera ?? widget.initialCamera;
     widget.controller?.attach(this);
   }


### PR DESCRIPTION
Fixes #948, fixes #949.

## Problem

Repeatedly picking locations (on the map or from search) makes the map flicker and eventually crashes the app. Reproduced deterministically on emulator: **Trufi App v5.1.0 died in 9 iterations, the core example app (v5.20) in 4**, both with the identical fatal NPE on the main thread:

```
java.lang.NullPointerException: Attempt to invoke interface method
'int io.flutter.view.TextureRegistry$SurfaceProducer.getWidth()' on a null object reference
  at io.flutter.plugin.platform.SurfaceProducerPlatformViewRenderTarget.getWidth
  at io.flutter.plugin.platform.VirtualDisplayController.getRenderTargetWidth
  at io.flutter.plugin.platform.PlatformViewsController$1.lambda$resize$0
```

**Root cause:** maplibre_gl's docs claim hybrid composition is the default, but the actual default in the platform interface is `useHybridComposition = false` — every Trufi map runs in **Virtual Display** mode. That mode has a resize-after-dispose race: each choose-on-map / search flow creates and destroys a map platform view while the keyboard drives viewport resizes, and eventually a resize lands on a view whose SurfaceProducer was already released → NPE → crash. Memory stays flat across cycles (measured) — it's a lifecycle race, not a leak.

## Fix

Opt in to **hybrid composition** on Android (one guarded static set in TrufiMap's initState), which bypasses VirtualDisplayController entirely. The plugin's own docs note Virtual Display "may result in errors on Android 12" — this is that class of error.

Trade-off: hybrid composition can be slower on Android 9 and below; Virtual Display crashes on modern Android. The reported devices (Redmi, Android 13/16) are exactly the affected cohort.

## Testing

- Baseline (unfixed): crash in 4 iterations on the example app, 9 on Trufi App.
- Fixed build: **15 iterations clean**, empty crash buffer, flat memory, map renders and pans normally (screenshot in review comment).
- `flutter test`: trufi_core_maps 37/37; the 5 red packages (custom_material, planner, routing, search_locations, utils) fail identically on clean `main` (preexisting/flaky, verified today).