### PR TITLE
fix(routing): route lines no longer share the my-location blue

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -2751,12 +2751,9 @@ TrufiLocation _searchLocationToTrufiLocation(SearchLocation location) {
   );
 }
 
-Color _parseColor(String hexColor, {Color fallback = const Color(0xFF1976D2)}) {
+Color _parseColor(String hexColor, {required Color fallback}) {
   try {
     final hex = hexColor.replaceFirst('#', '');
-    // GTFS treats an absent route_color as white (FFFFFF) — that's "no
-    // color", not a paintable line color, so fall back too.
-    if (hex.toUpperCase() == 'FFFFFF') return fallback;
     return Color(int.parse('FF$hex', radix: 16));
   } catch (_) {
     return fallback;

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -826,8 +826,13 @@ class _HomeScreenState extends State<HomeScreen>
       final bool useDots;
 
       if (leg.transitLeg) {
-        // Transit legs use route color
-        color = _parseColor(leg.routeColor);
+        // Transit legs use the GTFS route color; without one, fall back to
+        // the app's brand color instead of a blue that reads exactly like
+        // the my-location dot (#930).
+        color = _parseColor(
+          leg.routeColor,
+          fallback: Theme.of(context).colorScheme.primary,
+        );
         lineWidth = 6;
         useDots = false;
       } else if (leg.transportMode == routing.TransportMode.bicycle) {
@@ -2746,12 +2751,15 @@ TrufiLocation _searchLocationToTrufiLocation(SearchLocation location) {
   );
 }
 
-Color _parseColor(String hexColor) {
+Color _parseColor(String hexColor, {Color fallback = const Color(0xFF1976D2)}) {
   try {
     final hex = hexColor.replaceFirst('#', '');
+    // GTFS treats an absent route_color as white (FFFFFF) — that's "no
+    // color", not a paintable line color, so fall back too.
+    if (hex.toUpperCase() == 'FFFFFF') return fallback;
     return Color(int.parse('FF$hex', radix: 16));
   } catch (_) {
-    return const Color(0xFF1976D2);
+    return fallback;
   }
 }
 

--- a/packages/trufi_core_routing/lib/src/models/itinerary.dart
+++ b/packages/trufi_core_routing/lib/src/models/itinerary.dart
@@ -35,8 +35,11 @@ class Itinerary extends Equatable {
     return legs.fold<int>(0, (sum, leg) => sum + leg.distance.ceil());
   }
 
-  // Default colors for transit legs without route color
-  static const _defaultTransitColors = ['1976D2', 'E91E63', '4CAF50', 'FF9800'];
+  // Default colors for transit legs without route color. Deliberately no
+  // blue: the first slot lands on the first bus of nearly every itinerary
+  // in cities whose GTFS carries no route_color, and a blue line reads
+  // exactly like the my-location dot (#930).
+  static const _defaultTransitColors = ['673AB7', 'E91E63', '4CAF50', 'FF9800'];
 
   /// Creates an [Itinerary] from JSON.
   factory Itinerary.fromJson(

--- a/packages/trufi_core_routing/lib/src/models/itinerary.dart
+++ b/packages/trufi_core_routing/lib/src/models/itinerary.dart
@@ -39,7 +39,7 @@ class Itinerary extends Equatable {
   // blue: the first slot lands on the first bus of nearly every itinerary
   // in cities whose GTFS carries no route_color, and a blue line reads
   // exactly like the my-location dot (#930).
-  static const _defaultTransitColors = ['673AB7', 'E91E63', '4CAF50', 'FF9800'];
+  static const _defaultTransitColors = ['7E57C2', 'E91E63', '4CAF50', 'FF9800'];
 
   /// Creates an [Itinerary] from JSON.
   factory Itinerary.fromJson(
@@ -69,8 +69,13 @@ class Itinerary extends Equatable {
   static List<Leg> _assignDefaultColors(List<Leg> legs) {
     int transitIndex = 0;
     return legs.map((leg) {
-      if (leg.transitLeg &&
-          (leg.route?.color == null || leg.route!.color!.isEmpty)) {
+      // GTFS defines FFFFFF as the route_color default, i.e. "no color" —
+      // normalizing it here keeps every screen (map line, itinerary chip,
+      // detail timeline) consistent instead of each one special-casing it.
+      final color = leg.route?.color;
+      final hasColor =
+          color != null && color.isNotEmpty && color.toUpperCase() != 'FFFFFF';
+      if (leg.transitLeg && !hasColor) {
         final defaultColor =
             _defaultTransitColors[transitIndex % _defaultTransitColors.length];
         transitIndex++;

--- a/packages/trufi_core_routing/test/unit/itinerary_colors_test.dart
+++ b/packages/trufi_core_routing/test/unit/itinerary_colors_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_routing/trufi_core_routing.dart';
+
+Leg _transitLeg({Route? route}) => Leg(
+      mode: 'BUS',
+      startTime: DateTime(2026, 1, 1, 12),
+      endTime: DateTime(2026, 1, 1, 12, 30),
+      duration: const Duration(minutes: 30),
+      distance: 1000,
+      transitLeg: true,
+      route: route,
+    );
+
+Itinerary _itinerary(List<Leg> legs) => Itinerary(
+      legs: legs,
+      startTime: DateTime(2026, 1, 1, 12),
+      endTime: DateTime(2026, 1, 1, 13),
+      walkTime: Duration.zero,
+      duration: const Duration(hours: 1),
+      walkDistance: 0,
+    );
+
+void main() {
+  group('Itinerary default transit colors (#930)', () {
+    test('a colorless transit leg never gets the my-location blue', () {
+      final it = _itinerary([_transitLeg()]);
+      final color = it.legs.first.route?.color;
+      expect(color, isNotNull);
+      expect(color!.isNotEmpty, isTrue);
+      // 1976D2 read exactly like the location dot; 4285F4 is the dot itself.
+      expect(color.toUpperCase(), isNot(anyOf('1976D2', '4285F4')));
+    });
+
+    test('FFFFFF (GTFS "no color" default) is treated as unset', () {
+      final it = _itinerary([_transitLeg(route: const Route(color: 'FFFFFF'))]);
+      final color = it.legs.first.route?.color;
+      expect(color!.toUpperCase(), isNot('FFFFFF'));
+    });
+
+    test('two colorless legs get distinct palette colors', () {
+      final it = _itinerary([
+        _transitLeg(),
+        _transitLeg(route: const Route(color: '')),
+      ]);
+      final first = it.legs[0].route?.color;
+      final second = it.legs[1].route?.color;
+      expect(first, isNotNull);
+      expect(second, isNotNull);
+      expect(first, isNot(second));
+    });
+
+    test('a real GTFS route_color is preserved', () {
+      final it = _itinerary([_transitLeg(route: const Route(color: 'AB1234'))]);
+      expect(it.legs.first.route?.color, 'AB1234');
+    });
+  });
+}


### PR DESCRIPTION
Fixes #930.

## Problem

The current-location dot and the active route line render in near-identical blues, so users can't tell their position from the route.

## Root cause (two layers deep)

The visible blue almost never comes from data: transit legs without a GTFS `route_color` get colors assigned **by index** from a default palette in `Itinerary._assignDefaultColors`, and the palette's first slot was `1976D2` — so the **first bus of nearly every itinerary** rendered in a blue that reads exactly like the my-location dot (`4285F4`). Measured on Cochabamba's bundled GTFS: **140 of 144 routes carry no route_color**, so this was the norm, not the exception.

## Fix

- `trufi_core_routing`: replace the palette's blue with deep purple (`673AB7`) — deliberately no blue in the default palette. Real GTFS `route_color` values are untouched (agency colors keep winning, per convention).
- `trufi_core_home_screen` (hardening): treat `FFFFFF` as unset when parsing leg colors (GTFS defines white as the *absence* of route_color — it would paint an invisible line on light maps) and fall back to the app's brand color instead of another blue if parsing fails.

The my-location dot keeps its Google-blue — that convention is universal and users expect it ([map UI patterns](https://mapuipatterns.com/blue-dot/)); per the [GTFS spec](https://gtfs.org/) route_color absent ⇒ FFFFFF, which is why the fallback layer exists.

## Testing

- Emulator before/after in the review comment: same 2-bus itinerary (Quillacollo → Plaza Libertad, offline data), first leg was dot-blue, now deep purple, with the blue location dot visible in the same frame.
- `trufi_core_routing` unit tests: +69 −10, failures **identical on the unchanged tree** (preexisting HTTP-mock tests); no test asserts palette colors. `trufi_core_home_screen`: 7/7. Analyze clean in both (2 preexisting infos in routing).