### PR TITLE
fix(saved_places): reject duplicate places with a friendly warning

### DIFF
--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_de.arb
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_de.arb
@@ -34,5 +34,6 @@
   "change": "Ändern",
   "errorLoadingPlaces": "Fehler beim Laden der Orte",
   "retry": "Erneut versuchen",
-  "history": "Verlauf"
+  "history": "Verlauf",
+  "placeAlreadySaved": "„{placeName}\" ist an diesem Ort bereits gespeichert"
 }

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_de.arb
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_de.arb
@@ -35,5 +35,5 @@
   "errorLoadingPlaces": "Fehler beim Laden der Orte",
   "retry": "Erneut versuchen",
   "history": "Verlauf",
-  "placeAlreadySaved": "„{placeName}\" ist an diesem Ort bereits gespeichert"
+  "placeAlreadySaved": "„{placeName}“ ist an diesem Ort bereits gespeichert"
 }

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_en.arb
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_en.arb
@@ -46,5 +46,14 @@
   "history": "History",
   "@history": {
     "description": "Label for saved places coming from search history"
+  },
+  "placeAlreadySaved": "\"{placeName}\" is already saved at that location",
+  "@placeAlreadySaved": {
+    "description": "Shown when saving a place that duplicates an existing one (same name and location).",
+    "placeholders": {
+      "placeName": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_es.arb
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_es.arb
@@ -34,5 +34,6 @@
   "change": "Cambiar",
   "errorLoadingPlaces": "Error al cargar lugares",
   "retry": "Reintentar",
-  "history": "Historial"
+  "history": "Historial",
+  "placeAlreadySaved": "\"{placeName}\" ya está guardado en esa ubicación"
 }

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations.dart
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations.dart
@@ -312,6 +312,12 @@ abstract class SavedPlacesLocalizations {
   /// In en, this message translates to:
   /// **'History'**
   String get history;
+
+  /// Shown when saving a place that duplicates an existing one (same name and location).
+  ///
+  /// In en, this message translates to:
+  /// **'\"{placeName}\" is already saved at that location'**
+  String placeAlreadySaved(String placeName);
 }
 
 class _SavedPlacesLocalizationsDelegate

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_de.dart
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_de.dart
@@ -117,6 +117,6 @@ class SavedPlacesLocalizationsDe extends SavedPlacesLocalizations {
 
   @override
   String placeAlreadySaved(String placeName) {
-    return '„$placeName\" ist an diesem Ort bereits gespeichert';
+    return '„$placeName“ ist an diesem Ort bereits gespeichert';
   }
 }

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_de.dart
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_de.dart
@@ -114,4 +114,9 @@ class SavedPlacesLocalizationsDe extends SavedPlacesLocalizations {
 
   @override
   String get history => 'Verlauf';
+
+  @override
+  String placeAlreadySaved(String placeName) {
+    return '„$placeName\" ist an diesem Ort bereits gespeichert';
+  }
 }

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_en.dart
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_en.dart
@@ -114,4 +114,9 @@ class SavedPlacesLocalizationsEn extends SavedPlacesLocalizations {
 
   @override
   String get history => 'History';
+
+  @override
+  String placeAlreadySaved(String placeName) {
+    return '\"$placeName\" is already saved at that location';
+  }
 }

--- a/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_es.dart
+++ b/packages/screens/trufi_core_saved_places/lib/l10n/saved_places_localizations_es.dart
@@ -114,4 +114,9 @@ class SavedPlacesLocalizationsEs extends SavedPlacesLocalizations {
 
   @override
   String get history => 'Historial';
+
+  @override
+  String placeAlreadySaved(String placeName) {
+    return '\"$placeName\" ya está guardado en esa ubicación';
+  }
 }

--- a/packages/screens/trufi_core_saved_places/lib/src/cubit/saved_places_cubit.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/cubit/saved_places_cubit.dart
@@ -101,6 +101,23 @@ class SavedPlacesCubit extends Cubit<SavedPlacesState> {
     }
   }
 
+  /// Whether an equivalent place is already saved — same name (trimmed,
+  /// case-insensitive) at the same coordinates. Pass [excludeId] when
+  /// editing so a place doesn't collide with itself (#898).
+  bool isDuplicatePlace(SavedPlace place, {String? excludeId}) {
+    final name = place.name.trim().toLowerCase();
+    bool same(SavedPlace other) =>
+        other.id != excludeId &&
+        other.name.trim().toLowerCase() == name &&
+        (other.latitude - place.latitude).abs() < 1e-6 &&
+        (other.longitude - place.longitude).abs() < 1e-6;
+    return [
+      if (state.home != null) state.home!,
+      if (state.work != null) state.work!,
+      ...state.otherPlaces,
+    ].any(same);
+  }
+
   /// Adds a place to other places.
   Future<void> addOtherPlace(SavedPlace place) async {
     final otherPlace = place.copyWith(type: SavedPlaceType.other);

--- a/packages/screens/trufi_core_saved_places/lib/src/cubit/saved_places_cubit.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/cubit/saved_places_cubit.dart
@@ -101,16 +101,19 @@ class SavedPlacesCubit extends Cubit<SavedPlacesState> {
     }
   }
 
-  /// Whether an equivalent place is already saved — same name (trimmed,
-  /// case-insensitive) at the same coordinates. Pass [excludeId] when
-  /// editing so a place doesn't collide with itself (#898).
+  /// Whether two places share the same identity: same name (trimmed,
+  /// case-insensitive) at the same coordinates (sub-meter epsilon).
+  static bool hasSameIdentity(SavedPlace a, SavedPlace b) =>
+      a.name.trim().toLowerCase() == b.name.trim().toLowerCase() &&
+      (a.latitude - b.latitude).abs() < 1e-6 &&
+      (a.longitude - b.longitude).abs() < 1e-6;
+
+  /// Whether an equivalent place is already saved — see [hasSameIdentity].
+  /// Pass [excludeId] when editing so a place doesn't collide with
+  /// itself (#898).
   bool isDuplicatePlace(SavedPlace place, {String? excludeId}) {
-    final name = place.name.trim().toLowerCase();
     bool same(SavedPlace other) =>
-        other.id != excludeId &&
-        other.name.trim().toLowerCase() == name &&
-        (other.latitude - place.latitude).abs() < 1e-6 &&
-        (other.longitude - place.longitude).abs() < 1e-6;
+        other.id != excludeId && hasSameIdentity(other, place);
     return [
       if (state.home != null) state.home!,
       if (state.work != null) state.work!,

--- a/packages/screens/trufi_core_saved_places/lib/src/saved_places_trufi_screen.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/saved_places_trufi_screen.dart
@@ -171,7 +171,13 @@ class _SavedPlacesScreenWidget extends StatelessWidget {
     );
 
     if (updatedPlace != null && context.mounted) {
-      if (cubit.isDuplicatePlace(updatedPlace, excludeId: place.id)) {
+      // An edit that keeps the same name and coordinates can't create a
+      // new duplicate — skip the check so places that were duplicated
+      // before this guard existed stay editable (icon, type, ...).
+      final identityChanged =
+          !SavedPlacesCubit.hasSameIdentity(updatedPlace, place);
+      if (identityChanged &&
+          cubit.isDuplicatePlace(updatedPlace, excludeId: place.id)) {
         _showDuplicateWarning(context, updatedPlace);
         return;
       }

--- a/packages/screens/trufi_core_saved_places/lib/src/saved_places_trufi_screen.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/saved_places_trufi_screen.dart
@@ -137,9 +137,20 @@ class _SavedPlacesScreenWidget extends StatelessWidget {
       defaultLongitude: defaultCenter.longitude,
     );
 
-    if (place != null) {
+    if (place != null && context.mounted) {
+      if (cubit.isDuplicatePlace(place)) {
+        _showDuplicateWarning(context, place);
+        return;
+      }
       cubit.savePlace(place);
     }
+  }
+
+  void _showDuplicateWarning(BuildContext context, SavedPlace place) {
+    final localization = SavedPlacesLocalizations.of(context);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(localization.placeAlreadySaved(place.name))),
+    );
   }
 
   void _showEditPlaceDialog(BuildContext context, SavedPlace place) async {
@@ -159,7 +170,11 @@ class _SavedPlacesScreenWidget extends StatelessWidget {
       defaultLongitude: defaultCenter.longitude,
     );
 
-    if (updatedPlace != null) {
+    if (updatedPlace != null && context.mounted) {
+      if (cubit.isDuplicatePlace(updatedPlace, excludeId: place.id)) {
+        _showDuplicateWarning(context, updatedPlace);
+        return;
+      }
       cubit.updatePlace(updatedPlace);
     }
   }

--- a/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_places_screen.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_places_screen.dart
@@ -154,7 +154,13 @@ class _SavedPlacesScreenContent extends StatelessWidget {
     );
 
     if (updatedPlace != null && context.mounted) {
-      if (cubit.isDuplicatePlace(updatedPlace, excludeId: place.id)) {
+      // An edit that keeps the same name and coordinates can't create a
+      // new duplicate — skip the check so places that were duplicated
+      // before this guard existed stay editable (icon, type, ...).
+      final identityChanged =
+          !SavedPlacesCubit.hasSameIdentity(updatedPlace, place);
+      if (identityChanged &&
+          cubit.isDuplicatePlace(updatedPlace, excludeId: place.id)) {
         _showDuplicateWarning(context, updatedPlace);
         return;
       }

--- a/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_places_screen.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_places_screen.dart
@@ -133,7 +133,11 @@ class _SavedPlacesScreenContent extends StatelessWidget {
       defaultLongitude: defaultLongitude,
     );
 
-    if (place != null) {
+    if (place != null && context.mounted) {
+      if (cubit.isDuplicatePlace(place)) {
+        _showDuplicateWarning(context, place);
+        return;
+      }
       cubit.savePlace(place);
     }
   }
@@ -149,9 +153,20 @@ class _SavedPlacesScreenContent extends StatelessWidget {
       defaultLongitude: defaultLongitude,
     );
 
-    if (updatedPlace != null) {
+    if (updatedPlace != null && context.mounted) {
+      if (cubit.isDuplicatePlace(updatedPlace, excludeId: place.id)) {
+        _showDuplicateWarning(context, updatedPlace);
+        return;
+      }
       cubit.updatePlace(updatedPlace);
     }
+  }
+
+  void _showDuplicateWarning(BuildContext context, SavedPlace place) {
+    final localization = SavedPlacesLocalizations.of(context);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(localization.placeAlreadySaved(place.name))),
+    );
   }
 
   void _showDeleteConfirmation(BuildContext context, SavedPlace place) {

--- a/packages/screens/trufi_core_saved_places/test/duplicate_places_test.dart
+++ b/packages/screens/trufi_core_saved_places/test/duplicate_places_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_saved_places/trufi_core_saved_places.dart';
+
+class _InMemoryRepository implements SavedPlacesRepository {
+  final Map<String, SavedPlace> _places = {};
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<List<SavedPlace>> getPlacesByType(SavedPlaceType type) async =>
+      _places.values.where((p) => p.type == type).toList();
+
+  @override
+  Future<List<SavedPlace>> getAllPlaces() async => _places.values.toList();
+
+  @override
+  Future<SavedPlace?> getHome() async =>
+      _places.values.where((p) => p.type == SavedPlaceType.home).firstOrNull;
+
+  @override
+  Future<SavedPlace?> getWork() async =>
+      _places.values.where((p) => p.type == SavedPlaceType.work).firstOrNull;
+
+  @override
+  Future<List<SavedPlace>> getOtherPlaces() async =>
+      getPlacesByType(SavedPlaceType.other);
+
+  @override
+  Future<List<SavedPlace>> getHistory() async =>
+      getPlacesByType(SavedPlaceType.history);
+
+  @override
+  Future<void> savePlace(SavedPlace place) async => _places[place.id] = place;
+
+  @override
+  Future<void> updatePlace(SavedPlace place) async => _places[place.id] = place;
+
+  @override
+  Future<void> deletePlace(String id) async => _places.remove(id);
+
+  @override
+  Future<void> deletePlacesByType(SavedPlaceType type) async =>
+      _places.removeWhere((_, p) => p.type == type);
+
+  @override
+  Future<void> clearHistory() async =>
+      deletePlacesByType(SavedPlaceType.history);
+
+  @override
+  Future<void> addToHistory(SavedPlace place) async => savePlace(place);
+}
+
+SavedPlace _place({
+  String id = '1',
+  String name = 'Prueba',
+  double lat = -17.39884,
+  double lng = -66.16269,
+}) => SavedPlace(
+      id: id,
+      name: name,
+      latitude: lat,
+      longitude: lng,
+      type: SavedPlaceType.other,
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+void main() {
+  group('SavedPlacesCubit.isDuplicatePlace (#898)', () {
+    late SavedPlacesCubit cubit;
+
+    setUp(() async {
+      cubit = SavedPlacesCubit(repository: _InMemoryRepository());
+      await cubit.initialize();
+      await cubit.addOtherPlace(_place());
+    });
+
+    tearDown(() => cubit.close());
+
+    test('same name and same coordinates is a duplicate', () {
+      expect(cubit.isDuplicatePlace(_place(id: '2')), isTrue);
+    });
+
+    test('name comparison trims and ignores case', () {
+      expect(cubit.isDuplicatePlace(_place(id: '2', name: '  prueba ')), isTrue);
+    });
+
+    test('same name at a different location is allowed', () {
+      expect(
+        cubit.isDuplicatePlace(_place(id: '2', lat: -17.5)),
+        isFalse,
+      );
+    });
+
+    test('different name at the same location is allowed', () {
+      expect(cubit.isDuplicatePlace(_place(id: '2', name: 'Otra')), isFalse);
+    });
+
+    test('editing a place does not collide with itself', () {
+      expect(cubit.isDuplicatePlace(_place(), excludeId: '1'), isFalse);
+    });
+
+    test('home and work count as existing places', () async {
+      await cubit.setHome(_place(id: 'h', name: 'Casa', lat: -17.4));
+      expect(
+        cubit.isDuplicatePlace(_place(id: '2', name: 'Casa', lat: -17.4)),
+        isTrue,
+      );
+    });
+  });
+}

--- a/packages/screens/trufi_core_saved_places/test/duplicate_places_test.dart
+++ b/packages/screens/trufi_core_saved_places/test/duplicate_places_test.dart
@@ -110,5 +110,27 @@ void main() {
         isTrue,
       );
     });
+
+    test('epsilon: 1e-7 apart is still a duplicate, 1e-5 is not', () {
+      expect(
+        cubit.isDuplicatePlace(_place(id: '2', lat: -17.39884 + 1e-7)),
+        isTrue,
+      );
+      expect(
+        cubit.isDuplicatePlace(_place(id: '2', lat: -17.39884 + 1e-5)),
+        isFalse,
+      );
+    });
+
+    test('hasSameIdentity: unchanged edit keeps identity (pre-fix dupes stay editable)', () {
+      final original = _place(id: '1');
+      final editedIconOnly = original.copyWith(iconName: 'star');
+      expect(
+        SavedPlacesCubit.hasSameIdentity(editedIconOnly, original),
+        isTrue,
+      );
+      final renamed = original.copyWith(name: 'Otro nombre');
+      expect(SavedPlacesCubit.hasSameIdentity(renamed, original), isFalse);
+    });
   });
 }


### PR DESCRIPTION
Fixes #898.

## Problem

"Your Places" silently accepts multiple entries with the exact same name and the same coordinates — no warning, no prevention (reproduced on v5.20: three identical "Prueba" favorites).

## Fix

- New `SavedPlacesCubit.isDuplicatePlace(place, {excludeId})`: same name (trimmed, case-insensitive) at the same coordinates (1e-6 ≈ sub-meter epsilon — the stored values of "identical" map-picker selections differ by ~1e-14) against home, work and favorites. `excludeId` lets the edit flow avoid self-collision.
- Both add/edit flows now check it and show a localized snackbar (`placeAlreadySaved` in en/es/de) instead of saving.
- 6 unit tests with an in-memory repository.

## Honest notes

- The dialog wiring is **duplicated** between `saved_places_trufi_screen.dart` (the screen apps actually register) and `widgets/saved_places_screen.dart` — the first fix round only patched the latter and the emulator caught it (a third duplicate went straight through). Both are patched now; unifying them is tech debt for a follow-up.
- Same name at a *different* location (or different name at the same spot) is still allowed on purpose — only exact duplicates are rejected.

## Testing

- `flutter test` on the package: 16/16 (10 existing + 6 new). Analyze clean.
- Emulator before/after: duplicate save silently accepted before; now the snackbar shows and no entry is created (screenshots in review comment).