### PR TITLE
fix(transport_list): rank exact short-name matches first in route search

### DIFF
--- a/packages/screens/trufi_core_transport_list/lib/src/transport_list_data_provider.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/transport_list_data_provider.dart
@@ -154,12 +154,14 @@ abstract class TransportListDataProvider extends ChangeNotifier {
         return 3;
       }
 
-      final decorated = matches.asMap().entries.toList()
-        ..sort((a, b) {
-          final byRank = rank(a.value).compareTo(rank(b.value));
-          return byRank != 0 ? byRank : a.key.compareTo(b.key);
+      final decorated = [
+        for (var i = 0; i < matches.length; i++)
+          (rank: rank(matches[i]), index: i, route: matches[i]),
+      ]..sort((a, b) {
+          final byRank = a.rank.compareTo(b.rank);
+          return byRank != 0 ? byRank : a.index.compareTo(b.index);
         });
-      result = decorated.map((e) => e.value);
+      result = decorated.map((e) => e.route);
     }
 
     _state = _state.copyWith(filteredRoutes: result.toList());

--- a/packages/screens/trufi_core_transport_list/lib/src/transport_list_data_provider.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/transport_list_data_provider.dart
@@ -134,12 +134,32 @@ abstract class TransportListDataProvider extends ChangeNotifier {
 
     if (_query.isNotEmpty) {
       final lowerQuery = _query.toLowerCase();
-      result = result.where((route) {
+      final matches = result.where((route) {
         final searchText =
             '${route.shortName ?? ''} ${route.longName ?? ''} ${route.headsign ?? ''} ${route.agencyName ?? ''}'
                 .toLowerCase();
         return searchText.contains(lowerQuery);
-      });
+      }).toList();
+
+      // Rank by match quality so short queries stay useful: the route whose
+      // short name IS the query (bus "R") must beat the hundreds of routes
+      // that merely contain the letter somewhere (#844). Ties keep the
+      // original list order (sort is decorated with the index — List.sort
+      // is not stable).
+      int rank(TransportRoute route) {
+        final short = (route.shortName ?? '').trim().toLowerCase();
+        if (short == lowerQuery) return 0;
+        if (short.startsWith(lowerQuery)) return 1;
+        if (short.contains(lowerQuery)) return 2;
+        return 3;
+      }
+
+      final decorated = matches.asMap().entries.toList()
+        ..sort((a, b) {
+          final byRank = rank(a.value).compareTo(rank(b.value));
+          return byRank != 0 ? byRank : a.key.compareTo(b.key);
+        });
+      result = decorated.map((e) => e.value);
     }
 
     _state = _state.copyWith(filteredRoutes: result.toList());

--- a/packages/screens/trufi_core_transport_list/test/search_ranking_test.dart
+++ b/packages/screens/trufi_core_transport_list/test/search_ranking_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_transport_list/trufi_core_transport_list.dart';
+
+/// Minimal in-memory provider to exercise the base-class filter logic.
+class _FakeProvider extends TransportListDataProvider {
+  _FakeProvider(List<TransportRoute> routes) {
+    state = TransportListState(routes: routes, filteredRoutes: routes);
+  }
+
+  @override
+  Future<void> load() async {}
+
+  @override
+  Future<void> refresh() async {
+    state = state.copyWith(filteredRoutes: state.routes);
+  }
+
+  @override
+  Future<TransportRouteDetails?> getRouteDetails(String code) async => null;
+}
+
+const _routes = [
+  TransportRoute(
+    id: '1',
+    code: 'V1',
+    name: 'MiniBus 1',
+    shortName: '1',
+    longName: 'Verde',
+  ),
+  TransportRoute(
+    id: '2',
+    code: 'RA',
+    name: 'Ruta A',
+    shortName: 'RA',
+    longName: 'Ruta América',
+  ),
+  TransportRoute(
+    id: '3',
+    code: 'R',
+    name: 'Bus R',
+    shortName: 'R',
+    longName: 'Recoleta',
+  ),
+  TransportRoute(
+    id: '4',
+    code: 'TR7',
+    name: 'TR-7',
+    shortName: 'TR-7',
+    longName: 'Circular',
+  ),
+  TransportRoute(
+    id: '5',
+    code: 'B2',
+    name: 'MiniBus 2',
+    shortName: '2',
+    longName: 'Parque Central',
+  ),
+];
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('search ranking (#844)', () {
+    late _FakeProvider provider;
+
+    setUp(() => provider = _FakeProvider(_routes));
+
+    test('exact short-name match ranks first for a single-letter query', () {
+      provider.filter('r');
+      final names = provider.state.filteredRoutes
+          .map((r) => r.shortName)
+          .toList();
+      // Bus "R" first (exact), then "RA" (prefix), then "TR-7" (contains
+      // in short name), then the ones matching only in other fields —
+      // original order preserved within each rank.
+      expect(names, ['R', 'RA', 'TR-7', '1', '2']);
+    });
+
+    test('exact match wins regardless of case', () {
+      provider.filter('ra');
+      expect(provider.state.filteredRoutes.first.shortName, 'RA');
+    });
+
+    test('non-matching routes stay excluded', () {
+      provider.filter('recoleta');
+      final names = provider.state.filteredRoutes
+          .map((r) => r.shortName)
+          .toList();
+      expect(names, ['R']);
+    });
+
+    test('clearing the query restores the full list in original order', () {
+      provider.filter('r');
+      provider.filter('');
+      expect(provider.state.filteredRoutes.length, _routes.length);
+      expect(provider.state.filteredRoutes.first.shortName, '1');
+    });
+  });
+}

--- a/packages/screens/trufi_core_transport_list/test/search_ranking_test.dart
+++ b/packages/screens/trufi_core_transport_list/test/search_ranking_test.dart
@@ -95,5 +95,48 @@ void main() {
       expect(provider.state.filteredRoutes.length, _routes.length);
       expect(provider.state.filteredRoutes.first.shortName, '1');
     });
+
+    test('a route without short name still matches via its other fields', () {
+      final withNullShort = _FakeProvider([
+        ..._routes,
+        const TransportRoute(
+          id: '6',
+          code: 'X',
+          name: 'Sin corto',
+          longName: 'Ruta Recoleta Norte',
+        ),
+      ]);
+      withNullShort.filter('recoleta');
+      final names = withNullShort.state.filteredRoutes
+          .map((r) => r.id)
+          .toList();
+      // Bus "R" (longName Recoleta) and the null-shortName route both
+      // match; both rank 3, original order preserved.
+      expect(names, ['3', '6']);
+    });
+
+    test('a query with an inner space keeps matching like before', () {
+      provider.filter('ruta am');
+      expect(provider.state.filteredRoutes.map((r) => r.id).toList(), ['2']);
+    });
+
+    test('ties keep original order even on large lists (unstable-sort guard)', () {
+      // Dart's List.sort is insertion sort (de-facto stable) below ~32
+      // elements, so only a large fixture can catch the decoration being
+      // removed. All 120 routes match "z" via longName → all rank 3.
+      final large = _FakeProvider([
+        for (var i = 0; i < 120; i++)
+          TransportRoute(
+            id: '$i',
+            code: 'C$i',
+            name: 'Ruta $i',
+            shortName: '$i',
+            longName: 'Zona $i',
+          ),
+      ]);
+      large.filter('z');
+      final ids = large.state.filteredRoutes.map((r) => r.id).toList();
+      expect(ids, [for (var i = 0; i < 120; i++) '$i']);
+    });
   });
 }


### PR DESCRIPTION
Fixes #844.

## Problem

Searching "R" in the routes list returns every route that *contains* the letter anywhere ("MiniBus 1 **Verde**", "**Trufi** 01"...) with no ranking — the actual bus **R** is buried hundreds of rows deep. Reported on Cochabamba (657 routes) and confirmed by the reporter after an earlier close.

## Fix

The base provider's filter now sorts matches by quality before publishing them:
1. exact short-name match (case-insensitive, trimmed)
2. short-name prefix
3. short-name contains
4. matches only in long name / headsign / agency

Original list order is preserved within each rank (index-decorated sort — `List.sort` isn't stable). The filter itself is unchanged: same fields, same substring semantics, so no previously-findable route disappears. One fix covers both GTFS and OTP providers (shared base class).

## Testing

- 4 new unit tests on the ranking (exact-first for single-letter queries, case-insensitivity, exclusion unchanged, clear-query restores original order); package suite 16/16 green, analyze clean.
- Emulator before/after: "R" used to surface "MiniBus 1 (Verde)" first; now "Línea Roja (R)" and "MicroBus R" lead the list (screenshots in review comment).