### PR TITLE
fix(example): point the web planner at the gateway's /api prefix

### DIFF
--- a/apps/example/lib/main.dart
+++ b/apps/example/lib/main.dart
@@ -50,7 +50,10 @@ final List<IRoutingProvider> _routingEngines = [
   if (kIsWeb)
     TrufiPlannerProvider(
       config: const TrufiPlannerConfig.remote(
-        serverUrl: 'https://planner.trufi.app',
+        // The planner API lives behind the gateway's /api prefix; without
+        // it every request lands on the web app and comes back as HTML
+        // ("FormatException: Unexpected token '<'").
+        serverUrl: 'https://planner.trufi.app/api',
       ),
     ),
   // Online routing via OTP (dev servers)


### PR DESCRIPTION
## Problem

The example app's **web** build can never plan a route with Trufi Planner: every request fails with

```
FormatException: SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

## Root cause

The planner API lives behind the gateway's `/api` prefix, but the example configures `serverUrl: 'https://planner.trufi.app'`. Every call therefore lands on the web app and comes back as the HTML shell. Verified against production:

| Request | Result |
|---|---|
| `POST /api/plan` | `{"success":true,"paths":[…]}` — real itineraries |
| `POST /plan` | `<!DOCTYPE html>…` — the app shell |
| `GET /health` and `/api/health` | `{"status":"healthy"}` (which is why the provider looked reachable) |

The Cochabamba app already gets this right (`serverUrl: '$_baseUrl/api'` in trufi-app), so this is example-only — but the example is what city apps are copied from, so a wrong URL there propagates.

## Fix

One line plus a comment explaining the prefix.

## Testing

Headless Chrome against the built web app: before the change the planner returned the HTML error above; after it, the same origin/destination returns **5 itineraries**, and reload restores the full state (fields, plan, selected route). Screenshots in the review comment.