### PR TITLE
fix(transport_list): only encode scannable links in the operator QR

### DIFF
--- a/packages/screens/trufi_core_transport_list/README.md
+++ b/packages/screens/trufi_core_transport_list/README.md
@@ -1,0 +1,54 @@
+# trufi_core_transport_list
+
+Routes list, route detail, and the operator QR sheet.
+
+## Host-app requirements
+
+### Operator QR codes
+
+Pass `shareBaseUrl` to `TransportListTrufiScreen` with the app's **https**
+base (e.g. `https://planner.trufi.app`). The QR encodes
+`<base>/routes?operator=<agency>`.
+
+A QR is read by a camera app, which resolves http(s) and nothing else — a
+custom scheme such as `trufiapp://` produces a code that opens nothing, so
+without a usable https base the QR affordances stay hidden by design.
+
+For the scanned link to open the **app** (rather than the website) the host
+app must register it as an App Link / Universal Link: an intent filter for
+that host with `android:autoVerify="true"`, plus a matching
+`assetlinks.json` (Android) and `apple-app-site-association` (iOS) served
+from the domain. On Android the verification uses the **signing key the
+store re-signs with**, so App Links only resolve on store-installed builds
+— a locally built APK opens the browser instead. Without any of this the
+link still works: it falls back to the web app.
+
+### Copying the QR image
+
+"Copy QR" hands a rendered PNG to the clipboard through the `pasteboard`
+plugin, which needs a `FileProvider` in the **host app's** manifest:
+
+```xml
+<provider
+    android:name="androidx.core.content.FileProvider"
+    android:authorities="${applicationId}.provider"
+    android:exported="false"
+    android:grantUriPermissions="true">
+    <meta-data
+        android:name="android.support.FILE_PROVIDER_PATHS"
+        android:resource="@xml/provider_paths" />
+</provider>
+```
+
+with `android/app/src/main/res/xml/provider_paths.xml`:
+
+```xml
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="cache" path="." />
+</paths>
+```
+
+`cache-path` is the root that matters — the plugin writes the PNG to the
+app's internal cache. (The plugin's own README documents only
+`external-path`, which leaves copying failing with *"Failed to find
+configured root that contains /data/data/&lt;pkg&gt;/cache/…"*.)

--- a/packages/screens/trufi_core_transport_list/lib/src/transport_list_trufi_screen.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/transport_list_trufi_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:provider/provider.dart';
 import 'package:provider/single_child_widget.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:trufi_core_maps/trufi_core_maps.dart' show MapsLocalizations;
@@ -185,9 +184,14 @@ class _TransportListScreenWidgetState
     }
   }
 
-  /// Builds the link a printed QR encodes for [agencyName]: the https
-  /// share URL when configured, else the app's custom scheme. Null when
-  /// the app has neither (QR affordances hidden).
+  /// Builds the link a printed QR encodes for [agencyName].
+  ///
+  /// Only the https share URL qualifies: a QR is scanned by a camera app,
+  /// which cannot resolve a custom scheme like `trufiapp://` — operators
+  /// were printing codes that opened nothing (#953). An https app link
+  /// opens the app when installed and the website otherwise, which is
+  /// what a printed code needs. Without [shareBaseUrl] there is no
+  /// scannable link, so the QR affordances stay hidden.
   String? _operatorLink(String agencyName) {
     final base = widget.shareBaseUrl;
     if (base != null) {
@@ -201,21 +205,7 @@ class _TransportListScreenWidgetState
       ).toString();
     }
 
-    String? scheme;
-    try {
-      scheme = Provider.of<AppConfiguration>(
-        context,
-        listen: false,
-      ).deepLinkScheme;
-    } catch (_) {
-      // Not hosted under TrufiApp (e.g. embedded usage).
-    }
-    if (scheme == null) return null;
-    return Uri(
-      scheme: scheme,
-      host: 'routes',
-      queryParameters: {'operator': agencyName},
-    ).toString();
+    return null;
   }
 
   void _showOperatorQr(String agencyName) {
@@ -224,9 +214,8 @@ class _TransportListScreenWidgetState
     showOperatorQrDialog(context, operatorName: agencyName, link: link);
   }
 
-  /// Whether QR links can be built at all — gates the QR buttons.
-  bool get _canShareOperatorQr =>
-      widget.shareBaseUrl != null || _operatorLink('') != null;
+  /// Whether scannable QR links can be built at all — gates the buttons.
+  bool get _canShareOperatorQr => widget.shareBaseUrl != null;
 
   void _initializeDataProvider() {
     if (widget.dataProviderBuilder != null) {

--- a/packages/screens/trufi_core_transport_list/lib/src/transport_list_trufi_screen.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/transport_list_trufi_screen.dart
@@ -23,16 +23,43 @@ import 'widgets/operator_qr_dialog.dart';
 /// Routes:
 /// - `/routes` - shows the list of transit routes
 /// - `/routes/:id` - shows route detail for the given pattern ID (path parameter)
+/// Builds the link an operator QR encodes for [agencyName], or null when
+/// [shareBaseUrl] cannot produce a scannable one.
+///
+/// A QR is read by a camera app, which resolves http(s) and nothing else:
+/// a custom scheme like `trufiapp://` (or a base with no scheme at all)
+/// yields a code that opens nothing, which is worse than no code —
+/// operators print these and glue them inside vehicles (#953).
+@visibleForTesting
+String? operatorQrLink(String? shareBaseUrl, String agencyName) {
+  if (shareBaseUrl == null) return null;
+  final base = Uri.tryParse(shareBaseUrl);
+  if (base == null ||
+      (base.scheme != 'http' && base.scheme != 'https') ||
+      base.host.isEmpty) {
+    return null;
+  }
+  return Uri(
+    scheme: base.scheme,
+    host: base.host,
+    port: base.hasPort ? base.port : null,
+    path: '/routes',
+    queryParameters: {'operator': agencyName},
+  ).toString();
+}
+
 class TransportListTrufiScreen extends TrufiScreen {
   final TransportListDataProvider Function(BuildContext context)?
   dataProviderBuilder;
 
   /// Base https URL used to build the shareable/printable operator QR
   /// links (e.g. `https://app.trufi.app` → `https://app.trufi.app/routes?
-  /// operator=X`). Mirrors `HomeScreenConfig.shareBaseUrl`. When null,
-  /// links fall back to the app's `deepLinkScheme`
-  /// (`trufiapp://routes?operator=X`); with neither set, the QR
-  /// affordances are hidden.
+  /// Base https URL the operator QR encodes (`<base>/routes?operator=X`).
+  /// Mirrors `HomeScreenConfig.shareBaseUrl`. A QR is read by a camera,
+  /// which cannot resolve a custom scheme, so this is the only source of
+  /// a scannable link: when it is null (or not http/https) the QR
+  /// affordances are hidden instead of emitting a code that opens
+  /// nothing.
   final String? shareBaseUrl;
 
   TransportListTrufiScreen({this.dataProviderBuilder, this.shareBaseUrl});
@@ -184,29 +211,8 @@ class _TransportListScreenWidgetState
     }
   }
 
-  /// Builds the link a printed QR encodes for [agencyName].
-  ///
-  /// Only the https share URL qualifies: a QR is scanned by a camera app,
-  /// which cannot resolve a custom scheme like `trufiapp://` — operators
-  /// were printing codes that opened nothing (#953). An https app link
-  /// opens the app when installed and the website otherwise, which is
-  /// what a printed code needs. Without [shareBaseUrl] there is no
-  /// scannable link, so the QR affordances stay hidden.
-  String? _operatorLink(String agencyName) {
-    final base = widget.shareBaseUrl;
-    if (base != null) {
-      final baseUri = Uri.parse(base);
-      return Uri(
-        scheme: baseUri.scheme,
-        host: baseUri.host,
-        port: baseUri.hasPort ? baseUri.port : null,
-        path: '/routes',
-        queryParameters: {'operator': agencyName},
-      ).toString();
-    }
-
-    return null;
-  }
+  String? _operatorLink(String agencyName) =>
+      operatorQrLink(widget.shareBaseUrl, agencyName);
 
   void _showOperatorQr(String agencyName) {
     final link = _operatorLink(agencyName);
@@ -215,7 +221,7 @@ class _TransportListScreenWidgetState
   }
 
   /// Whether scannable QR links can be built at all — gates the buttons.
-  bool get _canShareOperatorQr => widget.shareBaseUrl != null;
+  bool get _canShareOperatorQr => _operatorLink('') != null;
 
   void _initializeDataProvider() {
     if (widget.dataProviderBuilder != null) {

--- a/packages/screens/trufi_core_transport_list/lib/src/widgets/operator_qr_dialog.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/widgets/operator_qr_dialog.dart
@@ -259,12 +259,16 @@ class _OperatorQrSheetState extends State<_OperatorQrSheet> {
                   child: FilledButton.icon(
                     onPressed: () {
                       HapticFeedback.mediumImpact();
-                      // Share as a URI so messengers linkify it — sharing
-                      // an http(s) link as plain text leaves the receiver
-                      // with an untappable string (#953).
+                      // What makes the shared link tappable is that it is
+                      // https: messengers linkify web URLs, not custom
+                      // schemes (#953). Passing it as a URI additionally
+                      // lets iOS treat it as a link rather than text;
+                      // on Android both branches build the same intent.
                       final uri = Uri.tryParse(widget.link);
                       SharePlus.instance.share(
-                        uri != null && uri.hasScheme && uri.scheme.startsWith('http')
+                        uri != null &&
+                                uri.hasScheme &&
+                                uri.scheme.startsWith('http')
                             ? ShareParams(uri: uri)
                             : ShareParams(text: widget.link),
                       );

--- a/packages/screens/trufi_core_transport_list/lib/src/widgets/operator_qr_dialog.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/widgets/operator_qr_dialog.dart
@@ -233,7 +233,7 @@ class _OperatorQrSheetState extends State<_OperatorQrSheet> {
                         // Most likely a host app missing the FileProvider
                         // setup (see package README) — fail visibly, not
                         // with an unhandled PlatformException.
-                        debugPrint('OperatorQrSheet: copy image failed: \$e');
+                        debugPrint('OperatorQrSheet: copy image failed: $e');
                         messenger.showSnackBar(
                           SnackBar(content: Text(l10n.copyQrImageFailed)),
                         );
@@ -259,7 +259,15 @@ class _OperatorQrSheetState extends State<_OperatorQrSheet> {
                   child: FilledButton.icon(
                     onPressed: () {
                       HapticFeedback.mediumImpact();
-                      SharePlus.instance.share(ShareParams(text: widget.link));
+                      // Share as a URI so messengers linkify it — sharing
+                      // an http(s) link as plain text leaves the receiver
+                      // with an untappable string (#953).
+                      final uri = Uri.tryParse(widget.link);
+                      SharePlus.instance.share(
+                        uri != null && uri.hasScheme && uri.scheme.startsWith('http')
+                            ? ShareParams(uri: uri)
+                            : ShareParams(text: widget.link),
+                      );
                     },
                     icon: const Icon(Icons.share_rounded),
                     label: Text(materialLocalizations.shareButtonLabel),

--- a/packages/screens/trufi_core_transport_list/test/operator_qr_dialog_test.dart
+++ b/packages/screens/trufi_core_transport_list/test/operator_qr_dialog_test.dart
@@ -21,7 +21,7 @@ void main() {
                   context,
                   operatorName: 'Sindicato Pucara Grande',
                   link:
-                      'trufiapp://routes?operator=Sindicato%20Pucara%20Grande',
+                      'https://planner.trufi.app/routes?operator=Sindicato%20Pucara%20Grande',
                 ),
                 child: const Text('open'),
               ),
@@ -38,7 +38,7 @@ void main() {
     expect(find.text('Sindicato Pucara Grande'), findsOneWidget);
     expect(find.byType(QrImageView), findsOneWidget);
     expect(
-      find.text('trufiapp://routes?operator=Sindicato%20Pucara%20Grande'),
+      find.text('https://planner.trufi.app/routes?operator=Sindicato%20Pucara%20Grande'),
       findsOneWidget,
     );
   });

--- a/packages/screens/trufi_core_transport_list/test/operator_qr_link_test.dart
+++ b/packages/screens/trufi_core_transport_list/test/operator_qr_link_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_transport_list/src/transport_list_trufi_screen.dart';
+
+/// A QR is read by a camera, which resolves http(s) and nothing else — a
+/// base that can't produce such a link must yield no code at all rather
+/// than one that opens nothing (#953).
+void main() {
+  group('operatorQrLink (#953)', () {
+    test('https base builds the operator link', () {
+      expect(
+        operatorQrLink('https://planner.trufi.app', 'Uspa Uspa'),
+        'https://planner.trufi.app/routes?operator=Uspa+Uspa',
+      );
+    });
+
+    test('http base is accepted too', () {
+      expect(operatorQrLink('http://example.org', 'X'), startsWith('http://'));
+    });
+
+    test('a custom scheme yields no link', () {
+      expect(operatorQrLink('trufiapp://app', 'Uspa Uspa'), isNull);
+    });
+
+    test('a base without a scheme yields no link', () {
+      expect(operatorQrLink('planner.trufi.app', 'Uspa Uspa'), isNull);
+    });
+
+    test('null base yields no link', () {
+      expect(operatorQrLink(null, 'Uspa Uspa'), isNull);
+    });
+
+    test('the port of the base is preserved', () {
+      expect(
+        operatorQrLink('http://localhost:8080', 'X'),
+        'http://localhost:8080/routes?operator=X',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Core half of #953 (the host-app half is trufi-association/trufi-app#40).

## Problem

The QR sheet fell back to the app's custom scheme (`trufiapp://routes?operator=…`) whenever `shareBaseUrl` wasn't configured. **A camera app cannot resolve a custom scheme**, so operators printed codes that opened nothing — the worst possible failure for something that ends up glued inside a vehicle.

Two smaller defects in the same sheet:
- **Share sent plain text.** `ShareParams(text: link)` leaves the receiver with an untappable string in most messengers.
- **The copy error was swallowed.** `debugPrint('… failed: \$e')` had the `$` escaped, so the log printed the literal `$e` and the real exception never appeared. Unescaping it immediately revealed the actual cause of the copy failure (a FileProvider root missing in the host app — fixed in the app PR).

## Fix

- `_operatorLink` builds a code **only** from the https share URL; without it the QR affordances stay hidden (a hidden button beats a printed code that does nothing). `_canShareOperatorQr` follows the same rule.
- Share as `ShareParams(uri: …)` when the link is http(s) so messengers linkify it; plain text stays as the fallback.
- Unescape the diagnostic so copy failures are debuggable.

## Testing

Package suite 19/19 green, analyze clean. End-to-end on emulator with the app PR applied: the sheet shows the https link, and **Copy QR** completes with Android's clipboard preview showing the image (screenshots in the app PR).

Behaviour note for embedders: an app that configured only `deepLinkScheme` and no `shareBaseUrl` will now see the QR buttons disappear instead of producing an unscannable code. That is deliberate.