### PR TITLE
fix(maps): tapping the map picks that point in choose-on-map

### DIFF
--- a/packages/trufi_core_maps/example/lib/engines/flutter_map_engine.dart
+++ b/packages/trufi_core_maps/example/lib/engines/flutter_map_engine.dart
@@ -134,7 +134,7 @@ class _FlutterMapWidgetState extends State<_FlutterMapWidget>
     super.didUpdateWidget(oldWidget);
 
     if (oldWidget.controller != widget.controller) {
-      oldWidget.controller?.detach();
+      oldWidget.controller?.detach(this);
       widget.controller?.attach(this);
     }
 
@@ -149,7 +149,7 @@ class _FlutterMapWidgetState extends State<_FlutterMapWidget>
 
   @override
   void dispose() {
-    widget.controller?.detach();
+    widget.controller?.detach(this);
     _mapCtl.dispose();
     super.dispose();
   }

--- a/packages/trufi_core_maps/lib/src/domain/controller/map_controller.dart
+++ b/packages/trufi_core_maps/lib/src/domain/controller/map_controller.dart
@@ -32,7 +32,17 @@ class TrufiMapController {
   void attach(TrufiMapDelegate delegate) => _delegate = delegate;
 
   /// Called by [TrufiMap] to unbind its state. Do not call directly.
-  void detach() => _delegate = null;
+  ///
+  /// Guarded on purpose: when the map engine changes, Flutter builds the
+  /// new map (which attaches) *before* disposing the old one (which
+  /// detaches). An unconditional detach therefore left the controller
+  /// bound to nothing for the rest of the screen's life — silently
+  /// killing every controller-driven action after a style switch
+  /// (camera moves, marker picking). Only the delegate currently bound
+  /// may unbind itself.
+  void detach(TrufiMapDelegate delegate) {
+    if (identical(_delegate, delegate)) _delegate = null;
+  }
 
   /// Current camera position, or null if the map is not yet ready.
   TrufiCameraPosition? get cameraPosition => _delegate?.cameraPosition;

--- a/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
@@ -158,7 +158,7 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
     super.didUpdateWidget(oldWidget);
 
     if (oldWidget.controller != widget.controller) {
-      oldWidget.controller?.detach();
+      oldWidget.controller?.detach(this);
       widget.controller?.attach(this);
     }
 
@@ -173,7 +173,7 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
 
   @override
   void dispose() {
-    widget.controller?.detach();
+    widget.controller?.detach(this);
     super.dispose();
   }
 

--- a/packages/trufi_core_maps/lib/src/presentation/widgets/choose_on_map_screen.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/widgets/choose_on_map_screen.dart
@@ -5,6 +5,7 @@ import 'package:latlong2/latlong.dart';
 import '../../../l10n/maps_localizations.dart';
 import '../../configuration/map_engine/map_engine_manager.dart';
 import '../../configuration/map_engine/trufi_map_engine.dart';
+import '../../domain/controller/map_controller.dart';
 import '../../domain/entities/camera.dart';
 import 'map_type_settings_screen.dart';
 
@@ -90,6 +91,8 @@ class _ChooseOnMapScreenState extends State<ChooseOnMapScreen> {
   late double _currentLatitude;
   late double _currentLongitude;
   late TrufiCameraPosition _initialCamera;
+  final TrufiMapController _mapController = TrufiMapController();
+  double _currentZoom = 15;
   bool _initialized = false;
 
   void _initializeIfNeeded(MapEngineManager mapEngineManager) {
@@ -101,6 +104,7 @@ class _ChooseOnMapScreenState extends State<ChooseOnMapScreen> {
       _currentLongitude =
           config.initialLongitude ?? mapEngineManager.defaultCenter.longitude;
       final zoom = config.initialZoom ?? mapEngineManager.defaultZoom;
+      _currentZoom = zoom;
 
       _initialCamera = TrufiCameraPosition(
         target: LatLng(_currentLatitude, _currentLongitude),
@@ -113,6 +117,21 @@ class _ChooseOnMapScreenState extends State<ChooseOnMapScreen> {
     setState(() {
       _currentLatitude = position.target.latitude;
       _currentLongitude = position.target.longitude;
+      _currentZoom = position.zoom;
+    });
+  }
+
+  /// Tapping the map picks that point: the marker is fixed at the centre
+  /// of the screen, so we bring the tapped location to it. Without this
+  /// the only way to choose a place is to drag the map around, which
+  /// reads as "the map ignores my clicks" (#819).
+  void _onMapClick(LatLng position) {
+    _mapController.moveCamera(
+      TrufiCameraPosition(target: position, zoom: _currentZoom),
+    );
+    setState(() {
+      _currentLatitude = position.latitude;
+      _currentLongitude = position.longitude;
     });
   }
 
@@ -128,8 +147,10 @@ class _ChooseOnMapScreenState extends State<ChooseOnMapScreen> {
       body: Stack(
         children: [
           mapEngineManager.currentEngine.buildMap(
+            controller: _mapController,
             initialCamera: _initialCamera,
             onCameraChanged: _onCameraChanged,
+            onMapClick: _onMapClick,
           ),
           Center(
             child: IgnorePointer(

--- a/packages/trufi_core_maps/lib/src/presentation/widgets/choose_on_map_screen.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/widgets/choose_on_map_screen.dart
@@ -92,7 +92,7 @@ class _ChooseOnMapScreenState extends State<ChooseOnMapScreen> {
   late double _currentLongitude;
   late TrufiCameraPosition _initialCamera;
   final TrufiMapController _mapController = TrufiMapController();
-  double _currentZoom = 15;
+  late double _currentZoom;
   bool _initialized = false;
 
   void _initializeIfNeeded(MapEngineManager mapEngineManager) {
@@ -126,6 +126,9 @@ class _ChooseOnMapScreenState extends State<ChooseOnMapScreen> {
   /// the only way to choose a place is to drag the map around, which
   /// reads as "the map ignores my clicks" (#819).
   void _onMapClick(LatLng position) {
+    // If the map isn't bound (nothing to move), don't claim the point:
+    // the marker would stay put while the coordinates said otherwise.
+    if (_mapController.cameraPosition == null) return;
     _mapController.moveCamera(
       TrufiCameraPosition(target: position, zoom: _currentZoom),
     );

--- a/packages/trufi_core_maps/pubspec.yaml
+++ b/packages/trufi_core_maps/pubspec.yaml
@@ -30,6 +30,8 @@ dependencies:
   trufi_core_utils: ^1.0.0
 
 dev_dependencies:
+  # used by the choose-on-map widget test to provide MapEngineManager
+  provider: ^6.1.2
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0

--- a/packages/trufi_core_maps/test/choose_on_map_tap_test.dart
+++ b/packages/trufi_core_maps/test/choose_on_map_tap_test.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:trufi_core_maps/trufi_core_maps.dart';
+
+/// Records every moveCamera the screen asks for, plus attach/detach order.
+final List<TrufiCameraPosition> moves = [];
+final List<String> lifecycle = [];
+
+/// Where the fake map pretends the user tapped.
+const tappedPoint = LatLng(-17.50000, -66.50000);
+
+class FakeEngine implements ITrufiMapEngine {
+  FakeEngine(this.engineId);
+  final String engineId;
+
+  @override
+  String get id => engineId;
+  @override
+  String get name => engineId;
+  @override
+  String get description => engineId;
+  @override
+  String localizedName(BuildContext context) => engineId;
+  @override
+  String localizedDescription(BuildContext context) => engineId;
+  @override
+  Widget? get previewWidget => null;
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Widget buildMap({
+    TrufiMapController? controller,
+    required TrufiCameraPosition initialCamera,
+    TrufiCameraPosition? camera,
+    ValueChanged<TrufiCameraPosition>? onCameraChanged,
+    void Function(LatLng)? onMapClick,
+    void Function(LatLng)? onMapLongClick,
+    List<TrufiLayer> layers = const [],
+    List<WidgetMarker> widgetMarkers = const [],
+  }) {
+    return _FakeMapWidget(
+      key: ValueKey(engineId),
+      label: engineId,
+      controller: controller,
+      initialCamera: initialCamera,
+      onMapClick: onMapClick,
+    );
+  }
+}
+
+/// Mirrors TrufiMap's controller lifecycle exactly (attach in initState,
+/// detach in dispose) and forwards taps like MapLibre's onMapClick.
+class _FakeMapWidget extends StatefulWidget {
+  const _FakeMapWidget({
+    super.key,
+    required this.label,
+    required this.controller,
+    required this.initialCamera,
+    this.onMapClick,
+  });
+  final String label;
+  final TrufiMapController? controller;
+  final TrufiCameraPosition initialCamera;
+  final void Function(LatLng)? onMapClick;
+
+  @override
+  State<_FakeMapWidget> createState() => _FakeMapWidgetState();
+}
+
+class _FakeMapWidgetState extends State<_FakeMapWidget>
+    implements TrufiMapDelegate {
+  late TrufiCameraPosition _camera;
+
+  @override
+  void initState() {
+    super.initState();
+    _camera = widget.initialCamera;
+    lifecycle.add('attach:${widget.label}');
+    widget.controller?.attach(this);
+  }
+
+  @override
+  void dispose() {
+    lifecycle.add('detach:${widget.label}');
+    widget.controller?.detach(this);
+    super.dispose();
+  }
+
+  @override
+  TrufiCameraPosition get cameraPosition => _camera;
+
+  @override
+  void moveCamera(TrufiCameraPosition position) {
+    _camera = position;
+    moves.add(position);
+  }
+
+  @override
+  void fitBounds(
+    LatLngBounds bounds, {
+    EdgeInsets padding = EdgeInsets.zero,
+    double minZoom = 2.0,
+    double maxZoom = 20.0,
+  }) {}
+
+  @override
+  List<TrufiMarker> pickMarkersAt(
+    LatLng tap, {
+    double hitboxPx = 24.0,
+    int? perLayerLimit,
+    int? globalLimit,
+  }) => const [];
+
+  @override
+  Widget build(BuildContext context) => GestureDetector(
+    behavior: HitTestBehavior.opaque,
+    onTap: () => widget.onMapClick?.call(tappedPoint),
+    child: const SizedBox.expand(),
+  );
+}
+
+/// The zoom the fake screen starts at (MapEngineManager.defaultZoom).
+const initialZoom = 12.0;
+
+/// Held so a test can switch the engine after pumping.
+late MapEngineManager currentManager;
+
+/// Switches to the other engine, which rebuilds the map widget — the
+/// path that used to leave the controller detached.
+Future<void> switchEngine(WidgetTester tester) async {
+  currentManager.setEngineByIndex(1);
+  await tester.pumpAndSettle();
+}
+
+Future<MapEngineManager> pumpScreen(
+  WidgetTester tester, {
+  int engineCount = 2,
+}) async {
+  final manager = MapEngineManager(
+    engines: [
+      for (var i = 0; i < engineCount; i++) FakeEngine('engine_$i'),
+    ],
+    defaultCenter: const LatLng(-17.39, -66.15),
+    defaultZoom: 12,
+  );
+
+  await tester.pumpWidget(
+    ChangeNotifierProvider<MapEngineManager>.value(
+      value: manager,
+      child: MaterialApp(
+        localizationsDelegates: const [MapsLocalizations.delegate],
+        home: const ChooseOnMapScreen(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  currentManager = manager;
+  return manager;
+}
+
+String coordsText(WidgetTester tester) {
+  final texts = tester
+      .widgetList<Text>(find.byType(Text))
+      .map((t) => t.data ?? '')
+      .where((s) => s.contains(','))
+      .toList();
+  return texts.isEmpty ? '<none>' : texts.first;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    moves.clear();
+    lifecycle.clear();
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('choose on map: tap to place (#819)', () {
+    testWidgets('a tap recentres the map and updates the coordinates', (
+      tester,
+    ) async {
+      await pumpScreen(tester);
+
+      await tester.tapAt(const Offset(400, 400));
+      await tester.pump();
+
+      expect(moves.length, 1, reason: 'the tap must move the camera');
+      expect(moves.single.target, tappedPoint);
+      expect(coordsText(tester), '-17.50000, -66.50000');
+    });
+
+    testWidgets('a tap keeps the current zoom', (tester) async {
+      await pumpScreen(tester);
+
+      await tester.tapAt(const Offset(400, 400));
+      await tester.pump();
+
+      expect(moves.single.zoom, initialZoom,
+          reason: 'placing a point must not zoom the map');
+    });
+
+    testWidgets('the tap still works after switching map engine', (
+      tester,
+    ) async {
+      // Regression guard: Flutter attaches the new map before disposing
+      // the old one, so an unconditional detach used to leave the
+      // controller bound to nothing — the coordinates changed while the
+      // marker stayed put, and the user confirmed a different place than
+      // the one shown.
+      await pumpScreen(tester);
+      await switchEngine(tester);
+
+      await tester.tapAt(const Offset(400, 400));
+      await tester.pump();
+
+      expect(moves.length, 1,
+          reason: 'the controller must survive an engine switch');
+      expect(coordsText(tester), '-17.50000, -66.50000');
+    });
+  });
+}


### PR DESCRIPTION
Fixes #819.

## Problem

In *"Elegir en el mapa"* the marker is fixed at the centre of the screen and the map only responded to **dragging**. Tapping a place did nothing at all — verified before the change: the pin stayed put and the coordinate chip never moved. For anyone used to a map that responds to a click, this reads as broken rather than as a different interaction model, which is exactly what the reporter described.

## Fix

`onMapClick` now moves the camera so the tapped location sits under the marker, and updates the tracked point. Dragging is untouched — both interactions work.

## Testing

Headless Chrome against the built web app:

- **Before**: tap at another point → chip still `-17.39884, -66.16269`, pin unmoved.
- **After**: same tap → map recentres, chip reads `-17.39563, -66.15604`, pin over the tapped place.

Package suite 37/37 green, analyze clean. Screenshots in the review comment.