### PR TITLE
fix(settings): plain-language routing options with a connectivity badge

### DIFF
--- a/packages/screens/trufi_core_settings/lib/l10n/settings_de.arb
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_de.arb
@@ -41,6 +41,6 @@
   "limitationRequiresInternet": "Erfordert Internet",
   "limitationSlower": "Langsamere Antwort",
   "limitationNoWalkingRoute": "Keine Fußweg-Route auf Karte",
-  "settingsWorksOffline": "Funktioniert ohne Verbindung",
-  "settingsNeedsInternet": "Benötigt eine Internetverbindung"
+  "settingsWorksOffline": "Ohne Verbindung",
+  "settingsNeedsInternet": "Braucht Internet"
 }

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_de.arb
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_de.arb
@@ -1,6 +1,5 @@
 {
   "@@locale": "de",
-
   "onboardingTitle": "Willkommen!",
   "onboardingSubtitle": "Lass uns deine Einstellungen festlegen",
   "onboardingLanguageTitle": "Wähle deine Sprache",
@@ -11,7 +10,6 @@
   "onboardingMapTitle": "Wähle deinen Kartenstil",
   "onboardingRoutingTitle": "Wähle deine Routenplanung",
   "onboardingComplete": "Los geht's",
-
   "privacyConsentTitle": "Hilf uns, die App zu verbessern",
   "privacyConsentSubtitle": "Hilf uns, die App zu verbessern, indem du anonyme Nutzungsdaten teilst",
   "privacyConsentInfoTitle": "Was wir sammeln",
@@ -20,7 +18,6 @@
   "privacyConsentInfoAnonymous": "Alle Daten sind vollständig anonym",
   "privacyConsentAccept": "Akzeptieren und fortfahren",
   "privacyConsentDecline": "Nein, danke",
-
   "settingsTitle": "Einstellungen",
   "settingsLanguage": "Sprache",
   "settingsSelectLanguage": "Wählen Sie Ihre bevorzugte Sprache:",
@@ -31,20 +28,19 @@
   "settingsThemeSystem": "Systemstandard",
   "settingsMap": "Karte",
   "settingsSelectMapType": "Wählen Sie Ihren bevorzugten Kartentyp:",
-
-  "settingsRouting": "Routenplanung",
-  "settingsSelectRoutingEngine": "Wählen Sie Ihre bevorzugte Routenplanung:",
-
+  "settingsRouting": "Routensuche",
+  "settingsSelectRoutingEngine": "Wähle den Dienst, mit dem deine Routen berechnet werden.",
   "settingsPrivacy": "Datenschutz",
   "settingsPrivacySubtitle": "Hilf uns, die App zu verbessern",
   "settingsPrivacyShareData": "Anonyme Nutzungsdaten teilen",
   "settingsPrivacyShareDataDescription": "Hilf uns, Fehler zu beheben und Nahverkehrsdaten zu verbessern",
-
   "engineOnlineName": "Online",
   "engineOnlineDescription": "OpenTripPlanner 2.8. Echtzeit-Routing mit detaillierten Fußweganweisungen.",
   "engineOfflineName": "Offline",
   "engineOfflineDescription": "GTFS-basiertes Routing. Funktioniert ohne Internet.",
   "limitationRequiresInternet": "Erfordert Internet",
   "limitationSlower": "Langsamere Antwort",
-  "limitationNoWalkingRoute": "Keine Fußweg-Route auf Karte"
+  "limitationNoWalkingRoute": "Keine Fußweg-Route auf Karte",
+  "settingsWorksOffline": "Funktioniert ohne Verbindung",
+  "settingsNeedsInternet": "Benötigt eine Internetverbindung"
 }

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_en.arb
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_en.arb
@@ -1,176 +1,141 @@
 {
   "@@locale": "en",
-
   "onboardingTitle": "Welcome!",
   "@onboardingTitle": {
     "description": "Onboarding screen title"
   },
-
   "onboardingSubtitle": "Let's set up your preferences",
   "@onboardingSubtitle": {
     "description": "Onboarding screen subtitle"
   },
-
   "onboardingLanguageTitle": "Choose your language",
   "@onboardingLanguageTitle": {
     "description": "Language selection title in onboarding"
   },
-
   "onboardingThemeTitle": "Choose your theme",
   "@onboardingThemeTitle": {
     "description": "Theme selection title in onboarding"
   },
-
   "onboardingThemeLight": "Light",
   "@onboardingThemeLight": {
     "description": "Light theme option"
   },
-
   "onboardingThemeDark": "Dark",
   "@onboardingThemeDark": {
     "description": "Dark theme option"
   },
-
   "onboardingThemeSystem": "System",
   "@onboardingThemeSystem": {
     "description": "System theme option"
   },
-
   "onboardingMapTitle": "Choose your map style",
   "@onboardingMapTitle": {
     "description": "Map selection title in onboarding"
   },
-
   "onboardingRoutingTitle": "Choose your routing engine",
   "@onboardingRoutingTitle": {
     "description": "Routing engine selection title in onboarding"
   },
-
   "onboardingComplete": "Get Started",
   "@onboardingComplete": {
     "description": "Button to complete onboarding"
   },
-
   "privacyConsentTitle": "Help Improve the App",
   "@privacyConsentTitle": {
     "description": "Privacy consent dialog title"
   },
-
   "privacyConsentSubtitle": "Help us improve the app by sharing anonymous usage data",
   "@privacyConsentSubtitle": {
     "description": "Privacy consent dialog subtitle"
   },
-
   "privacyConsentInfoTitle": "What we collect",
   "@privacyConsentInfoTitle": {
     "description": "Title for the information section"
   },
-
   "privacyConsentInfoLogs": "Error logs to help us fix bugs and crashes",
   "@privacyConsentInfoLogs": {
     "description": "Description of log collection"
   },
-
   "privacyConsentInfoRoutes": "Route searches to improve transit data quality",
   "@privacyConsentInfoRoutes": {
     "description": "Description of route data collection"
   },
-
   "privacyConsentInfoAnonymous": "All data is completely anonymous",
   "@privacyConsentInfoAnonymous": {
     "description": "Privacy assurance message"
   },
-
   "privacyConsentAccept": "Accept & Continue",
   "@privacyConsentAccept": {
     "description": "Button to accept privacy consent"
   },
-
   "privacyConsentDecline": "No Thanks",
   "@privacyConsentDecline": {
     "description": "Button to decline privacy consent"
   },
-
   "settingsTitle": "Settings",
   "@settingsTitle": {
     "description": "Settings screen title"
   },
-
   "settingsLanguage": "Language",
   "@settingsLanguage": {
     "description": "Language setting"
   },
-
   "settingsSelectLanguage": "Select your preferred language:",
   "@settingsSelectLanguage": {
     "description": "Language selection instruction"
   },
-
   "settingsTheme": "Theme",
   "@settingsTheme": {
     "description": "Theme setting"
   },
-
   "settingsSelectTheme": "Select your preferred theme:",
   "@settingsSelectTheme": {
     "description": "Theme selection instruction"
   },
-
   "settingsThemeLight": "Light Mode",
   "@settingsThemeLight": {
     "description": "Light theme option"
   },
-
   "settingsThemeDark": "Dark Mode",
   "@settingsThemeDark": {
     "description": "Dark theme option"
   },
-
   "settingsThemeSystem": "System Default",
   "@settingsThemeSystem": {
     "description": "System theme option"
   },
-
   "settingsMap": "Map",
   "@settingsMap": {
     "description": "Map settings section"
   },
-
   "settingsSelectMapType": "Select your preferred map type:",
   "@settingsSelectMapType": {
     "description": "Map type selection instruction"
   },
-
-  "settingsRouting": "Routing",
+  "settingsRouting": "Route search",
   "@settingsRouting": {
     "description": "Routing settings section"
   },
-
-  "settingsSelectRoutingEngine": "Select your preferred routing engine:",
+  "settingsSelectRoutingEngine": "Choose the service used to calculate your routes.",
   "@settingsSelectRoutingEngine": {
     "description": "Routing engine selection instruction"
   },
-
   "settingsPrivacy": "Privacy",
   "@settingsPrivacy": {
     "description": "Privacy settings section"
   },
-
   "settingsPrivacySubtitle": "Help improve the app",
   "@settingsPrivacySubtitle": {
     "description": "Privacy settings subtitle"
   },
-
   "settingsPrivacyShareData": "Share anonymous usage data",
   "@settingsPrivacyShareData": {
     "description": "Toggle label for sharing anonymous data"
   },
-
   "settingsPrivacyShareDataDescription": "Help us fix bugs and improve transit data",
   "@settingsPrivacyShareDataDescription": {
     "description": "Description of what data sharing does"
   },
-
   "engineOnlineName": "Online",
   "@engineOnlineName": {
     "description": "Name for online routing engine"
@@ -198,5 +163,13 @@
   "limitationNoWalkingRoute": "No walking route on map",
   "@limitationNoWalkingRoute": {
     "description": "Limitation tag for engines that don't show walking routes on map"
+  },
+  "settingsWorksOffline": "Works without a connection",
+  "settingsNeedsInternet": "Needs an internet connection",
+  "@settingsWorksOffline": {
+    "description": "Badge on a routing option that works offline."
+  },
+  "@settingsNeedsInternet": {
+    "description": "Badge on a routing option that requires internet."
   }
 }

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_es.arb
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_es.arb
@@ -1,6 +1,5 @@
 {
   "@@locale": "es",
-
   "onboardingTitle": "¡Bienvenido!",
   "onboardingSubtitle": "Vamos a configurar tus preferencias",
   "onboardingLanguageTitle": "Elige tu idioma",
@@ -11,7 +10,6 @@
   "onboardingMapTitle": "Elige tu estilo de mapa",
   "onboardingRoutingTitle": "Elige tu motor de enrutamiento",
   "onboardingComplete": "Comenzar",
-
   "privacyConsentTitle": "Ayuda a mejorar la app",
   "privacyConsentSubtitle": "Ayúdanos a mejorar la app compartiendo datos de uso anónimos",
   "privacyConsentInfoTitle": "Qué recopilamos",
@@ -20,7 +18,6 @@
   "privacyConsentInfoAnonymous": "Todos los datos son completamente anónimos",
   "privacyConsentAccept": "Aceptar y continuar",
   "privacyConsentDecline": "No, gracias",
-
   "settingsTitle": "Configuración",
   "settingsLanguage": "Idioma",
   "settingsSelectLanguage": "Selecciona tu idioma preferido:",
@@ -31,20 +28,19 @@
   "settingsThemeSystem": "Predeterminado del Sistema",
   "settingsMap": "Mapa",
   "settingsSelectMapType": "Selecciona tu tipo de mapa preferido:",
-
-  "settingsRouting": "Enrutamiento",
-  "settingsSelectRoutingEngine": "Selecciona tu motor de enrutamiento preferido:",
-
+  "settingsRouting": "Búsqueda de rutas",
+  "settingsSelectRoutingEngine": "Elige el servicio que se utilizará para calcular tus rutas.",
   "settingsPrivacy": "Privacidad",
   "settingsPrivacySubtitle": "Ayuda a mejorar la app",
   "settingsPrivacyShareData": "Compartir datos de uso anónimos",
   "settingsPrivacyShareDataDescription": "Ayúdanos a corregir errores y mejorar los datos de transporte",
-
   "engineOnlineName": "En línea",
   "engineOnlineDescription": "OpenTripPlanner 2.8. Rutas en tiempo real con indicaciones detalladas de caminata.",
   "engineOfflineName": "Sin conexión",
   "engineOfflineDescription": "Enrutamiento basado en GTFS. Funciona sin internet.",
   "limitationRequiresInternet": "Requiere internet",
   "limitationSlower": "Respuesta más lenta",
-  "limitationNoWalkingRoute": "Sin ruta de caminata en mapa"
+  "limitationNoWalkingRoute": "Sin ruta de caminata en mapa",
+  "settingsWorksOffline": "Funciona sin conexión",
+  "settingsNeedsInternet": "Requiere conexión a internet"
 }

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_localizations.dart
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_localizations.dart
@@ -274,13 +274,13 @@ abstract class SettingsLocalizations {
   /// Routing settings section
   ///
   /// In en, this message translates to:
-  /// **'Routing'**
+  /// **'Route search'**
   String get settingsRouting;
 
   /// Routing engine selection instruction
   ///
   /// In en, this message translates to:
-  /// **'Select your preferred routing engine:'**
+  /// **'Choose the service used to calculate your routes.'**
   String get settingsSelectRoutingEngine;
 
   /// Privacy settings section
@@ -348,6 +348,18 @@ abstract class SettingsLocalizations {
   /// In en, this message translates to:
   /// **'No walking route on map'**
   String get limitationNoWalkingRoute;
+
+  /// Badge on a routing option that works offline.
+  ///
+  /// In en, this message translates to:
+  /// **'Works without a connection'**
+  String get settingsWorksOffline;
+
+  /// Badge on a routing option that requires internet.
+  ///
+  /// In en, this message translates to:
+  /// **'Needs an internet connection'**
+  String get settingsNeedsInternet;
 }
 
 class _SettingsLocalizationsDelegate

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_de.dart
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_de.dart
@@ -97,11 +97,11 @@ class SettingsLocalizationsDe extends SettingsLocalizations {
   String get settingsSelectMapType => 'Wählen Sie Ihren bevorzugten Kartentyp:';
 
   @override
-  String get settingsRouting => 'Routenplanung';
+  String get settingsRouting => 'Routensuche';
 
   @override
   String get settingsSelectRoutingEngine =>
-      'Wählen Sie Ihre bevorzugte Routenplanung:';
+      'Wähle den Dienst, mit dem deine Routen berechnet werden.';
 
   @override
   String get settingsPrivacy => 'Datenschutz';
@@ -138,4 +138,10 @@ class SettingsLocalizationsDe extends SettingsLocalizations {
 
   @override
   String get limitationNoWalkingRoute => 'Keine Fußweg-Route auf Karte';
+
+  @override
+  String get settingsWorksOffline => 'Funktioniert ohne Verbindung';
+
+  @override
+  String get settingsNeedsInternet => 'Benötigt eine Internetverbindung';
 }

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_de.dart
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_de.dart
@@ -140,8 +140,8 @@ class SettingsLocalizationsDe extends SettingsLocalizations {
   String get limitationNoWalkingRoute => 'Keine Fußweg-Route auf Karte';
 
   @override
-  String get settingsWorksOffline => 'Funktioniert ohne Verbindung';
+  String get settingsWorksOffline => 'Ohne Verbindung';
 
   @override
-  String get settingsNeedsInternet => 'Benötigt eine Internetverbindung';
+  String get settingsNeedsInternet => 'Braucht Internet';
 }

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_en.dart
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_en.dart
@@ -96,11 +96,11 @@ class SettingsLocalizationsEn extends SettingsLocalizations {
   String get settingsSelectMapType => 'Select your preferred map type:';
 
   @override
-  String get settingsRouting => 'Routing';
+  String get settingsRouting => 'Route search';
 
   @override
   String get settingsSelectRoutingEngine =>
-      'Select your preferred routing engine:';
+      'Choose the service used to calculate your routes.';
 
   @override
   String get settingsPrivacy => 'Privacy';
@@ -137,4 +137,10 @@ class SettingsLocalizationsEn extends SettingsLocalizations {
 
   @override
   String get limitationNoWalkingRoute => 'No walking route on map';
+
+  @override
+  String get settingsWorksOffline => 'Works without a connection';
+
+  @override
+  String get settingsNeedsInternet => 'Needs an internet connection';
 }

--- a/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_es.dart
+++ b/packages/screens/trufi_core_settings/lib/l10n/settings_localizations_es.dart
@@ -97,11 +97,11 @@ class SettingsLocalizationsEs extends SettingsLocalizations {
   String get settingsSelectMapType => 'Selecciona tu tipo de mapa preferido:';
 
   @override
-  String get settingsRouting => 'Enrutamiento';
+  String get settingsRouting => 'Búsqueda de rutas';
 
   @override
   String get settingsSelectRoutingEngine =>
-      'Selecciona tu motor de enrutamiento preferido:';
+      'Elige el servicio que se utilizará para calcular tus rutas.';
 
   @override
   String get settingsPrivacy => 'Privacidad';
@@ -138,4 +138,10 @@ class SettingsLocalizationsEs extends SettingsLocalizations {
 
   @override
   String get limitationNoWalkingRoute => 'Sin ruta de caminata en mapa';
+
+  @override
+  String get settingsWorksOffline => 'Funciona sin conexión';
+
+  @override
+  String get settingsNeedsInternet => 'Requiere conexión a internet';
 }

--- a/packages/screens/trufi_core_settings/lib/settings_screen.dart
+++ b/packages/screens/trufi_core_settings/lib/settings_screen.dart
@@ -445,6 +445,15 @@ class _RoutingSettingsCard extends StatelessWidget {
             child: _EngineOptionTile(
               name: engine.localizedName(context),
               description: engine.localizedDescription(context),
+              // The connectivity requirement is what users actually
+              // choose on, so it gets its own line instead of being
+              // buried in the description (#921).
+              badge: isOffline
+                  ? settingsL10n.settingsWorksOffline
+                  : settingsL10n.settingsNeedsInternet,
+              badgeIcon: isOffline
+                  ? Icons.wifi_off_rounded
+                  : Icons.public_rounded,
               icon: isOffline
                   ? Icons.offline_bolt_rounded
                   : Icons.cloud_rounded,
@@ -746,12 +755,19 @@ class _EngineOptionTile extends StatelessWidget {
   final bool isSelected;
   final VoidCallback onTap;
 
+  /// Optional one-line qualifier under the description (e.g. whether the
+  /// option needs a connection). Map engines don't set it.
+  final String? badge;
+  final IconData? badgeIcon;
+
   const _EngineOptionTile({
     required this.name,
     required this.description,
     required this.icon,
     required this.isSelected,
     required this.onTap,
+    this.badge,
+    this.badgeIcon,
   });
 
   @override
@@ -819,6 +835,34 @@ class _EngineOptionTile extends StatelessWidget {
                       maxLines: 3,
                       overflow: TextOverflow.fade,
                     ),
+                    if (badge != null) ...[
+                      const SizedBox(height: 4),
+                      Row(
+                        children: [
+                          Icon(
+                            badgeIcon ?? Icons.info_outline_rounded,
+                            size: 14,
+                            color: isSelected
+                                ? colorScheme.primary
+                                : colorScheme.onSurfaceVariant,
+                          ),
+                          const SizedBox(width: 6),
+                          Flexible(
+                            child: Text(
+                              badge!,
+                              style: theme.textTheme.labelSmall?.copyWith(
+                                color: isSelected
+                                    ? colorScheme.primary
+                                    : colorScheme.onSurfaceVariant,
+                                fontWeight: FontWeight.w600,
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
                   ],
                 ),
               ),

--- a/packages/trufi_core_routing/lib/l10n/routing_de.arb
+++ b/packages/trufi_core_routing/lib/l10n/routing_de.arb
@@ -18,11 +18,11 @@
   "serviceClosedOpensDayAt": "Geschlossen · öffnet {day} um {time}",
   "serviceClosed": "Geschlossen",
   "serviceTomorrow": "morgen",
-  "trufiPlannerLocalDescription": "Läuft offline mit den in der App gebündelten GTFS-Daten",
-  "trufiPlannerRemoteDescription": "Unsere eigene Routing-Engine von unserem Server",
+  "trufiPlannerLocalDescription": "Findet Routen mit den auf deinem Gerät gespeicherten Daten.",
+  "trufiPlannerRemoteDescription": "Findet Routen über unseren eigenen Dienst. Benötigt eine Verbindung.",
   "trufiPlannerInfoTitle": "Über Trufi Planner",
   "trufiPlannerInfoIntro": "Trufi Planner ist unsere eigene Routing-Engine (kein OTP).",
   "trufiPlannerInfoLocalBody": "Auf dem Gerät läuft er zu 100% offline mit den gebündelten GTFS-Daten — Ergebnisse können daher von Online-Engines abweichen.",
   "trufiPlannerInfoRemoteBody": "Diese Web-Version fragt unseren Server ab; Ergebnisse können von OTP abweichen, da Algorithmus und Daten unterschiedlich sind.",
-  "otpOnlineDescription": "OpenTripPlanner {version} (online)"
+  "otpOnlineDescription": "Findet Routen über einen Online-Dienst. Kann aktuellere Informationen haben."
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_en.arb
+++ b/packages/trufi_core_routing/lib/l10n/routing_en.arb
@@ -56,22 +56,30 @@
   "@serviceActiveClosesAt": {
     "description": "Service-hours indicator label when the route is currently running. {time} is the closing time, e.g. '22:00'.",
     "placeholders": {
-      "time": { "type": "String" }
+      "time": {
+        "type": "String"
+      }
     }
   },
   "serviceClosedOpensAt": "Closed · opens at {time}",
   "@serviceClosedOpensAt": {
     "description": "Service-hours indicator label when the route runs today but the current time is before its start. {time} is the opening time.",
     "placeholders": {
-      "time": { "type": "String" }
+      "time": {
+        "type": "String"
+      }
     }
   },
   "serviceClosedOpensDayAt": "Closed · opens {day} at {time}",
   "@serviceClosedOpensDayAt": {
     "description": "Service-hours indicator label when the next service is on a different weekday. {day} is the localized day name (e.g. 'tomorrow', 'Mon'), {time} is the opening time.",
     "placeholders": {
-      "day": { "type": "String" },
-      "time": { "type": "String" }
+      "day": {
+        "type": "String"
+      },
+      "time": {
+        "type": "String"
+      }
     }
   },
   "serviceClosed": "Closed",
@@ -82,11 +90,11 @@
   "@serviceTomorrow": {
     "description": "Used inside serviceClosedOpensDayAt when the next service is on the next calendar day."
   },
-  "trufiPlannerLocalDescription": "Runs offline with the GTFS data bundled in the app",
+  "trufiPlannerLocalDescription": "Finds routes using the data saved on your device.",
   "@trufiPlannerLocalDescription": {
     "description": "Description of the offline Trufi Planner engine in selectors"
   },
-  "trufiPlannerRemoteDescription": "Our own routing engine served from our backend",
+  "trufiPlannerRemoteDescription": "Finds routes through our own service. Needs a connection.",
   "@trufiPlannerRemoteDescription": {
     "description": "Description of the server-backed Trufi Planner engine in selectors"
   },
@@ -106,13 +114,8 @@
   "@trufiPlannerInfoRemoteBody": {
     "description": "Info card body for the server-backed variant"
   },
-  "otpOnlineDescription": "OpenTripPlanner {version} (Online)",
+  "otpOnlineDescription": "Finds routes through an online service. May have more up-to-date information.",
   "@otpOnlineDescription": {
-    "description": "Default description for OpenTripPlanner engines; {version} is e.g. 2.8",
-    "placeholders": {
-      "version": {
-        "type": "String"
-      }
-    }
+    "description": "Description shown for OpenTripPlanner engines in the routing settings."
   }
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_es.arb
+++ b/packages/trufi_core_routing/lib/l10n/routing_es.arb
@@ -18,11 +18,11 @@
   "serviceClosedOpensDayAt": "Cerrado · abre {day} a las {time}",
   "serviceClosed": "Cerrado",
   "serviceTomorrow": "mañana",
-  "trufiPlannerLocalDescription": "Funciona offline con datos GTFS empacados en la app",
-  "trufiPlannerRemoteDescription": "Motor de rutas propio servido desde nuestro backend",
+  "trufiPlannerLocalDescription": "Busca rutas usando los datos guardados en tu dispositivo.",
+  "trufiPlannerRemoteDescription": "Busca rutas con nuestro propio servicio. Necesita conexión.",
   "trufiPlannerInfoTitle": "Acerca de Trufi Planner",
   "trufiPlannerInfoIntro": "Trufi Planner es nuestro motor de rutas propio (no OTP).",
   "trufiPlannerInfoLocalBody": "En esta versión móvil corre 100% offline, usando los datos GTFS empacados con la app — por eso los resultados pueden diferir de motores online.",
   "trufiPlannerInfoRemoteBody": "Esta versión web consulta nuestro servidor; los resultados pueden diferir de OTP por usar un algoritmo y datos distintos.",
-  "otpOnlineDescription": "OpenTripPlanner {version} (en línea)"
+  "otpOnlineDescription": "Busca rutas mediante un servicio en línea. Puede tener información más actualizada."
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_localizations.dart
+++ b/packages/trufi_core_routing/lib/l10n/routing_localizations.dart
@@ -214,13 +214,13 @@ abstract class RoutingLocalizations {
   /// Description of the offline Trufi Planner engine in selectors
   ///
   /// In en, this message translates to:
-  /// **'Runs offline with the GTFS data bundled in the app'**
+  /// **'Finds routes using the data saved on your device.'**
   String get trufiPlannerLocalDescription;
 
   /// Description of the server-backed Trufi Planner engine in selectors
   ///
   /// In en, this message translates to:
-  /// **'Our own routing engine served from our backend'**
+  /// **'Finds routes through our own service. Needs a connection.'**
   String get trufiPlannerRemoteDescription;
 
   /// Title of the Trufi Planner info card in routing preferences
@@ -247,11 +247,11 @@ abstract class RoutingLocalizations {
   /// **'This web version queries our server; results may differ from OTP because it uses a different algorithm and data.'**
   String get trufiPlannerInfoRemoteBody;
 
-  /// Default description for OpenTripPlanner engines; {version} is e.g. 2.8
+  /// Description shown for OpenTripPlanner engines in the routing settings.
   ///
   /// In en, this message translates to:
-  /// **'OpenTripPlanner {version} (Online)'**
-  String otpOnlineDescription(String version);
+  /// **'Finds routes through an online service. May have more up-to-date information.'**
+  String get otpOnlineDescription;
 }
 
 class _RoutingLocalizationsDelegate

--- a/packages/trufi_core_routing/lib/l10n/routing_localizations_de.dart
+++ b/packages/trufi_core_routing/lib/l10n/routing_localizations_de.dart
@@ -70,11 +70,11 @@ class RoutingLocalizationsDe extends RoutingLocalizations {
 
   @override
   String get trufiPlannerLocalDescription =>
-      'Läuft offline mit den in der App gebündelten GTFS-Daten';
+      'Findet Routen mit den auf deinem Gerät gespeicherten Daten.';
 
   @override
   String get trufiPlannerRemoteDescription =>
-      'Unsere eigene Routing-Engine von unserem Server';
+      'Findet Routen über unseren eigenen Dienst. Benötigt eine Verbindung.';
 
   @override
   String get trufiPlannerInfoTitle => 'Über Trufi Planner';
@@ -92,7 +92,6 @@ class RoutingLocalizationsDe extends RoutingLocalizations {
       'Diese Web-Version fragt unseren Server ab; Ergebnisse können von OTP abweichen, da Algorithmus und Daten unterschiedlich sind.';
 
   @override
-  String otpOnlineDescription(String version) {
-    return 'OpenTripPlanner $version (online)';
-  }
+  String get otpOnlineDescription =>
+      'Findet Routen über einen Online-Dienst. Kann aktuellere Informationen haben.';
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_localizations_en.dart
+++ b/packages/trufi_core_routing/lib/l10n/routing_localizations_en.dart
@@ -70,11 +70,11 @@ class RoutingLocalizationsEn extends RoutingLocalizations {
 
   @override
   String get trufiPlannerLocalDescription =>
-      'Runs offline with the GTFS data bundled in the app';
+      'Finds routes using the data saved on your device.';
 
   @override
   String get trufiPlannerRemoteDescription =>
-      'Our own routing engine served from our backend';
+      'Finds routes through our own service. Needs a connection.';
 
   @override
   String get trufiPlannerInfoTitle => 'About Trufi Planner';
@@ -92,7 +92,6 @@ class RoutingLocalizationsEn extends RoutingLocalizations {
       'This web version queries our server; results may differ from OTP because it uses a different algorithm and data.';
 
   @override
-  String otpOnlineDescription(String version) {
-    return 'OpenTripPlanner $version (Online)';
-  }
+  String get otpOnlineDescription =>
+      'Finds routes through an online service. May have more up-to-date information.';
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_localizations_es.dart
+++ b/packages/trufi_core_routing/lib/l10n/routing_localizations_es.dart
@@ -71,11 +71,11 @@ class RoutingLocalizationsEs extends RoutingLocalizations {
 
   @override
   String get trufiPlannerLocalDescription =>
-      'Funciona offline con datos GTFS empacados en la app';
+      'Busca rutas usando los datos guardados en tu dispositivo.';
 
   @override
   String get trufiPlannerRemoteDescription =>
-      'Motor de rutas propio servido desde nuestro backend';
+      'Busca rutas con nuestro propio servicio. Necesita conexión.';
 
   @override
   String get trufiPlannerInfoTitle => 'Acerca de Trufi Planner';
@@ -93,7 +93,6 @@ class RoutingLocalizationsEs extends RoutingLocalizations {
       'Esta versión web consulta nuestro servidor; los resultados pueden diferir de OTP por usar un algoritmo y datos distintos.';
 
   @override
-  String otpOnlineDescription(String version) {
-    return 'OpenTripPlanner $version (en línea)';
-  }
+  String get otpOnlineDescription =>
+      'Busca rutas mediante un servicio en línea. Puede tener información más actualizada.';
 }

--- a/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
@@ -76,7 +76,7 @@ class Otp15RoutingProvider extends IRoutingProvider {
   String get id => 'otp_1_5';
 
   @override
-  String get name => displayName ?? 'OTP 1.5';
+  String get name => displayName ?? 'OpenTripPlanner (OTP)';
 
   @override
   String get description =>
@@ -85,7 +85,7 @@ class Otp15RoutingProvider extends IRoutingProvider {
   @override
   String localizedDescription(BuildContext context) =>
       displayDescription ??
-      RoutingLocalizations.of(context).otpOnlineDescription('1.5');
+      RoutingLocalizations.of(context).otpOnlineDescription;
 
   @override
   bool get supportsTransitRoutes => true;

--- a/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
@@ -76,7 +76,7 @@ class Otp15RoutingProvider extends IRoutingProvider {
   String get id => 'otp_1_5';
 
   @override
-  String get name => displayName ?? 'OpenTripPlanner (OTP)';
+  String get name => displayName ?? 'OTP 1.5';
 
   @override
   String get description =>

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_routing_provider.dart
@@ -76,7 +76,7 @@ class Otp24RoutingProvider extends IRoutingProvider {
   @override
   String localizedDescription(BuildContext context) =>
       displayDescription ??
-      RoutingLocalizations.of(context).otpOnlineDescription('2.4');
+      RoutingLocalizations.of(context).otpOnlineDescription;
 
   @override
   bool get supportsTransitRoutes => true;

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
@@ -99,9 +99,7 @@ class Otp28RoutingProvider extends IRoutingProvider {
   String get id => 'otp_2_8';
 
   @override
-  // Users pick a service, not a version: the engine version is an
-  // implementation detail that meant nothing to them (#921).
-  String get name => displayName ?? 'OpenTripPlanner (OTP)';
+  String get name => displayName ?? 'OTP 2.8';
 
   @override
   String get description =>

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
@@ -99,7 +99,9 @@ class Otp28RoutingProvider extends IRoutingProvider {
   String get id => 'otp_2_8';
 
   @override
-  String get name => displayName ?? 'OTP 2.8';
+  // Users pick a service, not a version: the engine version is an
+  // implementation detail that meant nothing to them (#921).
+  String get name => displayName ?? 'OpenTripPlanner (OTP)';
 
   @override
   String get description =>
@@ -108,7 +110,7 @@ class Otp28RoutingProvider extends IRoutingProvider {
   @override
   String localizedDescription(BuildContext context) =>
       displayDescription ??
-      RoutingLocalizations.of(context).otpOnlineDescription('2.8');
+      RoutingLocalizations.of(context).otpOnlineDescription;
 
   @override
   bool get supportsTransitRoutes => true;

--- a/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_provider.dart
@@ -71,8 +71,8 @@ class TrufiPlannerProvider extends IRoutingProvider {
   String get description =>
       config.description ??
       (config.isLocal
-          ? 'Funciona offline con datos GTFS empacados en la app'
-          : 'Motor de rutas propio servido desde nuestro backend');
+          ? 'Finds routes using the data saved on your device.'
+          : 'Finds routes through our own service. Needs a connection.');
 
   @override
   String localizedDescription(BuildContext context) {


### PR DESCRIPTION
Fixes #921.

## Problem

The routing section asked users to pick between **engines**, by name and version:

> **Routing** — Select your preferred routing engine
> · **Trufi Planner** — Works offline with GTFS data packaged inside the app
> · **OTP 2.8.1** — OpenTripPlanner 2.8 (Online)

None of that answers the question people actually have: *will this work without internet, and which one is more up to date?*

## Fix

Applies the copy the reporter mocked up in the issue:

| | Before | After |
|---|---|---|
| Section | Routing — *Select your preferred routing engine* | **Route search** — *Choose the service used to calculate your routes* |
| Trufi Planner | *Works offline with GTFS data packaged inside the app* | *Finds routes using the data saved on your device* + **Works without a connection** |
| OTP | *OpenTripPlanner 2.8 (Online)* | *Finds routes through an online service. May have more up-to-date information* + **Needs an internet connection** |

The connectivity requirement gets its own line with an icon, because that is the real decision criterion; the screen already knew `requiresInternet`, it just wasn't showing it. en/es/de.

The OTP description no longer interpolates the engine version, so the `{version}` placeholder is gone from the ARB and from the three call sites.

## Not included (needs a decision)

The mockup also renames the option itself to **OpenTripPlanner (OTP)**. Both the example and trufi-app pass `displayName: 'OTP 2.8.1'` explicitly, so that rename is an app-side change rather than a core default — happy to do it in the apps if we want the version out of the UI entirely.

## Testing

Analyze clean on both touched packages; settings/routing suites unchanged. Screenshot of the result in the review comment.