### PR TITLE
fix(maps): require maplibre_gl 0.26.2 to avoid the iOS zero-frame camera crash

### DIFF
--- a/apps/example/pubspec.yaml
+++ b/apps/example/pubspec.yaml
@@ -32,7 +32,13 @@ dependencies:
   trufi_core_navigation: ^1.0.0
   trufi_core_poi_layers: ^1.0.0
   latlong2: ^0.9.1
-  maplibre_gl: ^0.26.1
+  # 0.26.2 minimum: 0.26.1 still crashes on iOS with SIGABRT
+  # (std::domain_error from mbgl::LatLng) when a camera op reaches a map
+  # whose native frame is zero-sized — a route-detail screen fitting the
+  # camera right after creating its map hits it. Fixed upstream in 0.26.2
+  # (maplibre/flutter-maplibre-gl#819, PR #841); crashed a real-device
+  # App Review submission on 0.25.0 (Trujillo, 2026-08-09).
+  maplibre_gl: ^0.26.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/screens/trufi_core_home_screen/example/pubspec.lock
+++ b/packages/screens/trufi_core_home_screen/example/pubspec.lock
@@ -468,26 +468,26 @@ packages:
     dependency: transitive
     description:
       name: maplibre_gl
-      sha256: "3c383a7e81f0ec5882c377b7d1686047d8bce35b6a3a9798dad8e57a03423e05"
+      sha256: b676f124a2fcf88c4dafedc7b462155e6396d61ce7af46354b4de11b45c9812f
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_platform_interface:
     dependency: transitive
     description:
       name: maplibre_gl_platform_interface
-      sha256: "4989f157fdb98ad346b31067cd30aefa7e67d0b235599e37b75608c9284cb459"
+      sha256: "1f0ca8a99f03fa9434618ee21f4e42dd615830a7dd973e632b11c73ffec993a8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_web:
     dependency: transitive
     description:
       name: maplibre_gl_web
-      sha256: "55a03e586d2007b646f163902388c3c17df536ea44e4b1c381754863201862e6"
+      sha256: bbf022f29ceef26d73f63e584819fbd02fbaf4eb1facf5234206c78936cf8f1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   material_color_utilities:
     dependency: transitive
     description:

--- a/packages/screens/trufi_core_saved_places/example/pubspec.lock
+++ b/packages/screens/trufi_core_saved_places/example/pubspec.lock
@@ -409,26 +409,26 @@ packages:
     dependency: transitive
     description:
       name: maplibre_gl
-      sha256: "3c383a7e81f0ec5882c377b7d1686047d8bce35b6a3a9798dad8e57a03423e05"
+      sha256: b676f124a2fcf88c4dafedc7b462155e6396d61ce7af46354b4de11b45c9812f
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_platform_interface:
     dependency: transitive
     description:
       name: maplibre_gl_platform_interface
-      sha256: "4989f157fdb98ad346b31067cd30aefa7e67d0b235599e37b75608c9284cb459"
+      sha256: "1f0ca8a99f03fa9434618ee21f4e42dd615830a7dd973e632b11c73ffec993a8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_web:
     dependency: transitive
     description:
       name: maplibre_gl_web
-      sha256: "55a03e586d2007b646f163902388c3c17df536ea44e4b1c381754863201862e6"
+      sha256: bbf022f29ceef26d73f63e584819fbd02fbaf4eb1facf5234206c78936cf8f1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   matcher:
     dependency: transitive
     description:

--- a/packages/screens/trufi_core_settings/example/pubspec.lock
+++ b/packages/screens/trufi_core_settings/example/pubspec.lock
@@ -497,26 +497,26 @@ packages:
     dependency: transitive
     description:
       name: maplibre_gl
-      sha256: "3c383a7e81f0ec5882c377b7d1686047d8bce35b6a3a9798dad8e57a03423e05"
+      sha256: b676f124a2fcf88c4dafedc7b462155e6396d61ce7af46354b4de11b45c9812f
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_platform_interface:
     dependency: transitive
     description:
       name: maplibre_gl_platform_interface
-      sha256: "4989f157fdb98ad346b31067cd30aefa7e67d0b235599e37b75608c9284cb459"
+      sha256: "1f0ca8a99f03fa9434618ee21f4e42dd615830a7dd973e632b11c73ffec993a8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_web:
     dependency: transitive
     description:
       name: maplibre_gl_web
-      sha256: "55a03e586d2007b646f163902388c3c17df536ea44e4b1c381754863201862e6"
+      sha256: bbf022f29ceef26d73f63e584819fbd02fbaf4eb1facf5234206c78936cf8f1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   matcher:
     dependency: transitive
     description:

--- a/packages/screens/trufi_core_transport_list/example/pubspec.lock
+++ b/packages/screens/trufi_core_transport_list/example/pubspec.lock
@@ -513,26 +513,26 @@ packages:
     dependency: transitive
     description:
       name: maplibre_gl
-      sha256: "3c383a7e81f0ec5882c377b7d1686047d8bce35b6a3a9798dad8e57a03423e05"
+      sha256: b676f124a2fcf88c4dafedc7b462155e6396d61ce7af46354b4de11b45c9812f
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_platform_interface:
     dependency: transitive
     description:
       name: maplibre_gl_platform_interface
-      sha256: "4989f157fdb98ad346b31067cd30aefa7e67d0b235599e37b75608c9284cb459"
+      sha256: "1f0ca8a99f03fa9434618ee21f4e42dd615830a7dd973e632b11c73ffec993a8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_web:
     dependency: transitive
     description:
       name: maplibre_gl_web
-      sha256: "55a03e586d2007b646f163902388c3c17df536ea44e4b1c381754863201862e6"
+      sha256: bbf022f29ceef26d73f63e584819fbd02fbaf4eb1facf5234206c78936cf8f1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   matcher:
     dependency: transitive
     description:

--- a/packages/trufi_core_maps/example/pubspec.lock
+++ b/packages/trufi_core_maps/example/pubspec.lock
@@ -433,26 +433,26 @@ packages:
     dependency: transitive
     description:
       name: maplibre_gl
-      sha256: "3c383a7e81f0ec5882c377b7d1686047d8bce35b6a3a9798dad8e57a03423e05"
+      sha256: b676f124a2fcf88c4dafedc7b462155e6396d61ce7af46354b4de11b45c9812f
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_platform_interface:
     dependency: transitive
     description:
       name: maplibre_gl_platform_interface
-      sha256: "4989f157fdb98ad346b31067cd30aefa7e67d0b235599e37b75608c9284cb459"
+      sha256: "1f0ca8a99f03fa9434618ee21f4e42dd615830a7dd973e632b11c73ffec993a8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_web:
     dependency: transitive
     description:
       name: maplibre_gl_web
-      sha256: "55a03e586d2007b646f163902388c3c17df536ea44e4b1c381754863201862e6"
+      sha256: bbf022f29ceef26d73f63e584819fbd02fbaf4eb1facf5234206c78936cf8f1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   matcher:
     dependency: transitive
     description:

--- a/packages/trufi_core_maps/pubspec.yaml
+++ b/packages/trufi_core_maps/pubspec.yaml
@@ -21,7 +21,13 @@ dependencies:
   flutter_bloc: ^9.1.1
   flutter_svg: ^2.2.3
   latlong2: ^0.9.1
-  maplibre_gl: ^0.26.1
+  # 0.26.2 minimum: 0.26.1 still crashes on iOS with SIGABRT
+  # (std::domain_error from mbgl::LatLng) when a camera op reaches a map
+  # whose native frame is zero-sized — a route-detail screen fitting the
+  # camera right after creating its map hits it. Fixed upstream in 0.26.2
+  # (maplibre/flutter-maplibre-gl#819, PR #841); crashed a real-device
+  # App Review submission on 0.25.0 (Trujillo, 2026-08-09).
+  maplibre_gl: ^0.26.2
   shared_preferences: ^2.5.4
   path_provider: ^2.1.5
   url_launcher: ^6.3.2

--- a/packages/trufi_core_search_locations/example/pubspec.lock
+++ b/packages/trufi_core_search_locations/example/pubspec.lock
@@ -409,26 +409,26 @@ packages:
     dependency: transitive
     description:
       name: maplibre_gl
-      sha256: "3c383a7e81f0ec5882c377b7d1686047d8bce35b6a3a9798dad8e57a03423e05"
+      sha256: b676f124a2fcf88c4dafedc7b462155e6396d61ce7af46354b4de11b45c9812f
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_platform_interface:
     dependency: transitive
     description:
       name: maplibre_gl_platform_interface
-      sha256: "4989f157fdb98ad346b31067cd30aefa7e67d0b235599e37b75608c9284cb459"
+      sha256: "1f0ca8a99f03fa9434618ee21f4e42dd615830a7dd973e632b11c73ffec993a8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_web:
     dependency: transitive
     description:
       name: maplibre_gl_web
-      sha256: "55a03e586d2007b646f163902388c3c17df536ea44e4b1c381754863201862e6"
+      sha256: bbf022f29ceef26d73f63e584819fbd02fbaf4eb1facf5234206c78936cf8f1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -689,26 +689,26 @@ packages:
     dependency: transitive
     description:
       name: maplibre_gl
-      sha256: "3c383a7e81f0ec5882c377b7d1686047d8bce35b6a3a9798dad8e57a03423e05"
+      sha256: b676f124a2fcf88c4dafedc7b462155e6396d61ce7af46354b4de11b45c9812f
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_platform_interface:
     dependency: transitive
     description:
       name: maplibre_gl_platform_interface
-      sha256: "4989f157fdb98ad346b31067cd30aefa7e67d0b235599e37b75608c9284cb459"
+      sha256: "1f0ca8a99f03fa9434618ee21f4e42dd615830a7dd973e632b11c73ffec993a8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   maplibre_gl_web:
     dependency: transitive
     description:
       name: maplibre_gl_web
-      sha256: "55a03e586d2007b646f163902388c3c17df536ea44e4b1c381754863201862e6"
+      sha256: bbf022f29ceef26d73f63e584819fbd02fbaf4eb1facf5234206c78936cf8f1c
       url: "https://pub.dev"
     source: hosted
-    version: "0.26.1"
+    version: "0.26.2"
   matcher:
     dependency: transitive
     description:


### PR DESCRIPTION
## Why

`^0.26.1` can resolve to **0.26.1**, which still aborts on iOS with SIGABRT (`std::domain_error` from `mbgl::util::LatLng`) whenever a camera operation reaches a map whose native frame is **zero-sized**. `TransportDetailScreen` triggers exactly that race: it creates its own map and fits the camera to the route geometry in a post-frame callback, before the platform view's first layout. Swift cannot catch the C++ exception, so the process dies.

Fixed upstream in **maplibre_gl 0.26.2**: *"iOS: Fixed a crash on cold launch when the map was first displayed at zero size (#841)"* — maplibre/flutter-maplibre-gl#819.

## Evidence

- Crashed a **real-device** App Store review submission on 0.25.0 (Trujillo Mi Ruta, iPhone 17 Pro / iOS 26.5.2, 2026-08-09): 3 identical native stacks ending in `__cxa_throw` → `MapLibreMapController.onMethodCall` (`camera#move`, MapLibreMapController.swift:482), console shows `libc++abi: terminating due to uncaught exception of type std::domain_error`.
- Reproduced deterministically on the iPhone 17 Pro simulator; gone after forcing 0.26.2 in the same app.
- This crash was previously misdiagnosed in our review notes as a simulator-only flake.

## Changes

- `trufi_core_maps` and the example app now require `maplibre_gl: ^0.26.2` (workspace lock already resolved 0.26.2; the constraint makes the floor explicit for consumers).

## Verification

- `flutter analyze`: clean
- `flutter test` in `trufi_core_maps`: 40/40 pass (the CI check runs no tests)