### PR TITLE
feat(search_locations): street → corners drill-down on the search screen (#745)

### DIFF
--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_de.arb
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_de.arb
@@ -9,6 +9,5 @@
   "yourPlaces": "DEINE ORTE",
   "searchResults": "SUCHERGEBNISSE",
   "noResultsFound": "Keine Ergebnisse gefunden",
-  "cornersOf": "Kreuzungen: {street}",
-  "seeCorners": "Kreuzungen anzeigen"
+  "searchCornersHint": "Kreuzungen suchen..."
 }

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_de.arb
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_de.arb
@@ -8,5 +8,7 @@
   "chooseOnMap": "Auf der Karte wählen",
   "yourPlaces": "DEINE ORTE",
   "searchResults": "SUCHERGEBNISSE",
-  "noResultsFound": "Keine Ergebnisse gefunden"
+  "noResultsFound": "Keine Ergebnisse gefunden",
+  "cornersOf": "Kreuzungen: {street}",
+  "seeCorners": "Kreuzungen anzeigen"
 }

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_en.arb
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_en.arb
@@ -36,17 +36,8 @@
   "@noResultsFound": {
     "description": "Message shown when a search returns no results"
   },
-  "cornersOf": "Corners of {street}",
-  "@cornersOf": {
-    "description": "Section title while picking one corner of a street in the drill-down flow. {street} is the street name.",
-    "placeholders": {
-      "street": {
-        "type": "String"
-      }
-    }
-  },
-  "seeCorners": "See corners",
-  "@seeCorners": {
-    "description": "Tooltip/semantics of the trailing button on a street result that opens its corners list"
+  "searchCornersHint": "Search corners...",
+  "@searchCornersHint": {
+    "description": "Hint of the filter field inside a street's corners list (drill-down flow); it searches only within those corners"
   }
 }

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_en.arb
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_en.arb
@@ -35,5 +35,18 @@
   "noResultsFound": "No results found",
   "@noResultsFound": {
     "description": "Message shown when a search returns no results"
+  },
+  "cornersOf": "Corners of {street}",
+  "@cornersOf": {
+    "description": "Section title while picking one corner of a street in the drill-down flow. {street} is the street name.",
+    "placeholders": {
+      "street": {
+        "type": "String"
+      }
+    }
+  },
+  "seeCorners": "See corners",
+  "@seeCorners": {
+    "description": "Tooltip/semantics of the trailing button on a street result that opens its corners list"
   }
 }

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_es.arb
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_es.arb
@@ -9,6 +9,5 @@
   "yourPlaces": "TUS LUGARES",
   "searchResults": "RESULTADOS DE BÚSQUEDA",
   "noResultsFound": "No se encontraron resultados",
-  "cornersOf": "Esquinas de {street}",
-  "seeCorners": "Ver esquinas"
+  "searchCornersHint": "Buscar esquinas..."
 }

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_es.arb
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_es.arb
@@ -8,5 +8,7 @@
   "chooseOnMap": "Elegir en el mapa",
   "yourPlaces": "TUS LUGARES",
   "searchResults": "RESULTADOS DE BÚSQUEDA",
-  "noResultsFound": "No se encontraron resultados"
+  "noResultsFound": "No se encontraron resultados",
+  "cornersOf": "Esquinas de {street}",
+  "seeCorners": "Ver esquinas"
 }

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations.dart
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations.dart
@@ -156,6 +156,18 @@ abstract class SearchLocationsLocalizations {
   /// In en, this message translates to:
   /// **'No results found'**
   String get noResultsFound;
+
+  /// Section title while picking one corner of a street in the drill-down flow. {street} is the street name.
+  ///
+  /// In en, this message translates to:
+  /// **'Corners of {street}'**
+  String cornersOf(String street);
+
+  /// Tooltip/semantics of the trailing button on a street result that opens its corners list
+  ///
+  /// In en, this message translates to:
+  /// **'See corners'**
+  String get seeCorners;
 }
 
 class _SearchLocationsLocalizationsDelegate

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations.dart
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations.dart
@@ -157,17 +157,11 @@ abstract class SearchLocationsLocalizations {
   /// **'No results found'**
   String get noResultsFound;
 
-  /// Section title while picking one corner of a street in the drill-down flow. {street} is the street name.
+  /// Hint of the filter field inside a street's corners list (drill-down flow); it searches only within those corners
   ///
   /// In en, this message translates to:
-  /// **'Corners of {street}'**
-  String cornersOf(String street);
-
-  /// Tooltip/semantics of the trailing button on a street result that opens its corners list
-  ///
-  /// In en, this message translates to:
-  /// **'See corners'**
-  String get seeCorners;
+  /// **'Search corners...'**
+  String get searchCornersHint;
 }
 
 class _SearchLocationsLocalizationsDelegate

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_de.dart
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_de.dart
@@ -34,4 +34,12 @@ class SearchLocationsLocalizationsDe extends SearchLocationsLocalizations {
 
   @override
   String get noResultsFound => 'Keine Ergebnisse gefunden';
+
+  @override
+  String cornersOf(String street) {
+    return 'Kreuzungen: $street';
+  }
+
+  @override
+  String get seeCorners => 'Kreuzungen anzeigen';
 }

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_de.dart
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_de.dart
@@ -36,10 +36,5 @@ class SearchLocationsLocalizationsDe extends SearchLocationsLocalizations {
   String get noResultsFound => 'Keine Ergebnisse gefunden';
 
   @override
-  String cornersOf(String street) {
-    return 'Kreuzungen: $street';
-  }
-
-  @override
-  String get seeCorners => 'Kreuzungen anzeigen';
+  String get searchCornersHint => 'Kreuzungen suchen...';
 }

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_en.dart
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_en.dart
@@ -34,4 +34,12 @@ class SearchLocationsLocalizationsEn extends SearchLocationsLocalizations {
 
   @override
   String get noResultsFound => 'No results found';
+
+  @override
+  String cornersOf(String street) {
+    return 'Corners of $street';
+  }
+
+  @override
+  String get seeCorners => 'See corners';
 }

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_en.dart
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_en.dart
@@ -36,10 +36,5 @@ class SearchLocationsLocalizationsEn extends SearchLocationsLocalizations {
   String get noResultsFound => 'No results found';
 
   @override
-  String cornersOf(String street) {
-    return 'Corners of $street';
-  }
-
-  @override
-  String get seeCorners => 'See corners';
+  String get searchCornersHint => 'Search corners...';
 }

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_es.dart
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_es.dart
@@ -36,10 +36,5 @@ class SearchLocationsLocalizationsEs extends SearchLocationsLocalizations {
   String get noResultsFound => 'No se encontraron resultados';
 
   @override
-  String cornersOf(String street) {
-    return 'Esquinas de $street';
-  }
-
-  @override
-  String get seeCorners => 'Ver esquinas';
+  String get searchCornersHint => 'Buscar esquinas...';
 }

--- a/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_es.dart
+++ b/packages/trufi_core_search_locations/lib/l10n/search_locations_localizations_es.dart
@@ -34,4 +34,12 @@ class SearchLocationsLocalizationsEs extends SearchLocationsLocalizations {
 
   @override
   String get noResultsFound => 'No se encontraron resultados';
+
+  @override
+  String cornersOf(String street) {
+    return 'Esquinas de $street';
+  }
+
+  @override
+  String get seeCorners => 'Ver esquinas';
 }

--- a/packages/trufi_core_search_locations/lib/src/services/composite_search_location_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/composite_search_location_service.dart
@@ -19,7 +19,9 @@ import 'search_location_service.dart';
 ///   junctions should lead), deduplicated by coordinates so the same
 ///   place found twice appears once;
 /// - [reverse] returns the first non-null answer, in order.
-class CompositeSearchLocationService implements SearchLocationService {
+class CompositeSearchLocationService
+    with SearchLocationDrillDown
+    implements SearchLocationService {
   final List<SearchLocationService> services;
 
   /// How long to wait for each service before dropping its results.
@@ -66,6 +68,30 @@ class CompositeSearchLocationService implements SearchLocationService {
         if (result != null) return result;
       } catch (_) {
         // Try the next one.
+      }
+    }
+    return null;
+  }
+
+  /// Forwards the street → corners flow (#745) to whichever child
+  /// service knows the location's inner points; results keep working
+  /// unchanged when no child does.
+  @override
+  bool canDrillDown(SearchLocation location) =>
+      _drillDownServiceFor(location) != null;
+
+  @override
+  Future<List<SearchLocation>> drillDown(SearchLocation location) {
+    final service = _drillDownServiceFor(location);
+    if (service == null) return Future.value(const <SearchLocation>[]);
+    return service.drillDown(location);
+  }
+
+  SearchLocationDrillDown? _drillDownServiceFor(SearchLocation location) {
+    for (final service in services) {
+      if (service is SearchLocationDrillDown) {
+        final candidate = service as SearchLocationDrillDown;
+        if (candidate.canDrillDown(location)) return candidate;
       }
     }
     return null;

--- a/packages/trufi_core_search_locations/lib/src/services/offline_search_data_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/offline_search_data_service.dart
@@ -28,7 +28,9 @@ import 'search_location_service.dart';
 /// Meant to be combined with an online service rather than to replace it
 /// (see [CompositeSearchLocationService]): this one owns streets and
 /// junctions, the online one owns everything else and stays fresher.
-class OfflineSearchDataService implements SearchLocationService {
+class OfflineSearchDataService
+    with SearchLocationDrillDown
+    implements SearchLocationService {
   /// Asset path of the generated `search.json`.
   final String assetPath;
 
@@ -100,6 +102,23 @@ class OfflineSearchDataService implements SearchLocationService {
   Future<List<SearchLocation>> junctionsOf(String streetRef) async {
     final data = await _ensureLoaded();
     return data.junctionsOf(streetRef);
+  }
+
+  /// A street result can be expanded into its corners when this dataset
+  /// knows at least one junction for it. Synchronous on purpose: street
+  /// results only exist after the data loaded, so `_data` is already in
+  /// memory by the time the search screen asks.
+  @override
+  bool canDrillDown(SearchLocation location) {
+    const prefix = 'street:';
+    if (!location.id.startsWith(prefix)) return false;
+    final ref = location.id.substring(prefix.length);
+    return _data?.hasJunctions(ref) ?? false;
+  }
+
+  @override
+  Future<List<SearchLocation>> drillDown(SearchLocation location) {
+    return junctionsOf(location.id.substring('street:'.length));
   }
 
   @override
@@ -256,6 +275,10 @@ class _SearchData {
     }
     return results;
   }
+
+  /// Whether [streetRef] has at least one well-formed junction.
+  bool hasJunctions(String streetRef) =>
+      (junctions[streetRef] ?? const []).isNotEmpty;
 
   /// Every junction of one street, for the drill-down flow.
   List<SearchLocation> junctionsOf(String streetRef) {

--- a/packages/trufi_core_search_locations/lib/src/services/search_location_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/search_location_service.dart
@@ -21,6 +21,28 @@ abstract class SearchLocationService {
   void dispose();
 }
 
+/// Optional capability for services whose results can be expanded into
+/// finer-grained locations — the street → corners flow (#745).
+///
+/// In cities without street numbers people give directions as
+/// intersections, so picking a street is rarely the end of the search:
+/// the old core let you tap a street and choose the corner. A service
+/// that knows a location's inner points (e.g. every junction of a
+/// street) implements this; [LocationSearchScreen] then offers the
+/// drill-down affordance on those results with no extra wiring in the
+/// host app — [CompositeSearchLocationService] forwards to whichever of
+/// its children can answer.
+abstract mixin class SearchLocationDrillDown {
+  /// Whether [location] can be expanded (e.g. a street whose corners
+  /// this service knows). Must be cheap and synchronous: the search
+  /// screen calls it per visible result while building the list.
+  bool canDrillDown(SearchLocation location);
+
+  /// The locations inside [location] (e.g. every corner of a street),
+  /// in a useful order. Only called when [canDrillDown] returned true.
+  Future<List<SearchLocation>> drillDown(SearchLocation location);
+}
+
 /// Exception thrown when a search operation fails.
 class SearchLocationException implements Exception {
   final String message;

--- a/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
+++ b/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
@@ -326,6 +326,10 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
                 },
                 onClear: () {
                   _searchController.clear();
+                  // Clearing is a full reset: also drop any corners view
+                  // (and orphan its in-flight load) so no stale drill-down
+                  // state survives into the next search.
+                  _exitDrillDown();
                   setState(() {
                     _query = '';
                     _searchResults = [];

--- a/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
+++ b/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
@@ -115,11 +115,16 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
   List<SearchLocation> _loadedPlaces = [];
   bool _isLoadingYourLocation = false;
 
-  // Street → corners drill-down (#745): while non-null, the results
-  // section shows the corners of this street instead of the search hits.
+  // Street → corners drill-down (#745): while non-null, the whole body
+  // becomes a dedicated sub-screen — "← <street>" as the title, a filter
+  // field that searches only within the corners, and nothing else (no
+  // quick actions, no saved places).
   SearchLocation? _drillDownParent;
   List<SearchLocation> _drillDownResults = [];
   bool _isDrillingDown = false;
+  final TextEditingController _cornerFilterController =
+      TextEditingController();
+  String _cornerFilter = '';
 
   @override
   void initState() {
@@ -196,10 +201,12 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
   Future<void> _enterDrillDown(SearchLocation street) async {
     final service = _drillDownService;
     if (service == null) return;
+    _cornerFilterController.clear();
     setState(() {
       _drillDownParent = street;
       _drillDownResults = [];
       _isDrillingDown = true;
+      _cornerFilter = '';
     });
     try {
       final corners = await service.drillDown(street);
@@ -222,11 +229,39 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
 
   void _exitDrillDown() {
     if (_drillDownParent == null) return;
+    _cornerFilterController.clear();
     setState(() {
       _drillDownParent = null;
       _drillDownResults = [];
       _isDrillingDown = false;
+      _cornerFilter = '';
     });
+  }
+
+  /// Corners matching the corner filter, accent- and case-insensitively.
+  /// The filter matches the cross street (the trimmed label), not the full
+  /// corner name: inside "Avenida Ayacucho" every corner contains
+  /// "ayacucho", so matching the full name would make the filter useless.
+  List<SearchLocation> get _filteredCorners {
+    final needle = _fold(_cornerFilter);
+    if (needle.isEmpty) return _drillDownResults;
+    return _drillDownResults
+        .where((c) => _fold(_cornerLabel(c)).contains(needle))
+        .toList();
+  }
+
+  /// Lowercases and strips accents, so "heroinas" finds "Heroínas".
+  static String _fold(String value) {
+    const from = 'áàäâãéèëêíìïîóòöôõúùüûñç';
+    const to = 'aaaaaeeeeiiiiooooouuuunc';
+    final lower = value.toLowerCase().trim();
+    final buffer = StringBuffer();
+    for (final rune in lower.runes) {
+      final char = String.fromCharCode(rune);
+      final index = from.indexOf(char);
+      buffer.write(index >= 0 ? to[index] : char);
+    }
+    return buffer.toString();
   }
 
   /// Label for a corner inside the corners list. The header already names
@@ -307,6 +342,7 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
   void dispose() {
     _debounce?.cancel();
     _searchController.dispose();
+    _cornerFilterController.dispose();
     _searchFocusNode.dispose();
     _staggerController.dispose();
     super.dispose();
@@ -318,6 +354,84 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
     final colorScheme = theme.colorScheme;
     final config = widget.configuration;
     final l10n = SearchLocationsLocalizations.of(context);
+
+    // The corners view is a sub-screen, not a section: "← <street>" as
+    // the title, a filter that searches only within the corners, and
+    // nothing else. The system back button leaves the corners first.
+    if (_drillDownParent != null) {
+      return PopScope(
+        canPop: false,
+        onPopInvokedWithResult: (didPop, _) {
+          if (!didPop) _exitDrillDown();
+        },
+        child: Scaffold(
+          backgroundColor: colorScheme.surface,
+          body: SafeArea(
+            child: Column(
+              children: [
+                _DrillDownHeader(
+                  title: _drillDownParent!.displayName,
+                  onBack: () {
+                    HapticFeedback.selectionClick();
+                    _exitDrillDown();
+                  },
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+                  child: TextField(
+                    controller: _cornerFilterController,
+                    onChanged: (value) =>
+                        setState(() => _cornerFilter = value),
+                    decoration: InputDecoration(
+                      hintText: l10n.searchCornersHint,
+                      prefixIcon: const Icon(Icons.search_rounded),
+                      filled: true,
+                      fillColor: colorScheme.surfaceContainerLow,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(14),
+                        borderSide: BorderSide.none,
+                      ),
+                      isDense: true,
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: _isDrillingDown
+                      ? const Center(child: CircularProgressIndicator())
+                      : _filteredCorners.isEmpty
+                          ? _EmptySearchResults(
+                              text: config.noResultsText ??
+                                  l10n.noResultsFound,
+                            )
+                          : ListView.builder(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 16,
+                              ),
+                              itemCount: _filteredCorners.length,
+                              itemBuilder: (context, index) {
+                                final corner = _filteredCorners[index];
+                                return Padding(
+                                  padding: const EdgeInsets.only(bottom: 8),
+                                  child: _ModernLocationTile(
+                                    location: corner,
+                                    displayNameOverride: _cornerLabel(corner),
+                                    icon: Icons.fork_right_rounded,
+                                    iconColor: colorScheme.primary,
+                                    onTap: () {
+                                      HapticFeedback.selectionClick();
+                                      Navigator.pop(context, corner);
+                                    },
+                                  ),
+                                );
+                              },
+                            ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
 
     return Scaffold(
       backgroundColor: colorScheme.surface,
@@ -432,45 +546,8 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
                     ),
                   ],
 
-                  // Corners of a street (drill-down, #745)
-                  if (_query.isNotEmpty && _drillDownParent != null) ...[
-                    _DrillDownHeader(
-                      title: l10n.cornersOf(_drillDownParent!.displayName),
-                      onBack: () {
-                        HapticFeedback.selectionClick();
-                        _exitDrillDown();
-                      },
-                    ),
-                    const SizedBox(height: 8),
-                    if (_isDrillingDown)
-                      const Padding(
-                        padding: EdgeInsets.all(32.0),
-                        child: Center(child: CircularProgressIndicator()),
-                      )
-                    else if (_drillDownResults.isEmpty)
-                      _EmptySearchResults(
-                        text: config.noResultsText ?? l10n.noResultsFound,
-                      )
-                    else
-                      ...List.generate(_drillDownResults.length, (index) {
-                        final corner = _drillDownResults[index];
-                        return Padding(
-                          padding: const EdgeInsets.only(bottom: 8),
-                          child: _ModernLocationTile(
-                            location: corner,
-                            displayNameOverride: _cornerLabel(corner),
-                            icon: Icons.fork_right_rounded,
-                            iconColor: colorScheme.primary,
-                            onTap: () {
-                              HapticFeedback.selectionClick();
-                              Navigator.pop(context, corner);
-                            },
-                          ),
-                        );
-                      }),
-                  ]
                   // Search Results
-                  else if (_query.isNotEmpty) ...[
+                  if (_query.isNotEmpty) ...[
                     _SectionTitle(
                       title: config.searchResultsTitle ?? l10n.searchResults,
                     ),
@@ -493,24 +570,27 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
                           padding: const EdgeInsets.only(bottom: 8),
                           child: _ModernLocationTile(
                             location: location,
-                            icon: Icons.place_rounded,
+                            icon: canDrill
+                                ? Icons.fork_right_rounded
+                                : Icons.place_rounded,
                             iconColor: colorScheme.primary,
+                            // A street with known corners is not a point —
+                            // picking it directly answers nothing. Tapping
+                            // it anywhere opens its corners list instead
+                            // (Sam's review on #964); everything else pops
+                            // as the selection.
                             onTap: () {
                               HapticFeedback.selectionClick();
-                              Navigator.pop(context, location);
+                              if (canDrill) {
+                                _enterDrillDown(location);
+                              } else {
+                                Navigator.pop(context, location);
+                              }
                             },
-                            // A street can be refined into one of its
-                            // corners; the tile itself still picks the
-                            // whole street — both are valid answers.
                             trailing: canDrill
-                                ? IconButton(
-                                    icon: const Icon(Icons.fork_right_rounded),
-                                    color: colorScheme.primary,
-                                    tooltip: l10n.seeCorners,
-                                    onPressed: () {
-                                      HapticFeedback.selectionClick();
-                                      _enterDrillDown(location);
-                                    },
+                                ? Icon(
+                                    Icons.chevron_right_rounded,
+                                    color: colorScheme.onSurfaceVariant,
                                   )
                                 : null,
                           ),
@@ -986,7 +1066,9 @@ class _SectionTitle extends StatelessWidget {
   }
 }
 
-/// Header of the corners list: back to the search results + street name.
+/// Title bar of the corners sub-screen: back to the results + the street
+/// name as the title (the rows below start at "&", so the street's own
+/// name lives only here).
 class _DrillDownHeader extends StatelessWidget {
   final String title;
   final VoidCallback onBack;
@@ -998,27 +1080,42 @@ class _DrillDownHeader extends StatelessWidget {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
-    return Row(
-      children: [
-        IconButton(
-          icon: const Icon(Icons.arrow_back_rounded, size: 20),
-          color: colorScheme.onSurfaceVariant,
-          visualDensity: VisualDensity.compact,
-          onPressed: onBack,
-        ),
-        Expanded(
-          child: Text(
-            title,
-            style: theme.textTheme.labelMedium?.copyWith(
-              fontWeight: FontWeight.w600,
-              color: colorScheme.onSurfaceVariant,
-              letterSpacing: 0.5,
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Row(
+        children: [
+          Material(
+            color: colorScheme.surfaceContainerLow,
+            borderRadius: BorderRadius.circular(12),
+            child: InkWell(
+              onTap: onBack,
+              borderRadius: BorderRadius.circular(12),
+              child: Container(
+                width: 44,
+                height: 44,
+                alignment: Alignment.center,
+                child: Icon(
+                  Icons.arrow_back_rounded,
+                  color: colorScheme.onSurface,
+                  size: 22,
+                ),
+              ),
             ),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
           ),
-        ),
-      ],
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              title,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: colorScheme.onSurface,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
+++ b/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
@@ -115,6 +115,12 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
   List<SearchLocation> _loadedPlaces = [];
   bool _isLoadingYourLocation = false;
 
+  // Street → corners drill-down (#745): while non-null, the results
+  // section shows the corners of this street instead of the search hits.
+  SearchLocation? _drillDownParent;
+  List<SearchLocation> _drillDownResults = [];
+  bool _isDrillingDown = false;
+
   @override
   void initState() {
     super.initState();
@@ -168,12 +174,58 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
   /// data loaded, 19 scans of the city's streets.
   void _onQueryChanged(String query) {
     _debounce?.cancel();
+    // Editing the query means the user moved on from the corners list.
+    _exitDrillDown();
     if (query.trim().isEmpty) {
       _performSearch(query);
       return;
     }
     _debounce = Timer(const Duration(milliseconds: 300), () {
       _performSearch(query);
+    });
+  }
+
+  /// The drill-down service behind [widget.searchService], if any.
+  SearchLocationDrillDown? get _drillDownService {
+    final service = widget.searchService;
+    return service is SearchLocationDrillDown
+        ? service as SearchLocationDrillDown
+        : null;
+  }
+
+  Future<void> _enterDrillDown(SearchLocation street) async {
+    final service = _drillDownService;
+    if (service == null) return;
+    setState(() {
+      _drillDownParent = street;
+      _drillDownResults = [];
+      _isDrillingDown = true;
+    });
+    try {
+      final corners = await service.drillDown(street);
+      // The user may have kept typing while the corners loaded.
+      if (mounted && identical(_drillDownParent, street)) {
+        setState(() {
+          _drillDownResults = corners;
+          _isDrillingDown = false;
+        });
+      }
+    } catch (_) {
+      if (mounted && identical(_drillDownParent, street)) {
+        setState(() {
+          _drillDownResults = [];
+          _isDrillingDown = false;
+        });
+      }
+    }
+  }
+
+  void _exitDrillDown() {
+    if (_drillDownParent == null) return;
+    setState(() {
+      _drillDownParent = null;
+      _drillDownResults = [];
+      _isDrillingDown = false;
     });
   }
 
@@ -360,8 +412,44 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
                     ),
                   ],
 
+                  // Corners of a street (drill-down, #745)
+                  if (_query.isNotEmpty && _drillDownParent != null) ...[
+                    _DrillDownHeader(
+                      title: l10n.cornersOf(_drillDownParent!.displayName),
+                      onBack: () {
+                        HapticFeedback.selectionClick();
+                        _exitDrillDown();
+                      },
+                    ),
+                    const SizedBox(height: 8),
+                    if (_isDrillingDown)
+                      const Padding(
+                        padding: EdgeInsets.all(32.0),
+                        child: Center(child: CircularProgressIndicator()),
+                      )
+                    else if (_drillDownResults.isEmpty)
+                      _EmptySearchResults(
+                        text: config.noResultsText ?? l10n.noResultsFound,
+                      )
+                    else
+                      ...List.generate(_drillDownResults.length, (index) {
+                        final corner = _drillDownResults[index];
+                        return Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: _ModernLocationTile(
+                            location: corner,
+                            icon: Icons.fork_right_rounded,
+                            iconColor: colorScheme.primary,
+                            onTap: () {
+                              HapticFeedback.selectionClick();
+                              Navigator.pop(context, corner);
+                            },
+                          ),
+                        );
+                      }),
+                  ]
                   // Search Results
-                  if (_query.isNotEmpty) ...[
+                  else if (_query.isNotEmpty) ...[
                     _SectionTitle(
                       title: config.searchResultsTitle ?? l10n.searchResults,
                     ),
@@ -378,6 +466,8 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
                     else
                       ...List.generate(_searchResults.length, (index) {
                         final location = _searchResults[index];
+                        final canDrill =
+                            _drillDownService?.canDrillDown(location) ?? false;
                         return Padding(
                           padding: const EdgeInsets.only(bottom: 8),
                           child: _ModernLocationTile(
@@ -388,6 +478,20 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
                               HapticFeedback.selectionClick();
                               Navigator.pop(context, location);
                             },
+                            // A street can be refined into one of its
+                            // corners; the tile itself still picks the
+                            // whole street — both are valid answers.
+                            trailing: canDrill
+                                ? IconButton(
+                                    icon: const Icon(Icons.fork_right_rounded),
+                                    color: colorScheme.primary,
+                                    tooltip: l10n.seeCorners,
+                                    onPressed: () {
+                                      HapticFeedback.selectionClick();
+                                      _enterDrillDown(location);
+                                    },
+                                  )
+                                : null,
                           ),
                         );
                       }),
@@ -861,6 +965,43 @@ class _SectionTitle extends StatelessWidget {
   }
 }
 
+/// Header of the corners list: back to the search results + street name.
+class _DrillDownHeader extends StatelessWidget {
+  final String title;
+  final VoidCallback onBack;
+
+  const _DrillDownHeader({required this.title, required this.onBack});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Row(
+      children: [
+        IconButton(
+          icon: const Icon(Icons.arrow_back_rounded, size: 20),
+          color: colorScheme.onSurfaceVariant,
+          visualDensity: VisualDensity.compact,
+          onPressed: onBack,
+        ),
+        Expanded(
+          child: Text(
+            title,
+            style: theme.textTheme.labelMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: colorScheme.onSurfaceVariant,
+              letterSpacing: 0.5,
+            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 /// Modern location tile
 class _ModernLocationTile extends StatelessWidget {
   final SearchLocation location;
@@ -868,11 +1009,15 @@ class _ModernLocationTile extends StatelessWidget {
   final Color iconColor;
   final VoidCallback onTap;
 
+  /// Optional widget at the row's end (e.g. the street → corners button).
+  final Widget? trailing;
+
   const _ModernLocationTile({
     required this.location,
     required this.icon,
     required this.iconColor,
     required this.onTap,
+    this.trailing,
   });
 
   @override
@@ -928,6 +1073,7 @@ class _ModernLocationTile extends StatelessWidget {
                   ],
                 ),
               ),
+              ?trailing,
             ],
           ),
         ),

--- a/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
+++ b/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
@@ -229,6 +229,22 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
     });
   }
 
+  /// Label for a corner inside the corners list. The header already names
+  /// the street, so repeating it on every row ("Avenida Ayacucho & Avenida
+  /// Aroma", "Avenida Ayacucho & Avenida Her…") is redundant and truncates
+  /// the one name that matters — the cross street. Rows start at "&"
+  /// instead. The popped [SearchLocation] keeps the full name, so the
+  /// origin/destination field still reads "Avenida Ayacucho & Avenida
+  /// Aroma".
+  String _cornerLabel(SearchLocation corner) {
+    final parent = _drillDownParent;
+    if (parent == null) return corner.displayName;
+    final prefix = '${parent.displayName} & ';
+    return corner.displayName.startsWith(prefix)
+        ? '& ${corner.displayName.substring(prefix.length)}'
+        : corner.displayName;
+  }
+
   Future<void> _performSearch(String query) async {
     if (query.trim().isEmpty) {
       setState(() {
@@ -442,6 +458,7 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
                           padding: const EdgeInsets.only(bottom: 8),
                           child: _ModernLocationTile(
                             location: corner,
+                            displayNameOverride: _cornerLabel(corner),
                             icon: Icons.fork_right_rounded,
                             iconColor: colorScheme.primary,
                             onTap: () {
@@ -1016,12 +1033,18 @@ class _ModernLocationTile extends StatelessWidget {
   /// Optional widget at the row's end (e.g. the street → corners button).
   final Widget? trailing;
 
+  /// Display-only label replacing [SearchLocation.displayName] (e.g. a
+  /// corner shown as "& Avenida Aroma" inside its street's corners list).
+  /// The location itself — and whatever gets popped on tap — is untouched.
+  final String? displayNameOverride;
+
   const _ModernLocationTile({
     required this.location,
     required this.icon,
     required this.iconColor,
     required this.onTap,
     this.trailing,
+    this.displayNameOverride,
   });
 
   @override
@@ -1054,7 +1077,7 @@ class _ModernLocationTile extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      location.displayName,
+                      displayNameOverride ?? location.displayName,
                       style: theme.textTheme.bodyLarge?.copyWith(
                         fontWeight: FontWeight.w500,
                         color: colorScheme.onSurface,

--- a/packages/trufi_core_search_locations/test/unit/composite_search_location_service_test.dart
+++ b/packages/trufi_core_search_locations/test/unit/composite_search_location_service_test.dart
@@ -116,4 +116,65 @@ void main() {
       expect(a.disposed && b.disposed, isTrue);
     });
   });
+  group('drill-down forwarding (#745)', () {
+    final street = _loc('street:s1', 'Avenida Ayacucho');
+    final corner = _loc('junction:s1:s2', 'Ayacucho & Heroínas');
+
+    test('delegates to the child that knows the location', () async {
+      final offline = _FakeDrillDownService(
+        [street],
+        corners: {
+          'street:s1': [corner],
+        },
+      );
+      final online = _FakeService(const []);
+      final composite = CompositeSearchLocationService(
+        services: [online, offline], // the capable child is not the first
+      );
+
+      expect(composite.canDrillDown(street), isTrue);
+      expect(await composite.drillDown(street), [corner]);
+      expect(offline.drillDownCalls, 1);
+    });
+
+    test('a result no child can expand reports not drillable', () async {
+      final offline = _FakeDrillDownService(
+        [street],
+        corners: {
+          'street:s1': [corner],
+        },
+      );
+      final other = _loc('photon:9', 'Plaza Colón');
+      final composite = CompositeSearchLocationService(services: [offline]);
+
+      expect(composite.canDrillDown(other), isFalse);
+      expect(await composite.drillDown(other), isEmpty);
+      expect(offline.drillDownCalls, 0);
+    });
+
+    test('plain services are simply skipped', () {
+      final composite = CompositeSearchLocationService(
+        services: [_FakeService(const [])],
+      );
+      expect(composite.canDrillDown(street), isFalse);
+    });
+  });
+}
+
+class _FakeDrillDownService extends _FakeService with SearchLocationDrillDown {
+  _FakeDrillDownService(super.results, {required this.corners});
+
+  /// Corners returned for any street id present in this map.
+  final Map<String, List<SearchLocation>> corners;
+  int drillDownCalls = 0;
+
+  @override
+  bool canDrillDown(SearchLocation location) =>
+      corners.containsKey(location.id);
+
+  @override
+  Future<List<SearchLocation>> drillDown(SearchLocation location) async {
+    drillDownCalls++;
+    return corners[location.id] ?? const [];
+  }
 }

--- a/packages/trufi_core_search_locations/test/unit/offline_search_data_service_test.dart
+++ b/packages/trufi_core_search_locations/test/unit/offline_search_data_service_test.dart
@@ -179,4 +179,46 @@ void main() {
       );
     });
   });
+
+  group('drill-down capability (#745)', () {
+    test('a street with corners is drillable once data is loaded', () async {
+      // canDrillDown is synchronous: it only answers truthfully after a
+      // search loaded the data — which is the only way the screen can be
+      // holding a street result in the first place.
+      final results = await service.search('ayacucho');
+      final street = results.firstWhere((r) => r.id == 'street:s1');
+      expect(service.canDrillDown(street), isTrue);
+
+      final corners = await service.drillDown(street);
+      expect(corners.length, 2);
+      expect(corners.map((c) => c.id), everyElement(startsWith('junction:')));
+    });
+
+    test('a street without corners is not drillable', () async {
+      final results = await service.search('junin');
+      final street = results.firstWhere((r) => r.id == 'street:s3');
+      expect(service.canDrillDown(street), isFalse);
+    });
+
+    test('junction results themselves are not drillable', () async {
+      final results = await service.search('ayacucho y heroinas');
+      final junction = results.firstWhere((r) => r.id.startsWith('junction:'));
+      expect(service.canDrillDown(junction), isFalse);
+    });
+
+    test('before any search the answer is simply false, not an error', () {
+      final fresh = OfflineSearchDataService();
+      expect(
+        fresh.canDrillDown(
+          const SearchLocation(
+            id: 'street:s1',
+            displayName: 'Avenida Ayacucho',
+            latitude: -17.39,
+            longitude: -66.15,
+          ),
+        ),
+        isFalse,
+      );
+    });
+  });
 }

--- a/packages/trufi_core_search_locations/test/widget/location_search_screen_drilldown_test.dart
+++ b/packages/trufi_core_search_locations/test/widget/location_search_screen_drilldown_test.dart
@@ -23,7 +23,7 @@ class _DrillDownService
   );
   static const corner = SearchLocation(
     id: 'junction:s1:s2',
-    displayName: 'Ayacucho & Heroínas',
+    displayName: 'Avenida Ayacucho & Avenida Heroínas',
     latitude: -17.3927,
     longitude: -66.1587,
   );
@@ -99,8 +99,11 @@ void main() {
     await tester.tap(find.byIcon(Icons.fork_right_rounded));
     await tester.pumpAndSettle();
 
-    // Corners list replaces the results.
-    expect(find.text('Ayacucho & Heroínas'), findsOneWidget);
+    // Corners list replaces the results. Rows start at "&" — the header
+    // already names the street, and repeating it truncated the cross
+    // street's name.
+    expect(find.text('& Avenida Heroínas'), findsOneWidget);
+    expect(find.text('Avenida Ayacucho & Avenida Heroínas'), findsNothing);
     expect(find.text('Plaza Colón'), findsNothing);
     expect(find.textContaining('Avenida Ayacucho'), findsOneWidget); // header
 
@@ -108,7 +111,7 @@ void main() {
     await tester.tap(find.byIcon(Icons.arrow_back_rounded).last);
     await tester.pumpAndSettle();
     expect(find.text('Plaza Colón'), findsOneWidget);
-    expect(find.text('Ayacucho & Heroínas'), findsNothing);
+    expect(find.text('& Avenida Heroínas'), findsNothing);
   });
 
   testWidgets('picking a corner pops it as the selected location',
@@ -145,10 +148,13 @@ void main() {
 
     await tester.tap(find.byIcon(Icons.fork_right_rounded));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Ayacucho & Heroínas'));
+    await tester.tap(find.text('& Avenida Heroínas'));
     await tester.pumpAndSettle();
 
     expect(picked?.id, 'junction:s1:s2');
+    // The trimmed label is display-only: the picked location keeps the
+    // full corner name for the origin/destination field.
+    expect(picked?.displayName, 'Avenida Ayacucho & Avenida Heroínas');
   });
 
   testWidgets('editing the query exits the corners list', (tester) async {
@@ -156,13 +162,13 @@ void main() {
 
     await tester.tap(find.byIcon(Icons.fork_right_rounded));
     await tester.pumpAndSettle();
-    expect(find.text('Ayacucho & Heroínas'), findsOneWidget);
+    expect(find.text('& Avenida Heroínas'), findsOneWidget);
 
     await tester.enterText(find.byType(TextField).first, 'ayacuch');
     await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpAndSettle();
 
-    expect(find.text('Ayacucho & Heroínas'), findsNothing);
+    expect(find.text('& Avenida Heroínas'), findsNothing);
     expect(find.text('Plaza Colón'), findsOneWidget);
   });
 }

--- a/packages/trufi_core_search_locations/test/widget/location_search_screen_drilldown_test.dart
+++ b/packages/trufi_core_search_locations/test/widget/location_search_screen_drilldown_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_search_locations/trufi_core_search_locations.dart';
+
+/// The street → corners flow on the search screen (#745): a street result
+/// whose service knows its corners gets a trailing button; tapping it
+/// swaps the results for the corners list, with a back affordance, and
+/// picking a corner returns it to the caller.
+class _DrillDownService
+    with SearchLocationDrillDown
+    implements SearchLocationService {
+  static const street = SearchLocation(
+    id: 'street:s1',
+    displayName: 'Avenida Ayacucho',
+    latitude: -17.3925,
+    longitude: -66.1588,
+  );
+  static const plainResult = SearchLocation(
+    id: 'photon:1',
+    displayName: 'Plaza Colón',
+    latitude: -17.3882,
+    longitude: -66.1557,
+  );
+  static const corner = SearchLocation(
+    id: 'junction:s1:s2',
+    displayName: 'Ayacucho & Heroínas',
+    latitude: -17.3927,
+    longitude: -66.1587,
+  );
+
+  @override
+  Future<List<SearchLocation>> search(String query) async =>
+      [street, plainResult];
+
+  @override
+  bool canDrillDown(SearchLocation location) => location.id == street.id;
+
+  @override
+  Future<List<SearchLocation>> drillDown(SearchLocation location) async =>
+      [corner];
+
+  @override
+  Future<SearchLocation?> reverse(double latitude, double longitude) async =>
+      null;
+
+  @override
+  void dispose() {}
+}
+
+void main() {
+  Future<SearchLocation?> pumpAndSearch(WidgetTester tester) async {
+    SearchLocation? picked;
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates:
+            SearchLocationsLocalizations.localizationsDelegates,
+        supportedLocales: SearchLocationsLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              picked = await Navigator.push<SearchLocation>(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => LocationSearchScreen(
+                    isOrigin: true,
+                    searchService: _DrillDownService(),
+                  ),
+                ),
+              );
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).first, 'ayacucho');
+    // Debounce (300 ms) + the async search.
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.pumpAndSettle();
+    return picked;
+  }
+
+  testWidgets('a drillable street shows the corners button; a plain '
+      'result does not', (tester) async {
+    await pumpAndSearch(tester);
+
+    expect(find.text('Avenida Ayacucho'), findsOneWidget);
+    expect(find.text('Plaza Colón'), findsOneWidget);
+    expect(find.byIcon(Icons.fork_right_rounded), findsOneWidget);
+  });
+
+  testWidgets('tapping the corners button lists the corners and back '
+      'returns to the results', (tester) async {
+    await pumpAndSearch(tester);
+
+    await tester.tap(find.byIcon(Icons.fork_right_rounded));
+    await tester.pumpAndSettle();
+
+    // Corners list replaces the results.
+    expect(find.text('Ayacucho & Heroínas'), findsOneWidget);
+    expect(find.text('Plaza Colón'), findsNothing);
+    expect(find.textContaining('Avenida Ayacucho'), findsOneWidget); // header
+
+    // Back returns to the plain results without re-searching.
+    await tester.tap(find.byIcon(Icons.arrow_back_rounded).last);
+    await tester.pumpAndSettle();
+    expect(find.text('Plaza Colón'), findsOneWidget);
+    expect(find.text('Ayacucho & Heroínas'), findsNothing);
+  });
+
+  testWidgets('picking a corner pops it as the selected location',
+      (tester) async {
+    SearchLocation? picked;
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates:
+            SearchLocationsLocalizations.localizationsDelegates,
+        supportedLocales: SearchLocationsLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              picked = await Navigator.push<SearchLocation>(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => LocationSearchScreen(
+                    isOrigin: true,
+                    searchService: _DrillDownService(),
+                  ),
+                ),
+              );
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).first, 'ayacucho');
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.fork_right_rounded));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Ayacucho & Heroínas'));
+    await tester.pumpAndSettle();
+
+    expect(picked?.id, 'junction:s1:s2');
+  });
+
+  testWidgets('editing the query exits the corners list', (tester) async {
+    await pumpAndSearch(tester);
+
+    await tester.tap(find.byIcon(Icons.fork_right_rounded));
+    await tester.pumpAndSettle();
+    expect(find.text('Ayacucho & Heroínas'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField).first, 'ayacuch');
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Ayacucho & Heroínas'), findsNothing);
+    expect(find.text('Plaza Colón'), findsOneWidget);
+  });
+}

--- a/packages/trufi_core_search_locations/test/widget/location_search_screen_drilldown_test.dart
+++ b/packages/trufi_core_search_locations/test/widget/location_search_screen_drilldown_test.dart
@@ -2,10 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:trufi_core_search_locations/trufi_core_search_locations.dart';
 
-/// The street → corners flow on the search screen (#745): a street result
-/// whose service knows its corners gets a trailing button; tapping it
-/// swaps the results for the corners list, with a back affordance, and
-/// picking a corner returns it to the caller.
+/// The street → corners flow on the search screen (#745, reshaped by Sam's
+/// review): tapping a street whose service knows its corners opens a
+/// dedicated corners sub-screen — "← `<street>`" as the title, a filter that
+/// searches only within the corners, and nothing else. Picking a corner
+/// returns it to the caller with its full name.
 class _DrillDownService
     with SearchLocationDrillDown
     implements SearchLocationService {
@@ -21,11 +22,17 @@ class _DrillDownService
     latitude: -17.3882,
     longitude: -66.1557,
   );
-  static const corner = SearchLocation(
+  static const cornerHeroinas = SearchLocation(
     id: 'junction:s1:s2',
     displayName: 'Avenida Ayacucho & Avenida Heroínas',
     latitude: -17.3927,
     longitude: -66.1587,
+  );
+  static const cornerAroma = SearchLocation(
+    id: 'junction:s1:s3',
+    displayName: 'Avenida Ayacucho & Avenida Aroma',
+    latitude: -17.3907,
+    longitude: -66.1571,
   );
 
   @override
@@ -37,7 +44,7 @@ class _DrillDownService
 
   @override
   Future<List<SearchLocation>> drillDown(SearchLocation location) async =>
-      [corner];
+      [cornerAroma, cornerHeroinas];
 
   @override
   Future<SearchLocation?> reverse(double latitude, double longitude) async =>
@@ -48,8 +55,10 @@ class _DrillDownService
 }
 
 void main() {
-  Future<SearchLocation?> pumpAndSearch(WidgetTester tester) async {
-    SearchLocation? picked;
+  SearchLocation? picked;
+
+  Future<void> pumpAndSearch(WidgetTester tester) async {
+    picked = null;
     await tester.pumpWidget(
       MaterialApp(
         localizationsDelegates:
@@ -64,6 +73,8 @@ void main() {
                   builder: (_) => LocationSearchScreen(
                     isOrigin: true,
                     searchService: _DrillDownService(),
+                    onYourLocation: () async => null,
+                    onChooseOnMap: () async => null,
                   ),
                 ),
               );
@@ -80,74 +91,58 @@ void main() {
     // Debounce (300 ms) + the async search.
     await tester.pump(const Duration(milliseconds: 350));
     await tester.pumpAndSettle();
-    return picked;
   }
 
-  testWidgets('a drillable street shows the corners button; a plain '
+  Future<void> openCorners(WidgetTester tester) async {
+    await pumpAndSearch(tester);
+    await tester.tap(find.text('Avenida Ayacucho'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('a drillable street shows the corners affordance; a plain '
       'result does not', (tester) async {
     await pumpAndSearch(tester);
 
     expect(find.text('Avenida Ayacucho'), findsOneWidget);
     expect(find.text('Plaza Colón'), findsOneWidget);
+    // The fork icon marks the drillable street; the plain result keeps
+    // the generic place pin. (Chevrons also appear on the quick-action
+    // rows, so they are not asserted by count.)
     expect(find.byIcon(Icons.fork_right_rounded), findsOneWidget);
+    expect(find.byIcon(Icons.place_rounded), findsOneWidget);
   });
 
-  testWidgets('tapping the corners button lists the corners and back '
-      'returns to the results', (tester) async {
-    await pumpAndSearch(tester);
-
-    await tester.tap(find.byIcon(Icons.fork_right_rounded));
-    await tester.pumpAndSettle();
-
-    // Corners list replaces the results. Rows start at "&" — the header
-    // already names the street, and repeating it truncated the cross
-    // street's name.
-    expect(find.text('& Avenida Heroínas'), findsOneWidget);
-    expect(find.text('Avenida Ayacucho & Avenida Heroínas'), findsNothing);
-    expect(find.text('Plaza Colón'), findsNothing);
-    expect(find.textContaining('Avenida Ayacucho'), findsOneWidget); // header
-
-    // Back returns to the plain results without re-searching.
-    await tester.tap(find.byIcon(Icons.arrow_back_rounded).last);
-    await tester.pumpAndSettle();
-    expect(find.text('Plaza Colón'), findsOneWidget);
-    expect(find.text('& Avenida Heroínas'), findsNothing);
-  });
-
-  testWidgets('picking a corner pops it as the selected location',
+  testWidgets('tapping the street itself opens the corners sub-screen '
+      '(a street is not a point — picking it directly answers nothing)',
       (tester) async {
-    SearchLocation? picked;
-    await tester.pumpWidget(
-      MaterialApp(
-        localizationsDelegates:
-            SearchLocationsLocalizations.localizationsDelegates,
-        supportedLocales: SearchLocationsLocalizations.supportedLocales,
-        home: Builder(
-          builder: (context) => ElevatedButton(
-            onPressed: () async {
-              picked = await Navigator.push<SearchLocation>(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => LocationSearchScreen(
-                    isOrigin: true,
-                    searchService: _DrillDownService(),
-                  ),
-                ),
-              );
-            },
-            child: const Text('open'),
-          ),
-        ),
-      ),
-    );
-    await tester.tap(find.text('open'));
-    await tester.pumpAndSettle();
-    await tester.enterText(find.byType(TextField).first, 'ayacucho');
-    await tester.pump(const Duration(milliseconds: 350));
+    await openCorners(tester);
+
+    // Nothing popped: we are inside the corners sub-screen.
+    expect(picked, isNull);
+    // Title bar carries the street name; rows start at "&".
+    expect(find.text('Avenida Ayacucho'), findsOneWidget); // the title
+    expect(find.text('& Avenida Aroma'), findsOneWidget);
+    expect(find.text('& Avenida Heroínas'), findsOneWidget);
+    // Only corners here: no search results, no quick actions.
+    expect(find.text('Plaza Colón'), findsNothing);
+    expect(find.text('Your Location'), findsNothing);
+    expect(find.text('Choose on Map'), findsNothing);
+  });
+
+  testWidgets('the corner filter searches only within the corners, '
+      'accent-insensitively', (tester) async {
+    await openCorners(tester);
+
+    await tester.enterText(find.byType(TextField).first, 'heroinas');
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byIcon(Icons.fork_right_rounded));
-    await tester.pumpAndSettle();
+    expect(find.text('& Avenida Heroínas'), findsOneWidget);
+    expect(find.text('& Avenida Aroma'), findsNothing);
+  });
+
+  testWidgets('picking a corner pops it with its full name', (tester) async {
+    await openCorners(tester);
+
     await tester.tap(find.text('& Avenida Heroínas'));
     await tester.pumpAndSettle();
 
@@ -157,18 +152,27 @@ void main() {
     expect(picked?.displayName, 'Avenida Ayacucho & Avenida Heroínas');
   });
 
-  testWidgets('editing the query exits the corners list', (tester) async {
-    await pumpAndSearch(tester);
+  testWidgets('the back button returns to the results', (tester) async {
+    await openCorners(tester);
 
-    await tester.tap(find.byIcon(Icons.fork_right_rounded));
-    await tester.pumpAndSettle();
-    expect(find.text('& Avenida Heroínas'), findsOneWidget);
-
-    await tester.enterText(find.byType(TextField).first, 'ayacuch');
-    await tester.pump(const Duration(milliseconds: 350));
+    await tester.tap(find.byIcon(Icons.arrow_back_rounded).last);
     await tester.pumpAndSettle();
 
-    expect(find.text('& Avenida Heroínas'), findsNothing);
     expect(find.text('Plaza Colón'), findsOneWidget);
+    expect(find.text('& Avenida Heroínas'), findsNothing);
+  });
+
+  testWidgets('the system back leaves the corners first, not the screen',
+      (tester) async {
+    await openCorners(tester);
+
+    final NavigatorState navigator = tester.state(find.byType(Navigator));
+    navigator.maybePop();
+    await tester.pumpAndSettle();
+
+    // Still on the search screen, back at the results.
+    expect(picked, isNull);
+    expect(find.text('Plaza Colón'), findsOneWidget);
+    expect(find.text('& Avenida Heroínas'), findsNothing);
   });
 }


### PR DESCRIPTION
Second half of #745 (the first half — offline street/junction data + composite search — landed in #962).

## What

In cities without street numbers people give directions as intersections, so picking a street is rarely the end of a search. The old core let you tap a street and then choose the corner; this restores that flow on top of the offline street data:

- **`SearchLocationDrillDown`** — optional capability mixin for services whose results can be expanded into finer-grained locations. `canDrillDown` is synchronous on purpose: the screen calls it per visible result while building the list.
- **`OfflineSearchDataService`** implements it for street results with at least one well-formed junction. The sync check never races the data load: street results can only exist after the data loaded.
- **`CompositeSearchLocationService`** forwards to whichever child can answer — host apps get the flow with **zero extra wiring**.
- **`LocationSearchScreen`** — street results whose service knows their corners get a trailing fork button. Tapping it swaps the results for the corners list (header with back); picking a corner pops it as the selection; editing the query exits the corners view. The tile body still picks the whole street — both are valid answers.
- **l10n**: `cornersOf` / `seeCorners` in en/es/de.

## Evidence (Android emulator, bundled Cochabamba sample)

`ayacucho` → the offline street shows the fork button (Photon results don't) → *Esquinas de Avenida Ayacucho* (Aroma / Heroínas / Rafael…) → the picked corner lands as the route origin.

## Tests

- `composite_search_location_service_test.dart`: forwarding contract (delegates to the capable child regardless of order; non-drillable results report false without calling children; plain services skipped) — 10/10.
- `offline_search_data_service_test.dart`: street-with-corners drillable, street-without not, junctions not, pre-load answers false — 16/16.
- `location_search_screen_drilldown_test.dart` (new): button only on drillable results; corners list + back; picking a corner pops it; editing the query exits — 4/4.
- `flutter analyze` clean. Pre-existing HTTP-mock test failures (Nominatim/Photon suites) are unchanged vs main. **The CI check runs no tests** — the counts above are local runs.