### PR TITLE
fix(routing): order OTP 2.8 itineraries by the router's generalized cost

### DIFF
--- a/packages/trufi_core_routing/lib/src/models/itinerary.dart
+++ b/packages/trufi_core_routing/lib/src/models/itinerary.dart
@@ -17,6 +17,7 @@ class Itinerary extends Equatable {
     this.transfers,
     this.arrivedAtDestinationWithRentedBicycle = false,
     this.emissionsPerPerson,
+    this.generalizedCost,
   }) : legs = _assignDefaultColors(legs),
        distance = _calculateDistance(legs);
 
@@ -29,6 +30,13 @@ class Itinerary extends Equatable {
   final int? transfers;
   final bool arrivedAtDestinationWithRentedBicycle;
   final double? emissionsPerPerson;
+
+  /// OTP's generalized cost for this itinerary (seconds-equivalent):
+  /// duration plus every configured penalty — transfers, boarding, walk
+  /// reluctance. Lower is better *by the router's own judgment*, which
+  /// is exactly what its arrival-time-ordered list does not convey.
+  final int? generalizedCost;
+
   final int distance;
 
   static int _calculateDistance(List<Leg> legs) {
@@ -63,6 +71,7 @@ class Itinerary extends Equatable {
       arrivedAtDestinationWithRentedBicycle:
           json['arrivedAtDestinationWithRentedBicycle'] as bool? ?? false,
       emissionsPerPerson: emissionsData?.getDouble('emissionsPerPersonCo2'),
+      generalizedCost: json.getInt('generalizedCost'),
     );
   }
 
@@ -103,6 +112,7 @@ class Itinerary extends Equatable {
       'arrivedAtDestinationWithRentedBicycle':
           arrivedAtDestinationWithRentedBicycle,
       'emissionsPerPerson': {'emissionsPerPersonCo2': emissionsPerPerson},
+      'generalizedCost': generalizedCost,
     };
   }
 
@@ -117,6 +127,7 @@ class Itinerary extends Equatable {
     int? transfers,
     bool? arrivedAtDestinationWithRentedBicycle,
     double? emissionsPerPerson,
+    int? generalizedCost,
   }) {
     return Itinerary(
       legs: legs ?? this.legs,
@@ -130,6 +141,7 @@ class Itinerary extends Equatable {
           arrivedAtDestinationWithRentedBicycle ??
           this.arrivedAtDestinationWithRentedBicycle,
       emissionsPerPerson: emissionsPerPerson ?? this.emissionsPerPerson,
+      generalizedCost: generalizedCost ?? this.generalizedCost,
     );
   }
 
@@ -168,6 +180,7 @@ class Itinerary extends Equatable {
     transfers,
     arrivedAtDestinationWithRentedBicycle,
     emissionsPerPerson,
+    generalizedCost,
     distance,
     legs,
   ];

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_28_routing_provider.dart
@@ -226,11 +226,46 @@ class Otp28RoutingProvider extends IRoutingProvider {
         _prefs.transportModes.single == RoutingMode.walk;
 
     return plan.copyWith(
-      itineraries: filterLongWalks(
-        plan.itineraries,
-        walkOnlyRequested: walkOnlyRequested,
+      itineraries: sortByGeneralizedCost(
+        filterLongWalks(
+          plan.itineraries,
+          walkOnlyRequested: walkOnlyRequested,
+        ),
       ),
     );
+  }
+
+  /// Orders itineraries by OTP's own generalized cost instead of the
+  /// arrival-time order the plan API returns them in.
+  ///
+  /// The arrival order routinely puts a transfer above a direct ride
+  /// (#849, #847): measured against the Cochabamba production graph,
+  /// Sacaba → UMSS returned a same-line transfer (233 "Nro. rojo" →
+  /// 233 "Bandera verde", 34 min, cost 3552) *above* a direct 241
+  /// (33 min, cost 2587) just because it arrived first. The router
+  /// already priced the transfer as worse — its cost includes the
+  /// configured transferPenalty and boardCost — so showing the list in
+  /// cost order surfaces the itinerary the router itself considers best.
+  ///
+  /// The sort is explicitly stable (index tiebreak): Dart's [List.sort]
+  /// is only de-facto stable below ~32 elements, and equal-cost
+  /// itineraries must keep OTP's arrival order. Itineraries without a
+  /// cost (older servers) keep their position relative to each other
+  /// and sink below priced ones, so mixed responses degrade gracefully.
+  @visibleForTesting
+  static List<Itinerary>? sortByGeneralizedCost(List<Itinerary>? itineraries) {
+    if (itineraries == null || itineraries.length < 2) return itineraries;
+    final indexed = itineraries.asMap().entries.toList()
+      ..sort((a, b) {
+        final costA = a.value.generalizedCost;
+        final costB = b.value.generalizedCost;
+        if (costA == null && costB == null) return a.key.compareTo(b.key);
+        if (costA == null) return 1;
+        if (costB == null) return -1;
+        final byCost = costA.compareTo(costB);
+        return byCost != 0 ? byCost : a.key.compareTo(b.key);
+      });
+    return [for (final entry in indexed) entry.value];
   }
 
   /// Drops walk-only itineraries longer than 1 km — in a transit search

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_2_8_queries.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_2_8_queries.dart
@@ -58,6 +58,7 @@ query plan(
       startTime
       endTime
       duration
+      generalizedCost
       walkTime
       walkDistance
       waitingTime
@@ -214,6 +215,7 @@ query plan(
       startTime
       endTime
       duration
+      generalizedCost
       walkTime
       walkDistance
       legs {

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_2_8_response_parser.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_8/otp_2_8_response_parser.dart
@@ -69,6 +69,7 @@ class Otp28ResponseParser {
       arrivedAtDestinationWithRentedBicycle:
           json['arrivedAtDestinationWithRentedBicycle'] as bool? ?? false,
       emissionsPerPerson: emissions?.toDouble(),
+      generalizedCost: json.getInt('generalizedCost'),
     );
   }
 

--- a/packages/trufi_core_routing/test/unit/otp_28_cost_sort_test.dart
+++ b/packages/trufi_core_routing/test/unit/otp_28_cost_sort_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_routing/trufi_core_routing.dart';
+
+/// The provider re-orders OTP's arrival-time list by the router's own
+/// generalized cost (#849, #847). The fixture numbers are the real
+/// Sacaba → UMSS measurement against the Cochabamba production graph:
+/// a same-line transfer (233+233, 34 min, cost 3552) came back FIRST,
+/// above a direct 241 (33 min, cost 2587).
+Itinerary _itinerary({
+  required int minutes,
+  int? cost,
+  int transitLegs = 1,
+}) {
+  final start = DateTime(2026, 8, 11, 12);
+  final end = start.add(Duration(minutes: minutes));
+  return Itinerary(
+    legs: [
+      for (var i = 0; i < transitLegs; i++)
+        Leg(
+          mode: 'BUS',
+          startTime: start,
+          endTime: end,
+          duration: Duration(minutes: minutes ~/ transitLegs),
+          distance: 5000,
+          transitLeg: true,
+        ),
+    ],
+    startTime: start,
+    endTime: end,
+    duration: Duration(minutes: minutes),
+    walkDistance: 200,
+    walkTime: const Duration(minutes: 3),
+    generalizedCost: cost,
+  );
+}
+
+void main() {
+  group('Otp28RoutingProvider.sortByGeneralizedCost (#849)', () {
+    test('the direct ride the router priced best comes first', () {
+      final sameLineTransfer = _itinerary(
+        minutes: 34,
+        cost: 3552,
+        transitLegs: 2,
+      );
+      final direct = _itinerary(minutes: 33, cost: 2587);
+      final otherDirect = _itinerary(minutes: 33, cost: 2835);
+
+      final sorted = Otp28RoutingProvider.sortByGeneralizedCost([
+        sameLineTransfer, // OTP's arrival order put the transfer first
+        direct,
+        otherDirect,
+      ]);
+
+      expect(sorted, [direct, otherDirect, sameLineTransfer]);
+    });
+
+    test('equal costs keep the arrival order (stable beyond 32 items)', () {
+      // Dart's List.sort is only de-facto stable below ~32 elements —
+      // a fixture this size is what catches a stability regression.
+      final itineraries = [
+        for (var i = 0; i < 40; i++) _itinerary(minutes: 30 + i, cost: 1000),
+      ];
+
+      final sorted = Otp28RoutingProvider.sortByGeneralizedCost(itineraries);
+
+      expect(sorted, itineraries);
+    });
+
+    test('unpriced itineraries sink below priced ones, keeping their '
+        'relative order', () {
+      final unpricedA = _itinerary(minutes: 20);
+      final unpricedB = _itinerary(minutes: 25);
+      final priced = _itinerary(minutes: 40, cost: 5000);
+
+      final sorted = Otp28RoutingProvider.sortByGeneralizedCost([
+        unpricedA,
+        priced,
+        unpricedB,
+      ]);
+
+      expect(sorted, [priced, unpricedA, unpricedB]);
+    });
+
+    test('null and short lists pass through untouched', () {
+      expect(Otp28RoutingProvider.sortByGeneralizedCost(null), isNull);
+      final single = [_itinerary(minutes: 10, cost: 1)];
+      expect(Otp28RoutingProvider.sortByGeneralizedCost(single), same(single));
+    });
+  });
+
+  group('Itinerary.generalizedCost parsing', () {
+    test('round-trips through JSON', () {
+      final json = _itinerary(minutes: 33, cost: 2587).toJson();
+      expect(json['generalizedCost'], 2587);
+      expect(Itinerary.fromJson(json).generalizedCost, 2587);
+    });
+
+    test('absent cost stays null (older servers)', () {
+      final json = _itinerary(minutes: 33).toJson()..remove('generalizedCost');
+      expect(Itinerary.fromJson(json).generalizedCost, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #849 · addresses the ranking half of #847.

## The measurement that pinned it down

Against an MD5-identical local copy of the Cochabamba production graph, **Sacaba centro → UMSS** returns:

| OTP's order (what users see today) | duration | generalizedCost |
|---|---|---|
| **233 → 233** (same line, 'Nro. rojo' → 'Bandera verde', a real get-off-and-reboard transfer — not interlining, verified via `interlineWithPreviousLeg`) | 34 min | **3552** |
| 241 direct | 33 min | 2587 |
| 241 direct | 33 min | 2835 |

The router had already priced the transfer as clearly worse — its generalized cost includes the configured `transferPenalty` (30 min) and `boardCost` — but the plan API returns **arrival-time order**, and the app showed it verbatim. That's the entire mechanism behind *"promotes slow multi-transfer routes over faster direct options"*: the config is fine (we also measured that **lowering** the penalties is what reproduces the complaint), the presentation order wasn't.

## What changed

- `Itinerary` now carries `generalizedCost` (query + parser + model, JSON round-trip).
- `Otp28RoutingProvider` re-orders the filtered list by it: **stable** (index tiebreak — `List.sort` is only de-facto stable below ~32 elements), unpriced itineraries (older servers) sink below priced ones keeping their relative order.

## After the fix (same lab)

`241 (2587) → 241 (2835) → 233+233 (3552)` — the direct rides lead.

## Tests

New `otp_28_cost_sort_test.dart` (6/6): the real-world fixture above, stability at 40 equal-cost items, unpriced sinking, null/short passthrough, JSON round-trip. Package suite strictly better than main (79/40 vs 73/41 — remaining failures are the pre-existing network-dependent suites). `flutter analyze`: no new issues. **CI runs no tests** — counts are local.