### PR TITLE
fix(l10n): locale-aware time, distance and duration formats (#945)

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/src/services/share_route_service.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/services/share_route_service.dart
@@ -77,7 +77,11 @@ class ShareRouteService {
     String? webBaseUrl,
   }) {
     final buffer = StringBuffer();
-    final timeFormat = DateFormat('HH:mm');
+    // The 'j' skeleton resolves to the locale's preferred clock — 24h
+    // where that's the convention, 12h with the right day-period marker
+    // elsewhere (#945). Shared text has no MediaQuery to consult, so the
+    // locale's own preference is the best available signal.
+    final timeFormat = _localeTimeFormat(strings.localeTag);
     final dateFormat = _localeDateFormat(strings.localeTag);
 
     // Header
@@ -262,6 +266,17 @@ class ShareRouteService {
 
   /// Locale-aware day/month/year order, tolerating locales intl has no
   /// symbols for (city languages) by falling back to the default pattern.
+  static DateFormat _localeTimeFormat(String? localeTag) {
+    if (localeTag == null) return DateFormat.jm();
+    try {
+      return DateFormat.jm(localeTag);
+    } catch (_) {
+      // Locale data not initialized for this tag — same fallback the
+      // date formatter below uses.
+      return DateFormat.jm();
+    }
+  }
+
   static DateFormat _localeDateFormat(String? localeTag) {
     if (localeTag == null) return DateFormat.yMd();
     try {

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_card.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_card.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart' as routing;
 import 'package:trufi_core_routing_ui/trufi_core_routing_ui.dart';
+import 'package:trufi_core_utils/trufi_core_utils.dart';
 
 import '../../l10n/home_screen_localizations.dart';
 
@@ -120,7 +120,7 @@ class ItineraryCard extends StatelessWidget {
             child: Row(
               children: [
                 Text(
-                  DateFormat('HH:mm').format(itinerary.startTime),
+                  formatClockTime(context, itinerary.startTime),
                   style: theme.textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.w600,
                   ),
@@ -134,7 +134,7 @@ class ItineraryCard extends StatelessWidget {
                   ),
                 ),
                 Text(
-                  DateFormat('HH:mm').format(itinerary.endTime),
+                  formatClockTime(context, itinerary.endTime),
                   style: theme.textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.w600,
                   ),

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_detail_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_detail_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart' as routing;
 import 'package:trufi_core_routing_ui/trufi_core_routing_ui.dart';
+import 'package:trufi_core_utils/trufi_core_utils.dart';
 
 import '../../l10n/home_screen_localizations.dart';
 
@@ -160,7 +160,7 @@ class ItineraryDetailContent extends StatelessWidget {
               if (context.watch<AppConfiguration?>()?.routingTimeOverride ==
                   null) ...[
                 Text(
-                  DateFormat('HH:mm').format(itinerary.startTime),
+                  formatClockTime(context, itinerary.startTime),
                   style: theme.textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.w600,
                   ),
@@ -174,7 +174,7 @@ class ItineraryDetailContent extends StatelessWidget {
                   ),
                 ),
                 Text(
-                  DateFormat('HH:mm').format(itinerary.endTime),
+                  formatClockTime(context, itinerary.endTime),
                   style: theme.textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.w600,
                   ),
@@ -454,7 +454,7 @@ class _PlaceItem extends StatelessWidget {
         if (time != null &&
             context.watch<AppConfiguration?>()?.routingTimeOverride == null)
           Text(
-            DateFormat('HH:mm').format(time!),
+            formatClockTime(context, time!),
             style: theme.textTheme.bodyMedium?.copyWith(
               color: colorScheme.onSurfaceVariant,
               fontWeight: FontWeight.w500,
@@ -964,7 +964,7 @@ class _LegItemState extends State<_LegItem> {
                     context.watch<AppConfiguration?>()?.routingTimeOverride ==
                         null)
                   Text(
-                    DateFormat('HH:mm').format(stop.arrivalTime!),
+                    formatClockTime(context, stop.arrivalTime!),
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: colorScheme.onSurfaceVariant,
                     ),

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_list.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/itinerary_list.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:intl/intl.dart' as intl;
 import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart' as routing;
 import 'package:trufi_core_utils/trufi_core_utils.dart';
@@ -630,7 +629,6 @@ class _AlternativeTimeCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = HomeScreenLocalizations.of(context);
-    final timeFormat = intl.DateFormat('HH:mm');
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 4),
@@ -670,7 +668,7 @@ class _AlternativeTimeCard extends StatelessWidget {
                 if (context.watch<AppConfiguration?>()?.routingTimeOverride ==
                     null) ...[
                   Text(
-                    l10n.departsAt(timeFormat.format(itinerary.startTime)),
+                    l10n.departsAt(formatClockTime(context, itinerary.startTime)),
                     style: theme.textTheme.bodyMedium?.copyWith(
                       fontWeight: FontWeight.w500,
                     ),
@@ -683,7 +681,7 @@ class _AlternativeTimeCard extends StatelessWidget {
                   ),
                   const SizedBox(width: 8),
                   Text(
-                    timeFormat.format(itinerary.endTime),
+                    formatClockTime(context, itinerary.endTime),
                     style: theme.textTheme.bodyMedium?.copyWith(
                       color: theme.colorScheme.onSurfaceVariant,
                     ),

--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_de.arb
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_de.arb
@@ -60,5 +60,7 @@
   "modeAerialLift": "Seilbahn",
   "modeFunicular": "Standseilbahn",
   "modeTrolleybus": "Oberleitungsbus",
-  "modeMonorail": "Einschienenbahn"
+  "modeMonorail": "Einschienenbahn",
+  "distanceKilometers": "{value} km",
+  "distanceMeters": "{value} m"
 }

--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_en.arb
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_en.arb
@@ -133,5 +133,23 @@
   "modeMonorail": "Monorail",
   "@modeMonorail": {
     "description": "GTFS route type shown as the transport mode"
+  },
+  "distanceKilometers": "{value} km",
+  "@distanceKilometers": {
+    "description": "Distance in kilometers; {value} is already formatted with the locale's decimal separator.",
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "distanceMeters": "{value} m",
+  "@distanceMeters": {
+    "description": "Distance in meters; {value} is a whole number formatted for the locale.",
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_es.arb
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_es.arb
@@ -60,5 +60,7 @@
   "modeAerialLift": "Teleférico",
   "modeFunicular": "Funicular",
   "modeTrolleybus": "Trolebús",
-  "modeMonorail": "Monorriel"
+  "modeMonorail": "Monorriel",
+  "distanceKilometers": "{value} km",
+  "distanceMeters": "{value} m"
 }

--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations.dart
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations.dart
@@ -342,6 +342,18 @@ abstract class TransportListLocalizations {
   /// In en, this message translates to:
   /// **'Monorail'**
   String get modeMonorail;
+
+  /// Distance in kilometers; {value} is already formatted with the locale's decimal separator.
+  ///
+  /// In en, this message translates to:
+  /// **'{value} km'**
+  String distanceKilometers(String value);
+
+  /// Distance in meters; {value} is a whole number formatted for the locale.
+  ///
+  /// In en, this message translates to:
+  /// **'{value} m'**
+  String distanceMeters(String value);
 }
 
 class _TransportListLocalizationsDelegate

--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations_de.dart
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations_de.dart
@@ -135,4 +135,14 @@ class TransportListLocalizationsDe extends TransportListLocalizations {
 
   @override
   String get modeMonorail => 'Einschienenbahn';
+
+  @override
+  String distanceKilometers(String value) {
+    return '$value km';
+  }
+
+  @override
+  String distanceMeters(String value) {
+    return '$value m';
+  }
 }

--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations_en.dart
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations_en.dart
@@ -140,4 +140,14 @@ class TransportListLocalizationsEn extends TransportListLocalizations {
 
   @override
   String get modeMonorail => 'Monorail';
+
+  @override
+  String distanceKilometers(String value) {
+    return '$value km';
+  }
+
+  @override
+  String distanceMeters(String value) {
+    return '$value m';
+  }
 }

--- a/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations_es.dart
+++ b/packages/screens/trufi_core_transport_list/lib/l10n/transport_list_localizations_es.dart
@@ -134,4 +134,14 @@ class TransportListLocalizationsEs extends TransportListLocalizations {
 
   @override
   String get modeMonorail => 'Monorriel';
+
+  @override
+  String distanceKilometers(String value) {
+    return '$value km';
+  }
+
+  @override
+  String distanceMeters(String value) {
+    return '$value m';
+  }
 }

--- a/packages/screens/trufi_core_transport_list/lib/src/transport_detail_screen.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/transport_detail_screen.dart
@@ -7,6 +7,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:trufi_core_base_widgets/trufi_core_base_widgets.dart';
 import 'package:trufi_core_maps/trufi_core_maps.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart';
+import 'package:intl/intl.dart';
 
 import '../l10n/transport_list_localizations.dart';
 import 'models/transport_route.dart';
@@ -775,12 +776,20 @@ class _RouteDistanceCalculator {
 
   static double _toRadians(double degrees) => degrees * math.pi / 180;
 
-  /// Formats distance for display.
-  static String format(double km) {
+  /// Formats distance for display, honoring the locale's decimal
+  /// separator and unit strings (#945): "15,8 km" for Spanish, "15.8 km"
+  /// for English — and whatever a city's extra languages define.
+  static String format(BuildContext context, double km) {
+    final l10n = TransportListLocalizations.of(context);
+    final locale = Localizations.localeOf(context).toString();
     if (km < 1) {
-      return '${(km * 1000).round()} m';
+      return l10n.distanceMeters(
+        NumberFormat('#,##0', locale).format((km * 1000).round()),
+      );
     }
-    return '${km.toStringAsFixed(1)} km';
+    return l10n.distanceKilometers(
+      NumberFormat('#,##0.0', locale).format(km),
+    );
   }
 }
 
@@ -1039,7 +1048,7 @@ class _StopsSheetContentState extends State<_StopsSheetContent> {
                   child: _StatItem(
                     icon: Icons.straighten_rounded,
                     label: TransportListLocalizations.of(context).labelDistance,
-                    value: _RouteDistanceCalculator.format(distance),
+                    value: _RouteDistanceCalculator.format(context, distance),
                     color: _foregroundColor(routeColor),
                   ),
                 ),
@@ -1520,7 +1529,7 @@ class _SidePanelStopsContent extends StatelessWidget {
                   child: _StatItem(
                     icon: Icons.straighten_rounded,
                     label: TransportListLocalizations.of(context).labelDistance,
-                    value: _RouteDistanceCalculator.format(distance),
+                    value: _RouteDistanceCalculator.format(context, distance),
                     color: routeColor,
                   ),
                 ),

--- a/packages/trufi_core_navigation/lib/l10n/navigation_de.arb
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_de.arb
@@ -28,5 +28,9 @@
   "navTransfer": "Umstieg",
   "navDestination": "Ziel",
   "navRoute": "Route",
-  "navStopsRemaining": "{count, plural, =1{Noch 1 Haltestelle} other{Noch {count} Haltestellen}}"
+  "navStopsRemaining": "{count, plural, =1{Noch 1 Haltestelle} other{Noch {count} Haltestellen}}",
+  "navDistanceMeters": "{value} m",
+  "navDistanceKilometers": "{value} km",
+  "navDurationMinutes": "{minutes} Min.",
+  "navDurationHoursMinutes": "{hours} Std. {minutes} Min."
 }

--- a/packages/trufi_core_navigation/lib/l10n/navigation_en.arb
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_en.arb
@@ -1,72 +1,171 @@
 {
   "@@locale": "en",
   "navExitNavigation": "Exit Navigation",
-  "@navExitNavigation": { "description": "Button and title for exiting navigation" },
+  "@navExitNavigation": {
+    "description": "Button and title for exiting navigation"
+  },
   "navExitConfirmTitle": "Exit Navigation?",
-  "@navExitConfirmTitle": { "description": "Title of exit navigation confirmation dialog" },
+  "@navExitConfirmTitle": {
+    "description": "Title of exit navigation confirmation dialog"
+  },
   "navExitConfirmMessage": "Are you sure you want to stop navigating this route?",
-  "@navExitConfirmMessage": { "description": "Message in exit navigation confirmation dialog" },
+  "@navExitConfirmMessage": {
+    "description": "Message in exit navigation confirmation dialog"
+  },
   "navCancel": "Cancel",
-  "@navCancel": { "description": "Cancel button label" },
+  "@navCancel": {
+    "description": "Cancel button label"
+  },
   "navExit": "Exit",
-  "@navExit": { "description": "Exit button label" },
+  "@navExit": {
+    "description": "Exit button label"
+  },
   "navClose": "Close",
-  "@navClose": { "description": "Close button label" },
+  "@navClose": {
+    "description": "Close button label"
+  },
   "navRetry": "Retry",
-  "@navRetry": { "description": "Retry button label" },
+  "@navRetry": {
+    "description": "Retry button label"
+  },
   "navSettings": "Settings",
-  "@navSettings": { "description": "Settings button label" },
+  "@navSettings": {
+    "description": "Settings button label"
+  },
   "navArrived": "You have arrived!",
-  "@navArrived": { "description": "Message when user arrives at destination" },
+  "@navArrived": {
+    "description": "Message when user arrives at destination"
+  },
   "navOffRoute": "You appear to be off the route",
-  "@navOffRoute": { "description": "Warning when user is off the planned route" },
+  "@navOffRoute": {
+    "description": "Warning when user is off the planned route"
+  },
   "navWeakGps": "GPS signal is weak",
-  "@navWeakGps": { "description": "Warning when GPS signal is weak" },
+  "@navWeakGps": {
+    "description": "Warning when GPS signal is weak"
+  },
   "navNext": "Next: ",
-  "@navNext": { "description": "Prefix for next instruction" },
+  "@navNext": {
+    "description": "Prefix for next instruction"
+  },
   "navError": "An error occurred",
-  "@navError": { "description": "Generic error message" },
+  "@navError": {
+    "description": "Generic error message"
+  },
   "navStarting": "Starting navigation...",
-  "@navStarting": { "description": "Message while navigation is starting" },
+  "@navStarting": {
+    "description": "Message while navigation is starting"
+  },
   "navGettingLocation": "Getting your location",
-  "@navGettingLocation": { "description": "Message while obtaining user location" },
+  "@navGettingLocation": {
+    "description": "Message while obtaining user location"
+  },
   "navCouldNotStartTracking": "Could not start location tracking",
-  "@navCouldNotStartTracking": { "description": "Error when location tracking fails to start" },
+  "@navCouldNotStartTracking": {
+    "description": "Error when location tracking fails to start"
+  },
   "navArrivedShort": "You have arrived",
-  "@navArrivedShort": { "description": "Short arrival notification" },
+  "@navArrivedShort": {
+    "description": "Short arrival notification"
+  },
   "navOneStop": "1 stop",
-  "@navOneStop": { "description": "Label for one remaining stop" },
+  "@navOneStop": {
+    "description": "Label for one remaining stop"
+  },
   "navStops": "{count} stops",
   "@navStops": {
     "description": "Label for multiple remaining stops",
-    "placeholders": { "count": { "type": "int" } }
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "navExitAt": "Exit at {stopName}",
   "@navExitAt": {
     "description": "Instruction to exit at a specific stop",
-    "placeholders": { "stopName": { "type": "String" } }
+    "placeholders": {
+      "stopName": {
+        "type": "String"
+      }
+    }
   },
   "navFinalDestination": "Final destination",
-  "@navFinalDestination": { "description": "Label for the final destination" },
+  "@navFinalDestination": {
+    "description": "Label for the final destination"
+  },
   "navPermissionDenied": "Location permission denied",
-  "@navPermissionDenied": { "description": "Error when location permission is denied" },
+  "@navPermissionDenied": {
+    "description": "Error when location permission is denied"
+  },
   "navPermissionPermanentlyDenied": "Location permission permanently denied. Please enable in settings.",
-  "@navPermissionPermanentlyDenied": { "description": "Error when location permission is permanently denied" },
+  "@navPermissionPermanentlyDenied": {
+    "description": "Error when location permission is permanently denied"
+  },
   "navLocationDisabled": "Location services are disabled. Please enable them.",
-  "@navLocationDisabled": { "description": "Error when location services are disabled" },
+  "@navLocationDisabled": {
+    "description": "Error when location services are disabled"
+  },
   "navOrigin": "Origin",
-  "@navOrigin": { "description": "Label for the route origin point" },
+  "@navOrigin": {
+    "description": "Label for the route origin point"
+  },
   "navTransfer": "Transfer",
-  "@navTransfer": { "description": "Label for a transfer point between routes" },
+  "@navTransfer": {
+    "description": "Label for a transfer point between routes"
+  },
   "navDestination": "Destination",
-  "@navDestination": { "description": "Label for the route destination point" },
+  "@navDestination": {
+    "description": "Label for the route destination point"
+  },
   "navRoute": "Route",
-  "@navRoute": { "description": "Fallback name for a route without a name" },
+  "@navRoute": {
+    "description": "Fallback name for a route without a name"
+  },
   "navStopsRemaining": "{count, plural, =1{1 stop remaining} other{{count} stops remaining}}",
   "@navStopsRemaining": {
     "description": "How many stops remain before exiting the vehicle",
     "placeholders": {
       "count": {
+        "type": "int"
+      }
+    }
+  },
+  "navDistanceMeters": "{value} m",
+  "@navDistanceMeters": {
+    "description": "Distance to the next stop in meters; {value} is locale-formatted.",
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "navDistanceKilometers": "{value} km",
+  "@navDistanceKilometers": {
+    "description": "Distance in kilometers; {value} is locale-formatted with one decimal.",
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "navDurationMinutes": "{minutes} min",
+  "@navDurationMinutes": {
+    "description": "Duration under an hour.",
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "navDurationHoursMinutes": "{hours}h {minutes}m",
+  "@navDurationHoursMinutes": {
+    "description": "Duration of an hour or more.",
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
         "type": "int"
       }
     }

--- a/packages/trufi_core_navigation/lib/l10n/navigation_es.arb
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_es.arb
@@ -28,5 +28,9 @@
   "navTransfer": "Transbordo",
   "navDestination": "Destino",
   "navRoute": "Ruta",
-  "navStopsRemaining": "{count, plural, =1{Queda 1 parada} other{Quedan {count} paradas}}"
+  "navStopsRemaining": "{count, plural, =1{Queda 1 parada} other{Quedan {count} paradas}}",
+  "navDistanceMeters": "{value} m",
+  "navDistanceKilometers": "{value} km",
+  "navDurationMinutes": "{minutes} min",
+  "navDurationHoursMinutes": "{hours}h {minutes}m"
 }

--- a/packages/trufi_core_navigation/lib/l10n/navigation_localizations.dart
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_localizations.dart
@@ -276,6 +276,30 @@ abstract class NavigationLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =1{1 stop remaining} other{{count} stops remaining}}'**
   String navStopsRemaining(int count);
+
+  /// Distance to the next stop in meters; {value} is locale-formatted.
+  ///
+  /// In en, this message translates to:
+  /// **'{value} m'**
+  String navDistanceMeters(String value);
+
+  /// Distance in kilometers; {value} is locale-formatted with one decimal.
+  ///
+  /// In en, this message translates to:
+  /// **'{value} km'**
+  String navDistanceKilometers(String value);
+
+  /// Duration under an hour.
+  ///
+  /// In en, this message translates to:
+  /// **'{minutes} min'**
+  String navDurationMinutes(int minutes);
+
+  /// Duration of an hour or more.
+  ///
+  /// In en, this message translates to:
+  /// **'{hours}h {minutes}m'**
+  String navDurationHoursMinutes(int hours, int minutes);
 }
 
 class _NavigationLocalizationsDelegate

--- a/packages/trufi_core_navigation/lib/l10n/navigation_localizations_de.dart
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_localizations_de.dart
@@ -110,4 +110,24 @@ class NavigationLocalizationsDe extends NavigationLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String navDistanceMeters(String value) {
+    return '$value m';
+  }
+
+  @override
+  String navDistanceKilometers(String value) {
+    return '$value km';
+  }
+
+  @override
+  String navDurationMinutes(int minutes) {
+    return '$minutes Min.';
+  }
+
+  @override
+  String navDurationHoursMinutes(int hours, int minutes) {
+    return '$hours Std. $minutes Min.';
+  }
 }

--- a/packages/trufi_core_navigation/lib/l10n/navigation_localizations_en.dart
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_localizations_en.dart
@@ -109,4 +109,24 @@ class NavigationLocalizationsEn extends NavigationLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String navDistanceMeters(String value) {
+    return '$value m';
+  }
+
+  @override
+  String navDistanceKilometers(String value) {
+    return '$value km';
+  }
+
+  @override
+  String navDurationMinutes(int minutes) {
+    return '$minutes min';
+  }
+
+  @override
+  String navDurationHoursMinutes(int hours, int minutes) {
+    return '${hours}h ${minutes}m';
+  }
 }

--- a/packages/trufi_core_navigation/lib/l10n/navigation_localizations_es.dart
+++ b/packages/trufi_core_navigation/lib/l10n/navigation_localizations_es.dart
@@ -110,4 +110,24 @@ class NavigationLocalizationsEs extends NavigationLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String navDistanceMeters(String value) {
+    return '$value m';
+  }
+
+  @override
+  String navDistanceKilometers(String value) {
+    return '$value km';
+  }
+
+  @override
+  String navDurationMinutes(int minutes) {
+    return '$minutes min';
+  }
+
+  @override
+  String navDurationHoursMinutes(int hours, int minutes) {
+    return '${hours}h ${minutes}m';
+  }
 }

--- a/packages/trufi_core_navigation/lib/src/presentation/widgets/navigation_instruction_card.dart
+++ b/packages/trufi_core_navigation/lib/src/presentation/widgets/navigation_instruction_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 import '../../../l10n/navigation_localizations.dart';
 import '../../models/navigation_instruction.dart';
@@ -113,7 +114,7 @@ class NavigationInstructionCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.end,
                     children: [
                       Text(
-                        _formatDistance(distanceToNextStop!),
+                        _formatDistance(context, distanceToNextStop!),
                         style: theme.textTheme.titleMedium?.copyWith(
                           fontWeight: FontWeight.bold,
                           color: colorScheme.primary,
@@ -121,7 +122,7 @@ class NavigationInstructionCard extends StatelessWidget {
                       ),
                       if (etaToDestination != null)
                         Text(
-                          '~${_formatDuration(etaToDestination!)}',
+                          '~${_formatDuration(context, etaToDestination!)}',
                           style: theme.textTheme.bodySmall?.copyWith(
                             color: colorScheme.onSurfaceVariant,
                           ),
@@ -346,20 +347,30 @@ class NavigationInstructionCard extends StatelessWidget {
     );
   }
 
-  String _formatDistance(double meters) {
+  /// Locale-aware distance/duration strings (#945): units and decimal
+  /// separator come from the ARBs and NumberFormat, not string literals.
+  String _formatDistance(BuildContext context, double meters) {
+    final l10n = NavigationLocalizations.of(context);
+    final locale = Localizations.localeOf(context).toString();
     if (meters < 1000) {
-      return '${meters.round()} m';
+      return l10n.navDistanceMeters(
+        NumberFormat('#,##0', locale).format(meters.round()),
+      );
     }
-    return '${(meters / 1000).toStringAsFixed(1)} km';
+    return l10n.navDistanceKilometers(
+      NumberFormat('#,##0.0', locale).format(meters / 1000),
+    );
   }
 
-  String _formatDuration(Duration duration) {
+  String _formatDuration(BuildContext context, Duration duration) {
+    final l10n = NavigationLocalizations.of(context);
     if (duration.inMinutes < 60) {
-      return '${duration.inMinutes} min';
+      return l10n.navDurationMinutes(duration.inMinutes);
     }
-    final hours = duration.inHours;
-    final minutes = duration.inMinutes % 60;
-    return '${hours}h ${minutes}m';
+    return l10n.navDurationHoursMinutes(
+      duration.inHours,
+      duration.inMinutes % 60,
+    );
   }
 
   Widget _buildItinerarySummary(BuildContext context) {
@@ -396,7 +407,7 @@ class NavigationInstructionCard extends StatelessWidget {
                     borderRadius: BorderRadius.circular(16),
                   ),
                   child: Text(
-                    _formatDuration(totalDuration!),
+                    _formatDuration(context, totalDuration!),
                     style: const TextStyle(
                       color: Colors.white,
                       fontWeight: FontWeight.bold,

--- a/packages/trufi_core_planner/lib/src/models/gtfs_frequency.dart
+++ b/packages/trufi_core_planner/lib/src/models/gtfs_frequency.dart
@@ -18,19 +18,9 @@ class GtfsFrequency {
   /// Headway as Duration.
   Duration get headway => Duration(seconds: headwaySecs);
 
-  /// Human-readable frequency string (e.g., "every 10 min").
-  String get displayFrequency {
-    final minutes = headwaySecs ~/ 60;
-    if (minutes < 60) {
-      return 'every $minutes min';
-    }
-    final hours = minutes ~/ 60;
-    final remainingMinutes = minutes % 60;
-    if (remainingMinutes == 0) {
-      return 'every $hours hr';
-    }
-    return 'every $hours hr $remainingMinutes min';
-  }
+  // NOTE(#945): the old `displayFrequency` getter ("every 10 min") was an
+  // English-only trap for UI code. Use the raw [headway] and format in the
+  // widget layer with the screen package's localizations.
 
   /// Start time as formatted string (HH:MM).
   String get startTimeFormatted => _formatTime(startTime);

--- a/packages/trufi_core_routing/lib/l10n/routing_de.arb
+++ b/packages/trufi_core_routing/lib/l10n/routing_de.arb
@@ -24,5 +24,7 @@
   "trufiPlannerInfoIntro": "Trufi Planner ist unsere eigene Routing-Engine (kein OTP).",
   "trufiPlannerInfoLocalBody": "Auf dem Gerät läuft er zu 100% offline mit den gebündelten GTFS-Daten — Ergebnisse können daher von Online-Engines abweichen.",
   "trufiPlannerInfoRemoteBody": "Diese Web-Version fragt unseren Server ab; Ergebnisse können von OTP abweichen, da Algorithmus und Daten unterschiedlich sind.",
-  "otpOnlineDescription": "Findet Routen über einen Online-Dienst. Kann aktuellere Informationen haben."
+  "otpOnlineDescription": "Findet Routen über einen Online-Dienst. Kann aktuellere Informationen haben.",
+  "distanceKilometers": "{value} km",
+  "distanceMeters": "{value} m"
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_en.arb
+++ b/packages/trufi_core_routing/lib/l10n/routing_en.arb
@@ -117,5 +117,23 @@
   "otpOnlineDescription": "Finds routes through an online service. May have more up-to-date information.",
   "@otpOnlineDescription": {
     "description": "Description shown for OpenTripPlanner engines in the routing settings."
+  },
+  "distanceKilometers": "{value} km",
+  "@distanceKilometers": {
+    "description": "Distance in kilometers; {value} is already formatted with the locale's decimal separator.",
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
+  },
+  "distanceMeters": "{value} m",
+  "@distanceMeters": {
+    "description": "Distance in meters; {value} is a whole number formatted for the locale.",
+    "placeholders": {
+      "value": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_es.arb
+++ b/packages/trufi_core_routing/lib/l10n/routing_es.arb
@@ -24,5 +24,7 @@
   "trufiPlannerInfoIntro": "Trufi Planner es nuestro motor de rutas propio (no OTP).",
   "trufiPlannerInfoLocalBody": "En esta versión móvil corre 100% offline, usando los datos GTFS empacados con la app — por eso los resultados pueden diferir de motores online.",
   "trufiPlannerInfoRemoteBody": "Esta versión web consulta nuestro servidor; los resultados pueden diferir de OTP por usar un algoritmo y datos distintos.",
-  "otpOnlineDescription": "Busca rutas mediante un servicio en línea. Puede tener información más actualizada."
+  "otpOnlineDescription": "Busca rutas mediante un servicio en línea. Puede tener información más actualizada.",
+  "distanceKilometers": "{value} km",
+  "distanceMeters": "{value} m"
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_localizations.dart
+++ b/packages/trufi_core_routing/lib/l10n/routing_localizations.dart
@@ -252,6 +252,18 @@ abstract class RoutingLocalizations {
   /// In en, this message translates to:
   /// **'Finds routes through an online service. May have more up-to-date information.'**
   String get otpOnlineDescription;
+
+  /// Distance in kilometers; {value} is already formatted with the locale's decimal separator.
+  ///
+  /// In en, this message translates to:
+  /// **'{value} km'**
+  String distanceKilometers(String value);
+
+  /// Distance in meters; {value} is a whole number formatted for the locale.
+  ///
+  /// In en, this message translates to:
+  /// **'{value} m'**
+  String distanceMeters(String value);
 }
 
 class _RoutingLocalizationsDelegate

--- a/packages/trufi_core_routing/lib/l10n/routing_localizations_de.dart
+++ b/packages/trufi_core_routing/lib/l10n/routing_localizations_de.dart
@@ -94,4 +94,14 @@ class RoutingLocalizationsDe extends RoutingLocalizations {
   @override
   String get otpOnlineDescription =>
       'Findet Routen über einen Online-Dienst. Kann aktuellere Informationen haben.';
+
+  @override
+  String distanceKilometers(String value) {
+    return '$value km';
+  }
+
+  @override
+  String distanceMeters(String value) {
+    return '$value m';
+  }
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_localizations_en.dart
+++ b/packages/trufi_core_routing/lib/l10n/routing_localizations_en.dart
@@ -94,4 +94,14 @@ class RoutingLocalizationsEn extends RoutingLocalizations {
   @override
   String get otpOnlineDescription =>
       'Finds routes through an online service. May have more up-to-date information.';
+
+  @override
+  String distanceKilometers(String value) {
+    return '$value km';
+  }
+
+  @override
+  String distanceMeters(String value) {
+    return '$value m';
+  }
 }

--- a/packages/trufi_core_routing/lib/l10n/routing_localizations_es.dart
+++ b/packages/trufi_core_routing/lib/l10n/routing_localizations_es.dart
@@ -95,4 +95,14 @@ class RoutingLocalizationsEs extends RoutingLocalizations {
   @override
   String get otpOnlineDescription =>
       'Busca rutas mediante un servicio en línea. Puede tener información más actualizada.';
+
+  @override
+  String distanceKilometers(String value) {
+    return '$value km';
+  }
+
+  @override
+  String distanceMeters(String value) {
+    return '$value m';
+  }
 }

--- a/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_preferences.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_preferences.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:intl/intl.dart';
 
 import '../../../l10n/routing_localizations.dart';
 
@@ -485,8 +486,18 @@ class _DistanceChip extends StatelessWidget {
     final label = distance == null
         ? RoutingLocalizations.of(context).prefsNoLimit
         : distance! >= 1000
-        ? '${(distance! / 1000).toStringAsFixed(1)} km'
-        : '${distance!.toInt()} m';
+        ? RoutingLocalizations.of(context).distanceKilometers(
+            NumberFormat(
+              '#,##0.0',
+              Localizations.localeOf(context).toString(),
+            ).format(distance! / 1000),
+          )
+        : RoutingLocalizations.of(context).distanceMeters(
+            NumberFormat(
+              '#,##0',
+              Localizations.localeOf(context).toString(),
+            ).format(distance!.toInt()),
+          );
 
     return Material(
       color: isSelected

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_preferences.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_preferences.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:intl/intl.dart';
 
 import '../../../l10n/routing_localizations.dart';
 
@@ -478,8 +479,18 @@ class _DistanceChip extends StatelessWidget {
     final label = distance == null
         ? RoutingLocalizations.of(context).prefsNoLimit
         : distance! >= 1000
-        ? '${(distance! / 1000).toStringAsFixed(1)} km'
-        : '${distance!.toInt()} m';
+        ? RoutingLocalizations.of(context).distanceKilometers(
+            NumberFormat(
+              '#,##0.0',
+              Localizations.localeOf(context).toString(),
+            ).format(distance! / 1000),
+          )
+        : RoutingLocalizations.of(context).distanceMeters(
+            NumberFormat(
+              '#,##0',
+              Localizations.localeOf(context).toString(),
+            ).format(distance!.toInt()),
+          );
 
     return Material(
       color: isSelected

--- a/packages/trufi_core_routing_ui/lib/src/itinerary_ui.dart
+++ b/packages/trufi_core_routing_ui/lib/src/itinerary_ui.dart
@@ -1,16 +1,9 @@
-import 'package:intl/intl.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart';
 
 import 'leg_ui.dart';
 
 /// UI extensions for [Itinerary] from trufi_core_routing package.
 extension ItineraryUI on Itinerary {
-  /// Start time formatted as HH:mm.
-  String get startTimeHHmm => DateFormat('HH:mm').format(startTime);
-
-  /// End time formatted as HH:mm.
-  String get endTimeHHmm => DateFormat('HH:mm').format(endTime);
-
   /// Compress consecutive walk/bike legs into single legs.
   List<Leg> get compressLegs {
     final compressedLegs = <Leg>[];

--- a/packages/trufi_core_routing_ui/lib/src/leg_ui.dart
+++ b/packages/trufi_core_routing_ui/lib/src/leg_ui.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart';
 
 import 'transport_mode_ui.dart';
@@ -19,12 +18,6 @@ extension LegUI on Leg {
   String get headSign {
     return route?.shortName ?? (route?.longName ?? (shortName ?? ''));
   }
-
-  /// Start time formatted as HH:mm.
-  String get startTimeString => DateFormat('HH:mm').format(startTime);
-
-  /// End time formatted as HH:mm.
-  String get endTimeString => DateFormat('HH:mm').format(endTime);
 }
 
 /// Utility functions for working with legs.

--- a/packages/trufi_core_utils/lib/src/time_format.dart
+++ b/packages/trufi_core_utils/lib/src/time_format.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+/// Formats a clock time the way the user's locale (and device setting)
+/// expects — "21:13" for a 24-hour convention, "9:13 PM" for en_US, and
+/// so on.
+///
+/// This replaces the hardcoded `DateFormat('HH:mm')` calls that assumed
+/// every rider reads 24-hour time (#945). It goes through
+/// [MaterialLocalizations], so it follows the app's locale — including
+/// languages served by the fallback delegates (#944) — and honors the
+/// device's "use 24-hour format" setting via [MediaQuery].
+String formatClockTime(BuildContext context, DateTime time) {
+  return MaterialLocalizations.of(context).formatTimeOfDay(
+    TimeOfDay.fromDateTime(time),
+    alwaysUse24HourFormat: MediaQuery.alwaysUse24HourFormatOf(context),
+  );
+}

--- a/packages/trufi_core_utils/lib/trufi_core_utils.dart
+++ b/packages/trufi_core_utils/lib/trufi_core_utils.dart
@@ -12,3 +12,4 @@ export './src/location_service.dart';
 
 // Device
 export './src/device/shared_preferences_device_id_service.dart';
+export 'src/time_format.dart';


### PR DESCRIPTION
The four **Formatting** items from the #945 tracker, one coherent batch:

| Item | Before | After |
|---|---|---|
| Clock times (12 sites) | `DateFormat('HH:mm')` — 24h for everyone | `formatClockTime()` (new in `trufi_core_utils`): `MaterialLocalizations.formatTimeOfDay` honoring locale + the device's 24-hour setting → **12:21 PM** in English, **12:21** in Spanish. Works for fallback-delegate languages from #944 too. |
| Shared-route text | `HH:mm` | `DateFormat.jm(localeTag)` — the 'j' skeleton is the locale's preferred clock (no MediaQuery in shared text) |
| Distances (route detail stats, OTP 1.5/2.4 walk-distance sliders) | `'${km.toStringAsFixed(1)} km'` — English dot always | `distanceKilometers`/`distanceMeters` ARB keys + `NumberFormat` → **27,1 km** (es) / **27.1 km** (en) |
| Navigation card | `'2.4 km'`, `'5 min'`, `'1h 20m'` literals | `navDistance*`/`navDuration*` ARB keys |
| `GtfsFrequency.displayFrequency` | `'every 10 min'` (English-only trap, zero consumers) | removed; raw `headway` stays for widget-layer formatting |

Also removed the dead `startTimeString`/`endTimeHHmm`-style getters in `trufi_core_routing_ui` (no consumers — they were the trap the audit flagged).

## Verification

- Emulator (screenshots in the ops repo): Spanish route detail **"27,1 km"** with the locale's comma; English itinerary list **"12:21 PM → 12:53 PM"**.
- Touched package suites all green locally; CI now runs them too (#966).

Remaining #945 items (wiring + cosmetics + docs) stay tracked — each is its own PR-sized change.