### PR TITLE
fix(l10n): forward the app language to routing and geocoding (#945)

### DIFF
--- a/packages/screens/trufi_core_about/lib/about_trufi_screen.dart
+++ b/packages/screens/trufi_core_about/lib/about_trufi_screen.dart
@@ -59,9 +59,6 @@ class AboutTrufiScreen extends TrufiScreen {
   ];
 
   @override
-  List<Locale> get supportedLocales => AboutLocalizations.supportedLocales;
-
-  @override
   ScreenMenuItem? get menuItem => const ScreenMenuItem(
     icon: Icons.info_outline,
     order: 900,

--- a/packages/screens/trufi_core_fares/example/lib/main.dart
+++ b/packages/screens/trufi_core_fares/example/lib/main.dart
@@ -97,7 +97,7 @@ class MyApp extends StatelessWidget {
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
-      supportedLocales: screen.supportedLocales,
+      supportedLocales: FaresLocalizations.supportedLocales,
     );
   }
 }

--- a/packages/screens/trufi_core_fares/lib/src/fares_trufi_screen.dart
+++ b/packages/screens/trufi_core_fares/lib/src/fares_trufi_screen.dart
@@ -35,9 +35,6 @@ class FaresTrufiScreen extends TrufiScreen {
   ];
 
   @override
-  List<Locale> get supportedLocales => FaresLocalizations.supportedLocales;
-
-  @override
   ScreenMenuItem? get menuItem =>
       const ScreenMenuItem(icon: Icons.payments_outlined, order: 150);
 

--- a/packages/screens/trufi_core_feedback/example/lib/main.dart
+++ b/packages/screens/trufi_core_feedback/example/lib/main.dart
@@ -34,7 +34,7 @@ class MyApp extends StatelessWidget {
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
-      supportedLocales: screen.supportedLocales,
+      supportedLocales: FeedbackLocalizations.supportedLocales,
     );
   }
 }

--- a/packages/screens/trufi_core_feedback/lib/src/feedback_trufi_screen.dart
+++ b/packages/screens/trufi_core_feedback/lib/src/feedback_trufi_screen.dart
@@ -38,9 +38,6 @@ class FeedbackTrufiScreen extends TrufiScreen {
   ];
 
   @override
-  List<Locale> get supportedLocales => FeedbackLocalizations.supportedLocales;
-
-  @override
   ScreenMenuItem? get menuItem =>
       const ScreenMenuItem(icon: Icons.feedback_outlined, order: 800);
 

--- a/packages/screens/trufi_core_home_screen/example/lib/main.dart
+++ b/packages/screens/trufi_core_home_screen/example/lib/main.dart
@@ -69,7 +69,7 @@ class MyApp extends StatelessWidget {
           GlobalWidgetsLocalizations.delegate,
           GlobalCupertinoLocalizations.delegate,
         ],
-        supportedLocales: screen.supportedLocales,
+        supportedLocales: HomeScreenLocalizations.supportedLocales,
       ),
     );
   }

--- a/packages/screens/trufi_core_home_screen/lib/src/cubit/route_planner_cubit.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/cubit/route_planner_cubit.dart
@@ -33,6 +33,16 @@ class RoutePlannerCubit extends Cubit<RoutePlannerState> {
   /// resolved against today at this time.
   final TimeOfDay? _routingTimeOverride;
 
+  /// BCP-47 tag of the app's current language, forwarded to the routing
+  /// provider so server-produced texts (alerts, street names in
+  /// instructions) come back in the rider's language instead of the
+  /// server's default (#945). Kept fresh by the home screen on every
+  /// dependency change — a Cubit has no BuildContext of its own.
+  String? _locale;
+
+  /// Updates the language forwarded with every plan request.
+  void updateLocale(String? languageTag) => _locale = languageTag;
+
   /// Optional GTFS-backed lookup used to enrich [routing.Leg.serviceHours]
   /// after the provider has parsed a plan. OTP REST/GraphQL doesn't
   /// expose calendar+frequencies in a directly usable shape, so this
@@ -236,6 +246,7 @@ class RoutePlannerCubit extends Cubit<RoutePlannerState> {
         _requestService.fetchPlan(
           from: state.fromPlace!,
           to: state.toPlace!,
+          locale: _locale,
           dateTime: effectiveDateTime,
           arriveBy: arriveBy,
         ),

--- a/packages/screens/trufi_core_home_screen/lib/src/home_screen_trufi_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/home_screen_trufi_screen.dart
@@ -111,9 +111,6 @@ class HomeScreenTrufiScreen extends TrufiScreen {
   ];
 
   @override
-  List<Locale> get supportedLocales => HomeScreenLocalizations.supportedLocales;
-
-  @override
   List<SingleChildWidget> get providers => [
     BlocProvider<RoutePlannerCubit>(
       create: (context) => RoutePlannerCubit(

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -204,6 +204,13 @@ class _HomeScreenState extends State<HomeScreen>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    // Keep the plan cubit's language current so server-produced texts
+    // (alerts, instruction street names) come back in the rider's
+    // language (#945). Locale is an inherited dependency, so this fires
+    // again whenever the user switches languages.
+    context.read<RoutePlannerCubit>().updateLocale(
+          Localizations.localeOf(context).toLanguageTag(),
+        );
     // Listen to shared route notifier for deep links
     _setupSharedRouteListener();
     // Parse URL parameters on first load (web only)

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -208,8 +208,10 @@ class _HomeScreenState extends State<HomeScreen>
     // (alerts, instruction street names) come back in the rider's
     // language (#945). Locale is an inherited dependency, so this fires
     // again whenever the user switches languages.
+    // OTP's GraphQL `locale` argument is a two-letter ISO 639-1 code —
+    // send `languageCode`, not the full tag ('es', never 'es-BO').
     context.read<RoutePlannerCubit>().updateLocale(
-          Localizations.localeOf(context).toLanguageTag(),
+          Localizations.localeOf(context).languageCode,
         );
     // Listen to shared route notifier for deep links
     _setupSharedRouteListener();

--- a/packages/screens/trufi_core_saved_places/example/lib/main.dart
+++ b/packages/screens/trufi_core_saved_places/example/lib/main.dart
@@ -44,7 +44,7 @@ class MyApp extends StatelessWidget {
           GlobalWidgetsLocalizations.delegate,
           GlobalCupertinoLocalizations.delegate,
         ],
-        supportedLocales: screen.supportedLocales,
+        supportedLocales: SavedPlacesLocalizations.supportedLocales,
       ),
     );
   }

--- a/packages/screens/trufi_core_saved_places/lib/src/saved_places_trufi_screen.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/saved_places_trufi_screen.dart
@@ -57,10 +57,6 @@ class SavedPlacesTrufiScreen extends TrufiScreen {
   ];
 
   @override
-  List<Locale> get supportedLocales =>
-      SavedPlacesLocalizations.supportedLocales;
-
-  @override
   List<SingleChildWidget> get providers => [
     BlocProvider<SavedPlacesCubit>(
       create: (_) => SavedPlacesCubit(repository: _repository)..initialize(),

--- a/packages/screens/trufi_core_transport_list/example/lib/main.dart
+++ b/packages/screens/trufi_core_transport_list/example/lib/main.dart
@@ -46,7 +46,7 @@ class MyApp extends StatelessWidget {
           GlobalWidgetsLocalizations.delegate,
           GlobalCupertinoLocalizations.delegate,
         ],
-        supportedLocales: screen.supportedLocales,
+        supportedLocales: TransportListLocalizations.supportedLocales,
       ),
     );
   }

--- a/packages/screens/trufi_core_transport_list/lib/src/transport_list_trufi_screen.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/transport_list_trufi_screen.dart
@@ -115,10 +115,6 @@ class TransportListTrufiScreen extends TrufiScreen {
   ];
 
   @override
-  List<Locale> get supportedLocales =>
-      TransportListLocalizations.supportedLocales;
-
-  @override
   List<SingleChildWidget> get providers => [];
 
   @override

--- a/packages/trufi_core_interfaces/lib/src/config/trufi_screen.dart
+++ b/packages/trufi_core_interfaces/lib/src/config/trufi_screen.dart
@@ -48,8 +48,11 @@ abstract class TrufiScreen {
   /// Localization delegates for this screen
   List<LocalizationsDelegate> get localizationsDelegates;
 
-  /// Supported locales for this screen
-  List<Locale> get supportedLocales => [];
+  // NOTE(#945): the old `supportedLocales` getter was dead API — every
+  // screen overrode it and nothing ever read it. The app's language set is
+  // the city's decision (`TrufiLocaleConfig.supportedLocales`), not an
+  // aggregation of what each screen ships, so the getter was removed
+  // rather than wired up.
 
   /// Menu item configuration (null if not shown in menu)
   ScreenMenuItem? get menuItem => null;

--- a/packages/trufi_core_search_locations/lib/src/services/composite_search_location_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/composite_search_location_service.dart
@@ -20,7 +20,7 @@ import 'search_location_service.dart';
 ///   place found twice appears once;
 /// - [reverse] returns the first non-null answer, in order.
 class CompositeSearchLocationService
-    with SearchLocationDrillDown
+    with SearchLocationDrillDown, LanguageAwareSearch
     implements SearchLocationService {
   final List<SearchLocationService> services;
 
@@ -95,6 +95,17 @@ class CompositeSearchLocationService
       }
     }
     return null;
+  }
+
+  /// Forwards the app language to every child that can localize its
+  /// results (#945); language-unaware children are left alone.
+  @override
+  set searchLanguage(String? languageCode) {
+    for (final service in services) {
+      if (service is LanguageAwareSearch) {
+        (service as LanguageAwareSearch).searchLanguage = languageCode;
+      }
+    }
   }
 
   @override

--- a/packages/trufi_core_search_locations/lib/src/services/nominatim_search_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/nominatim_search_service.dart
@@ -22,7 +22,6 @@ class NominatimSearchService
   /// User-Agent header (required by Nominatim usage policy).
   final String userAgent;
 
-  /// Language for results (e.g., 'en', 'de', 'es').
   /// Language for result texts. Mutable: the search screen keeps it in
   /// sync with the app's locale (see [LanguageAwareSearch]).
   String? language;

--- a/packages/trufi_core_search_locations/lib/src/services/nominatim_search_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/nominatim_search_service.dart
@@ -14,7 +14,8 @@ import 'search_location_service.dart';
 ///
 /// Note: The public Nominatim API has usage limits. For production use,
 /// consider hosting your own instance or using a commercial provider.
-class NominatimSearchService implements SearchLocationService {
+class NominatimSearchService
+    with LanguageAwareSearch implements SearchLocationService {
   /// Base URL for the Nominatim API.
   final String baseUrl;
 
@@ -22,7 +23,9 @@ class NominatimSearchService implements SearchLocationService {
   final String userAgent;
 
   /// Language for results (e.g., 'en', 'de', 'es').
-  final String? language;
+  /// Language for result texts. Mutable: the search screen keeps it in
+  /// sync with the app's locale (see [LanguageAwareSearch]).
+  String? language;
 
   /// Maximum number of results to return.
   final int limit;
@@ -63,6 +66,9 @@ class NominatimSearchService implements SearchLocationService {
     DeviceIdService? deviceIdService,
   }) : _client = client ?? http.Client(),
        _deviceIdService = deviceIdService ?? SharedPreferencesDeviceIdService();
+
+  @override
+  set searchLanguage(String? languageCode) => language = languageCode;
 
   Future<Map<String, String>> _buildHeaders() async {
     final headers = <String, String>{'User-Agent': userAgent};

--- a/packages/trufi_core_search_locations/lib/src/services/photon_search_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/photon_search_service.dart
@@ -11,12 +11,15 @@ import 'search_location_service.dart';
 ///
 /// Photon is a free, open-source geocoding API powered by OpenStreetMap data.
 /// https://photon.komoot.io/
-class PhotonSearchService implements SearchLocationService {
+class PhotonSearchService
+    with LanguageAwareSearch implements SearchLocationService {
   /// Base URL for the Photon API.
   final String baseUrl;
 
   /// Language for results (e.g., 'en', 'de', 'es').
-  final String? language;
+  /// Language for result texts. Mutable: the search screen keeps it in
+  /// sync with the app's locale (see [LanguageAwareSearch]).
+  String? language;
 
   /// Latitude for location bias (results closer to this point are prioritized).
   final double? biasLatitude;
@@ -48,6 +51,9 @@ class PhotonSearchService implements SearchLocationService {
     DeviceIdService? deviceIdService,
   }) : _client = client ?? http.Client(),
        _deviceIdService = deviceIdService ?? SharedPreferencesDeviceIdService();
+
+  @override
+  set searchLanguage(String? languageCode) => language = languageCode;
 
   Future<Map<String, String>?> _buildHeaders() async {
     try {

--- a/packages/trufi_core_search_locations/lib/src/services/photon_search_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/photon_search_service.dart
@@ -21,6 +21,16 @@ class PhotonSearchService
   /// sync with the app's locale (see [LanguageAwareSearch]).
   String? language;
 
+  /// Languages this Photon deployment accepts in its `lang` parameter.
+  /// Public Photon rejects anything else with **HTTP 400** ("language es
+  /// is not supported, supported languages are: default, en, de, fr"),
+  /// which would kill every search for riders using an unsupported app
+  /// language — Spanish being the default of the flagship app. Languages
+  /// outside this set are simply not forwarded (Photon then answers in
+  /// its default), which is the pre-#969 behavior. Deployments re-imported
+  /// with more languages can widen the set.
+  final Set<String> supportedLanguages;
+
   /// Latitude for location bias (results closer to this point are prioritized).
   final double? biasLatitude;
 
@@ -49,11 +59,15 @@ class PhotonSearchService
     this.boundingBox,
     http.Client? client,
     DeviceIdService? deviceIdService,
+    this.supportedLanguages = const {'en', 'de', 'fr'},
   }) : _client = client ?? http.Client(),
        _deviceIdService = deviceIdService ?? SharedPreferencesDeviceIdService();
 
   @override
-  set searchLanguage(String? languageCode) => language = languageCode;
+  set searchLanguage(String? languageCode) =>
+      language = supportedLanguages.contains(languageCode)
+          ? languageCode
+          : null;
 
   Future<Map<String, String>?> _buildHeaders() async {
     try {

--- a/packages/trufi_core_search_locations/lib/src/services/search_location_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/search_location_service.dart
@@ -21,6 +21,16 @@ abstract class SearchLocationService {
   void dispose();
 }
 
+/// Optional capability for search services that can localize their result
+/// texts (#945). [LocationSearchScreen] keeps the language in sync with the
+/// app's locale on every dependency change, so switching the app language
+/// switches the geocoder's answers too;
+/// [CompositeSearchLocationService] forwards to every capable child.
+abstract mixin class LanguageAwareSearch {
+  /// Language for result texts, as a lowercase code (e.g. 'es', 'qu').
+  set searchLanguage(String? languageCode);
+}
+
 /// Optional capability for services whose results can be expanded into
 /// finer-grained locations — the street → corners flow (#745).
 ///

--- a/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
+++ b/packages/trufi_core_search_locations/lib/src/widgets/location_search_screen.dart
@@ -140,6 +140,18 @@ class _LocationSearchScreenState extends State<LocationSearchScreen>
     });
   }
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Keep the geocoder answering in the rider's language (#945). Locale
+    // is an inherited dependency, so a language switch re-fires this.
+    final service = widget.searchService;
+    if (service is LanguageAwareSearch) {
+      (service as LanguageAwareSearch).searchLanguage =
+          Localizations.localeOf(context).languageCode;
+    }
+  }
+
   Future<void> _loadPlaces() async {
     if (widget.myPlacesProvider != null) {
       final places = await widget.myPlacesProvider!.getMyPlaces();

--- a/packages/trufi_core_search_locations/test/unit/composite_search_location_service_test.dart
+++ b/packages/trufi_core_search_locations/test/unit/composite_search_location_service_test.dart
@@ -159,6 +159,21 @@ void main() {
       expect(composite.canDrillDown(street), isFalse);
     });
   });
+
+  group('language forwarding (#945)', () {
+    test('forwards the language to every capable child and skips the rest',
+        () {
+      final aware = _FakeLanguageAwareService();
+      final plain = _FakeService(const []);
+      final composite = CompositeSearchLocationService(
+        services: [plain, aware],
+      );
+
+      composite.searchLanguage = 'qu';
+
+      expect(aware.received, 'qu');
+    });
+  });
 }
 
 class _FakeDrillDownService extends _FakeService with SearchLocationDrillDown {
@@ -177,4 +192,13 @@ class _FakeDrillDownService extends _FakeService with SearchLocationDrillDown {
     drillDownCalls++;
     return corners[location.id] ?? const [];
   }
+}
+
+class _FakeLanguageAwareService extends _FakeService with LanguageAwareSearch {
+  _FakeLanguageAwareService() : super(const []);
+
+  String? received;
+
+  @override
+  set searchLanguage(String? languageCode) => received = languageCode;
 }

--- a/packages/trufi_core_search_locations/test/unit/photon_search_service_test.dart
+++ b/packages/trufi_core_search_locations/test/unit/photon_search_service_test.dart
@@ -410,4 +410,30 @@ void main() {
       });
     });
   });
+
+  group('language whitelist (#969 fresh review)', () {
+    // Public Photon rejects unsupported `lang` values with HTTP 400
+    // ("language es is not supported"), which would kill every search
+    // for Spanish riders — the flagship app's default language.
+    test('an unsupported app language is not forwarded to Photon', () {
+      final service = PhotonSearchService(baseUrl: 'https://photon.test');
+      service.searchLanguage = 'es';
+      expect(service.language, isNull);
+    });
+
+    test('a supported language is forwarded', () {
+      final service = PhotonSearchService(baseUrl: 'https://photon.test');
+      service.searchLanguage = 'de';
+      expect(service.language, 'de');
+    });
+
+    test('a widened deployment can accept more languages', () {
+      final service = PhotonSearchService(
+        baseUrl: 'https://photon.test',
+        supportedLanguages: {'en', 'es'},
+      );
+      service.searchLanguage = 'es';
+      expect(service.language, 'es');
+    });
+  });
 }

--- a/packages/trufi_core_search_locations/test/widget/location_search_screen_drilldown_test.dart
+++ b/packages/trufi_core_search_locations/test/widget/location_search_screen_drilldown_test.dart
@@ -8,8 +8,13 @@ import 'package:trufi_core_search_locations/trufi_core_search_locations.dart';
 /// searches only within the corners, and nothing else. Picking a corner
 /// returns it to the caller with its full name.
 class _DrillDownService
-    with SearchLocationDrillDown
+    with SearchLocationDrillDown, LanguageAwareSearch
     implements SearchLocationService {
+  String? languageReceived;
+
+  @override
+  set searchLanguage(String? languageCode) => languageReceived = languageCode;
+
   static const street = SearchLocation(
     id: 'street:s1',
     displayName: 'Avenida Ayacucho',
@@ -174,5 +179,22 @@ void main() {
     expect(picked, isNull);
     expect(find.text('Plaza Colón'), findsOneWidget);
     expect(find.text('& Avenida Heroínas'), findsNothing);
+  });
+
+  testWidgets('the screen keeps the geocoder language in sync with the '
+      'app locale (#945)', (tester) async {
+    final service = _DrillDownService();
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('es'),
+        localizationsDelegates:
+            SearchLocationsLocalizations.localizationsDelegates,
+        supportedLocales: SearchLocationsLocalizations.supportedLocales,
+        home: LocationSearchScreen(isOrigin: true, searchService: service),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(service.languageReceived, 'es');
   });
 }


### PR DESCRIPTION
The two **Wiring** items from the #945 tracker.

## The gap

Servers could answer in the rider's language — OTP's `locale` variable and Photon/Nominatim's `lang`/`accept-language` were all plumbed — but **nothing ever told them which language**. Server-produced texts (alerts, geocoder result names/addresses) always came back in the server's default.

## What changed

- **Plan requests**: `RoutePlannerCubit.updateLocale()` carries the app's language tag, kept fresh by the home screen's `didChangeDependencies` (locale is an inherited dependency, so switching languages re-fires it — one wiring point instead of touching all 7 `fetchPlan` call sites), and `fetchPlan` finally passes `locale:` down the already-supporting chain.
- **Geocoders**: new `LanguageAwareSearch` capability, same pattern as `SearchLocationDrillDown` from #964: Photon and Nominatim implement it, `CompositeSearchLocationService` forwards to every capable child, and `LocationSearchScreen` keeps it in sync with the app locale. Language-unaware services are untouched.
- **`TrufiScreen.supportedLocales` removed** — dead API: every screen overrode it, nothing consumed it, and under the N-language model the city's `TrufiLocaleConfig` is the authority on languages (aggregating per-screen lists would contradict #919/#944). Per-screen example apps now use their own localizations' `supportedLocales`.

## Tests

- Composite forwards `searchLanguage` to capable children, skips plain services (unit).
- `LocationSearchScreen` syncs the service language from the app locale (widget).
- Full workspace: **all 11 test-bearing packages green** (`melos ci:test` equivalent, which this repo's CI now actually runs — #966).