### PR TITLE
fix: fresh-review follow-ups — NumberFormat locale fallback + OTP 1.5 endpoint path check

### DIFF
--- a/packages/screens/trufi_core_transport_list/lib/src/transport_detail_screen.dart
+++ b/packages/screens/trufi_core_transport_list/lib/src/transport_detail_screen.dart
@@ -7,7 +7,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:trufi_core_base_widgets/trufi_core_base_widgets.dart';
 import 'package:trufi_core_maps/trufi_core_maps.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart';
-import 'package:intl/intl.dart';
+import 'package:trufi_core_utils/trufi_core_utils.dart';
 
 import '../l10n/transport_list_localizations.dart';
 import 'models/transport_route.dart';
@@ -784,11 +784,11 @@ class _RouteDistanceCalculator {
     final locale = Localizations.localeOf(context).toString();
     if (km < 1) {
       return l10n.distanceMeters(
-        NumberFormat('#,##0', locale).format((km * 1000).round()),
+        safeNumberFormat('#,##0', locale).format((km * 1000).round()),
       );
     }
     return l10n.distanceKilometers(
-      NumberFormat('#,##0.0', locale).format(km),
+      safeNumberFormat('#,##0.0', locale).format(km),
     );
   }
 }

--- a/packages/trufi_core_navigation/lib/src/presentation/widgets/navigation_instruction_card.dart
+++ b/packages/trufi_core_navigation/lib/src/presentation/widgets/navigation_instruction_card.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:trufi_core_utils/trufi_core_utils.dart';
 
 import '../../../l10n/navigation_localizations.dart';
 import '../../models/navigation_instruction.dart';
@@ -354,11 +354,11 @@ class NavigationInstructionCard extends StatelessWidget {
     final locale = Localizations.localeOf(context).toString();
     if (meters < 1000) {
       return l10n.navDistanceMeters(
-        NumberFormat('#,##0', locale).format(meters.round()),
+        safeNumberFormat('#,##0', locale).format(meters.round()),
       );
     }
     return l10n.navDistanceKilometers(
-      NumberFormat('#,##0.0', locale).format(meters / 1000),
+      safeNumberFormat('#,##0.0', locale).format(meters / 1000),
     );
   }
 

--- a/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_preferences.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_preferences.dart
@@ -487,13 +487,13 @@ class _DistanceChip extends StatelessWidget {
         ? RoutingLocalizations.of(context).prefsNoLimit
         : distance! >= 1000
         ? RoutingLocalizations.of(context).distanceKilometers(
-            NumberFormat(
+            _safeNumberFormat(
               '#,##0.0',
               Localizations.localeOf(context).toString(),
             ).format(distance! / 1000),
           )
         : RoutingLocalizations.of(context).distanceMeters(
-            NumberFormat(
+            _safeNumberFormat(
               '#,##0',
               Localizations.localeOf(context).toString(),
             ).format(distance!.toInt()),
@@ -683,5 +683,16 @@ class _SettingsCard extends StatelessWidget {
       ),
       child: child,
     );
+  }
+}
+
+/// [NumberFormat] that never throws on a locale intl has no number
+/// symbols for (Quechua, Aymara, …) — falls back to the default locale
+/// instead of red-screening the slider label (#945 fresh review).
+NumberFormat _safeNumberFormat(String pattern, String locale) {
+  try {
+    return NumberFormat(pattern, locale);
+  } catch (_) {
+    return NumberFormat(pattern);
   }
 }

--- a/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_1_5/otp_15_routing_provider.dart
@@ -449,7 +449,14 @@ class Otp15RoutingProvider extends IRoutingProvider {
     final trimmed = endpoint.endsWith('/')
         ? endpoint.substring(0, endpoint.length - 1)
         : endpoint;
-    if (trimmed.contains('/plan')) {
+    // Decide on the URL *path*, not the raw string: a host like
+    // `plan.example.com` contains '/plan' as a substring (the '//' of the
+    // scheme plus the host) and used to be returned verbatim, breaking
+    // routing for any deployment whose hostname starts with "plan"
+    // (fresh-review finding on #966; _buildIndexEndpoint already used the
+    // path-based check).
+    final path = Uri.tryParse(trimmed)?.path ?? '';
+    if (path == '/plan' || path.endsWith('/plan') || path.contains('/plan/')) {
       return trimmed;
     }
     return '$trimmed/otp/routers/default/plan';

--- a/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_preferences.dart
+++ b/packages/trufi_core_routing/lib/src/providers/otp_2_4/otp_24_preferences.dart
@@ -480,13 +480,13 @@ class _DistanceChip extends StatelessWidget {
         ? RoutingLocalizations.of(context).prefsNoLimit
         : distance! >= 1000
         ? RoutingLocalizations.of(context).distanceKilometers(
-            NumberFormat(
+            _safeNumberFormat(
               '#,##0.0',
               Localizations.localeOf(context).toString(),
             ).format(distance! / 1000),
           )
         : RoutingLocalizations.of(context).distanceMeters(
-            NumberFormat(
+            _safeNumberFormat(
               '#,##0',
               Localizations.localeOf(context).toString(),
             ).format(distance!.toInt()),
@@ -676,5 +676,16 @@ class _SettingsCard extends StatelessWidget {
       ),
       child: child,
     );
+  }
+}
+
+/// [NumberFormat] that never throws on a locale intl has no number
+/// symbols for (Quechua, Aymara, …) — falls back to the default locale
+/// instead of red-screening the slider label (#945 fresh review).
+NumberFormat _safeNumberFormat(String pattern, String locale) {
+  try {
+    return NumberFormat(pattern, locale);
+  } catch (_) {
+    return NumberFormat(pattern);
   }
 }

--- a/packages/trufi_core_routing/test/unit/otp_1_5_repository_test.dart
+++ b/packages/trufi_core_routing/test/unit/otp_1_5_repository_test.dart
@@ -249,5 +249,39 @@ void main() {
 
       providerWithSlash.dispose();
     });
+
+    test('a hostname starting with "plan" still gets the REST path appended '
+        '(fresh-review finding: contains(\'/plan\') matched the host)',
+        () async {
+      final provider = Otp15RoutingProvider(
+        endpoint: 'https://plan.example.com',
+        httpClient: mockHttpClient,
+      );
+
+      when(
+        () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+      ).thenAnswer((_) async => http.Response(fixtureResponse, 200));
+
+      await provider.fetchPlan(
+        from: TestConfig.originLocation,
+        to: TestConfig.destinationLocation,
+        dateTime: DateTime(2025, 12, 1, 12, 0),
+      );
+
+      final captured =
+          verify(
+                () => mockHttpClient.get(
+                  captureAny(),
+                  headers: any(named: 'headers'),
+                ),
+              ).captured.first
+              as Uri;
+
+      expect(captured.host, 'plan.example.com');
+      expect(captured.path, equals('/otp/routers/default/plan'));
+
+      provider.dispose();
+    });
+
   });
 }

--- a/packages/trufi_core_utils/lib/src/number_format.dart
+++ b/packages/trufi_core_utils/lib/src/number_format.dart
@@ -1,0 +1,16 @@
+import 'package:intl/intl.dart';
+
+/// A [NumberFormat] that never throws on an unknown locale.
+///
+/// `NumberFormat(pattern, locale)` throws an [ArgumentError] for locales
+/// intl has no number symbols for — which includes exactly the languages
+/// cities add through the N-language model (Quechua, Aymara, Guaraní).
+/// Falling back to the pattern's default locale keeps the number readable
+/// instead of red-screening the widget (#945 fresh-review finding).
+NumberFormat safeNumberFormat(String pattern, String locale) {
+  try {
+    return NumberFormat(pattern, locale);
+  } catch (_) {
+    return NumberFormat(pattern);
+  }
+}

--- a/packages/trufi_core_utils/lib/trufi_core_utils.dart
+++ b/packages/trufi_core_utils/lib/trufi_core_utils.dart
@@ -13,3 +13,4 @@ export './src/location_service.dart';
 // Device
 export './src/device/shared_preferences_device_id_service.dart';
 export 'src/time_format.dart';
+export 'src/number_format.dart';

--- a/packages/trufi_core_utils/pubspec.yaml
+++ b/packages/trufi_core_utils/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  intl: ^0.20.2
   geolocator: ^14.0.0
   package_info_plus: ^10.0.0
   provider: ^6.1.5+1

--- a/packages/trufi_core_utils/test/number_format_test.dart
+++ b/packages/trufi_core_utils/test/number_format_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_utils/trufi_core_utils.dart';
+
+void main() {
+  group('safeNumberFormat (#945 fresh review)', () {
+    test('known locales keep their symbols', () {
+      expect(safeNumberFormat('#,##0.0', 'es').format(27.1), '27,1');
+      expect(safeNumberFormat('#,##0.0', 'en').format(27.1), '27.1');
+    });
+
+    test('a locale intl has no number symbols for must not throw', () {
+      // Quechua/Aymara/Guaraní are exactly the languages cities add via
+      // the N-language model; NumberFormat('...', 'qu') throws an
+      // ArgumentError without this fallback.
+      expect(() => safeNumberFormat('#,##0.0', 'qu').format(27.1),
+          returnsNormally);
+      expect(() => safeNumberFormat('#,##0', 'ay').format(790),
+          returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
Two real findings from the adversarial re-review of the merged #966/#968 batch (process: the fresh-eyes audit that the review flow mandates — run late this time, which is on us, but run).

## 1. `NumberFormat` crashes on N-language locales (latent, from #968)

`NumberFormat('#,##0.0', 'qu')` throws `ArgumentError: Invalid locale "qu"` — verified against intl 0.20.2's `numberFormatSymbols` table (118 locales, no `qu`/`ay`/`gn`, no `'fallback'` entry). The #944 ARB/Material fallback machinery doesn't help: intl is a separate layer. The day a city ships Quechua or Aymara — the exact languages the N-language model exists for — the route-detail stats, both OTP walk-distance sliders and the navigation card red-screen.

**Fix**: `safeNumberFormat()` in `trufi_core_utils` — try the locale, fall back to the pattern's default (same pattern `_localeDateFormat` already uses). `trufi_core_routing` gets a private copy of the guard (it doesn't depend on utils). Regression test formats with `'qu'` and `'ay'`.

## 2. `Otp15RoutingProvider._restEndpoint` matches '/plan' inside the *hostname* (pre-existing, surfaced auditing #966)

`'https://plan.example.com'.contains('/plan')` is true (`//` of the scheme + the host), so the endpoint was returned verbatim without appending the REST path — broken routing for any deployment whose hostname starts with "plan". Not introduced by #966 (which only moved the slash trim); the sibling `_buildIndexEndpoint` already used the correct path-based check. Now decided on `Uri.path`. Regression test pins `plan.example.com → /otp/routers/default/plan`.

## Verification

utils 32/32 (incl. new qu/ay test) · routing 90/90 (incl. new host test) · transport_list 25/25 · navigation 7/7 · analyze clean (only pre-existing infos).