### PR TITLE
N-language audit: last fixed-language literals + screen-less app fixes (#945)

### DIFF
--- a/docs/l10n-standards.md
+++ b/docs/l10n-standards.md
@@ -53,3 +53,55 @@ Localizations are generated using melos. The generated Dart files are committed 
 - [ ] Dependencies (`flutter_localizations`, `intl`) in pubspec.yaml
 - [ ] Generated Dart files committed
 - [ ] Exported in barrel file
+
+## Adding a new language
+
+trufi-core is N-language: the set of languages is decided **per city app**, not
+by core. Core packages ship en/es/de; a city adds its own languages (including
+ones Flutter doesn't know, like Quechua `qu` or Aymara `ay`) without touching
+core. The city's `TrufiLocaleConfig` is the single authority on which locales
+the app offers.
+
+### In a city app
+
+1. **Declare the locale** in the app's `TrufiLocaleConfig`
+   (`supportedLocales` + display names for the language picker).
+2. **Translate the app-level ARBs** the app owns. Core-package strings
+   resolve through each package's own delegate; if the language is not one
+   core ships, those strings fall back per delegate resolution — translate
+   upstream (a core PR adding the ARB) when the city needs them.
+3. **Framework delegates**: for locales Flutter itself doesn't support,
+   register `fallbackFrameworkLocalizationsDelegates()` (from
+   `trufi_core_ui`) after the `GlobalMaterialLocalizations` family, so
+   Material/Cupertino widgets keep working instead of asserting at startup.
+
+### In a core package (adding a language core ships)
+
+1. Copy `<prefix>_en.arb` → `<prefix>_<lang>.arb`, translate every key,
+   keep the `@@locale` header.
+2. Regenerate (`flutter gen-l10n` in the package) and **commit the
+   generated files** — CI diffs them and fails on drift.
+3. Repeat per package: each package has its own ARB set and delegate;
+   there is no global table.
+
+### The traps that already cost time (do not relearn these)
+
+- **`intl` is a separate layer from Flutter l10n.** `NumberFormat`
+  throws `ArgumentError` for locales without number symbols (`qu`, `ay`,
+  `gn`): never call it with a raw app locale — use
+  `safeNumberFormat(...)` from `trufi_core_utils`, which falls back to
+  the default symbols instead of red-screening.
+- **Time formatting** goes through
+  `MaterialLocalizations.formatTimeOfDay` (see
+  `trufi_core_utils/time_format.dart`), which honors the device's 24h
+  setting and never throws for unknown locales. Don't use
+  `DateFormat.jm()` with an app locale.
+- **External services don't speak every locale.** Public Photon rejects
+  unsupported `lang` values with **HTTP 400** (silently killing search) —
+  `PhotonSearchService.supportedLanguages` whitelists what may be
+  forwarded; anything else is sent without `lang`. OTP's GraphQL `locale`
+  takes a two-letter ISO 639-1 code: forward `languageCode`, never
+  `toLanguageTag()`.
+- **Fallback UI that renders before delegates exist** (init screen)
+  resolves the ambient locale first and only then falls back to English —
+  keep that property when touching early-boot widgets.

--- a/packages/trufi_core_interfaces/lib/src/models/trufi_place.dart
+++ b/packages/trufi_core_interfaces/lib/src/models/trufi_place.dart
@@ -204,66 +204,6 @@ class LevenshteinObject<T> {
   final int distance;
 }
 
-/// Location model from geocoding responses.
-class LocationModel {
-  LocationModel({this.geometry, this.type, this.name, this.street});
-
-  Geometry? geometry;
-  String? type;
-  String? name;
-  String? street;
-
-  String get getCode => "$type $name $street";
-
-  factory LocationModel.fromJson(Map<String, dynamic> json) {
-    final county = json["properties"]["county"] as String?;
-    final street = json["properties"]["street"] as String?;
-    final locality = json["properties"]["locality"] as String?;
-    final streetAll = <String>[
-      if (county != null) county,
-      if (street != null) street,
-      if (locality != null) locality,
-    ];
-
-    return LocationModel(
-      geometry: Geometry.fromJson(json["geometry"] as Map<String, dynamic>),
-      type: json["properties"]["type"],
-      name: json["properties"]["name"],
-      street: streetAll.join(", "),
-    );
-  }
-
-  TrufiLocation toTrufiLocation() {
-    return TrufiLocation(
-      description: name ?? 'Not description',
-      latitude: geometry?.coordinates?[1] ?? 0,
-      longitude: geometry?.coordinates?[0] ?? 0,
-      address: street,
-      type: type,
-    );
-  }
-}
-
-/// Geometry from GeoJSON.
-class Geometry {
-  Geometry({this.coordinates, this.type});
-
-  List<double>? coordinates;
-  String? type;
-
-  factory Geometry.fromJson(Map<String, dynamic> json) => Geometry(
-    coordinates: List<double>.from(
-      (json["coordinates"] as List).map((x) => x.toDouble()),
-    ),
-    type: json["type"].toString(),
-  );
-
-  Map<String, dynamic> toJson() => {
-    "coordinates": List<dynamic>.from((coordinates ?? []).map((x) => x)),
-    "type": type,
-  };
-}
-
 /// Default location types.
 enum DefaultLocation { defaultHome, defaultWork }
 

--- a/packages/trufi_core_maps/lib/l10n/maps_de.arb
+++ b/packages/trufi_core_maps/lib/l10n/maps_de.arb
@@ -10,6 +10,7 @@
   "confirmLocation": "Standort bestätigen",
   "offlineMapName": "Offline-Karte",
   "offlineMapDescription": "Vollständig offline nutzbare Karte",
+  "vectorMapName": "Vektorkarte (MapLibre)",
   "errorLoadingOfflineMap": "Fehler beim Laden der Offline-Karte",
   "retry": "Erneut versuchen",
   "vectorMapDescription": "Vektorkarte mit modernem Design und besserer Leistung",

--- a/packages/trufi_core_maps/lib/l10n/maps_en.arb
+++ b/packages/trufi_core_maps/lib/l10n/maps_en.arb
@@ -40,6 +40,10 @@
   "@offlineMapDescription": {
     "description": "Default description for the offline map engine"
   },
+  "vectorMapName": "Vector (MapLibre)",
+  "@vectorMapName": {
+    "description": "Default display name for the MapLibre vector map engine"
+  },
   "errorLoadingOfflineMap": "Error loading offline map",
   "@errorLoadingOfflineMap": {
     "description": "Error title shown when the offline map fails to load"

--- a/packages/trufi_core_maps/lib/l10n/maps_es.arb
+++ b/packages/trufi_core_maps/lib/l10n/maps_es.arb
@@ -10,6 +10,7 @@
   "confirmLocation": "Confirmar ubicación",
   "offlineMapName": "Mapa offline",
   "offlineMapDescription": "Mapa completamente offline",
+  "vectorMapName": "Mapa vectorial (MapLibre)",
   "errorLoadingOfflineMap": "Error al cargar el mapa offline",
   "retry": "Reintentar",
   "vectorMapDescription": "Mapa vectorial con estilo moderno y mejor rendimiento",

--- a/packages/trufi_core_maps/lib/l10n/maps_localizations.dart
+++ b/packages/trufi_core_maps/lib/l10n/maps_localizations.dart
@@ -160,6 +160,12 @@ abstract class MapsLocalizations {
   /// **'Fully offline map'**
   String get offlineMapDescription;
 
+  /// Default display name for the MapLibre vector map engine
+  ///
+  /// In en, this message translates to:
+  /// **'Vector (MapLibre)'**
+  String get vectorMapName;
+
   /// Error title shown when the offline map fails to load
   ///
   /// In en, this message translates to:

--- a/packages/trufi_core_maps/lib/l10n/maps_localizations_de.dart
+++ b/packages/trufi_core_maps/lib/l10n/maps_localizations_de.dart
@@ -39,6 +39,9 @@ class MapsLocalizationsDe extends MapsLocalizations {
   String get offlineMapDescription => 'Vollständig offline nutzbare Karte';
 
   @override
+  String get vectorMapName => 'Vektorkarte (MapLibre)';
+
+  @override
   String get errorLoadingOfflineMap => 'Fehler beim Laden der Offline-Karte';
 
   @override

--- a/packages/trufi_core_maps/lib/l10n/maps_localizations_en.dart
+++ b/packages/trufi_core_maps/lib/l10n/maps_localizations_en.dart
@@ -39,6 +39,9 @@ class MapsLocalizationsEn extends MapsLocalizations {
   String get offlineMapDescription => 'Fully offline map';
 
   @override
+  String get vectorMapName => 'Vector (MapLibre)';
+
+  @override
   String get errorLoadingOfflineMap => 'Error loading offline map';
 
   @override

--- a/packages/trufi_core_maps/lib/l10n/maps_localizations_es.dart
+++ b/packages/trufi_core_maps/lib/l10n/maps_localizations_es.dart
@@ -39,6 +39,9 @@ class MapsLocalizationsEs extends MapsLocalizations {
   String get offlineMapDescription => 'Mapa completamente offline';
 
   @override
+  String get vectorMapName => 'Mapa vectorial (MapLibre)';
+
+  @override
   String get errorLoadingOfflineMap => 'Error al cargar el mapa offline';
 
   @override

--- a/packages/trufi_core_maps/lib/src/configuration/map_engine/maplibre_engine.dart
+++ b/packages/trufi_core_maps/lib/src/configuration/map_engine/maplibre_engine.dart
@@ -53,7 +53,9 @@ class MapLibreEngine implements ITrufiMapEngine {
 
   @override
   String localizedName(BuildContext context) =>
-      nameBuilder?.call(context) ?? name;
+      nameBuilder?.call(context) ??
+      displayName ??
+      MapsLocalizations.of(context).vectorMapName;
 
   @override
   String localizedDescription(BuildContext context) =>

--- a/packages/trufi_core_maps/test/maplibre_engine_l10n_test.dart
+++ b/packages/trufi_core_maps/test/maplibre_engine_l10n_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_maps/trufi_core_maps.dart';
+
+/// The engine picker shows `localizedName`/`localizedDescription`; when a
+/// city doesn't pass a display name, the default must come from
+/// MapsLocalizations instead of a hardcoded English literal (#945).
+void main() {
+  Future<BuildContext> contextWithLocale(
+    WidgetTester tester,
+    Locale locale,
+  ) async {
+    late BuildContext captured;
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: locale,
+        localizationsDelegates: MapsLocalizations.localizationsDelegates,
+        supportedLocales: MapsLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            captured = context;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    return captured;
+  }
+
+  const bareEngine = MapLibreEngine(styleString: 'https://example.com/style');
+
+  group('MapLibreEngine.localizedName default', () {
+    testWidgets('is localized for Spanish', (tester) async {
+      final context = await contextWithLocale(tester, const Locale('es'));
+      expect(bareEngine.localizedName(context), 'Mapa vectorial (MapLibre)');
+    });
+
+    testWidgets('keeps the historical English text', (tester) async {
+      final context = await contextWithLocale(tester, const Locale('en'));
+      expect(bareEngine.localizedName(context), 'Vector (MapLibre)');
+    });
+
+    testWidgets('displayName still wins over the localized default', (
+      tester,
+    ) async {
+      const engine = MapLibreEngine(
+        styleString: 'https://example.com/style',
+        displayName: 'Liberty',
+      );
+      final context = await contextWithLocale(tester, const Locale('es'));
+      expect(engine.localizedName(context), 'Liberty');
+    });
+
+    testWidgets('nameBuilder wins over everything', (tester) async {
+      final engine = MapLibreEngine(
+        styleString: 'https://example.com/style',
+        displayName: 'Liberty',
+        nameBuilder: (_) => 'Ciudad',
+      );
+      final context = await contextWithLocale(tester, const Locale('es'));
+      expect(engine.localizedName(context), 'Ciudad');
+    });
+  });
+}

--- a/packages/trufi_core_ui/lib/l10n/core_de.arb
+++ b/packages/trufi_core_ui/lib/l10n/core_de.arb
@@ -16,6 +16,7 @@
   "errorInitialization": "App konnte nicht initialisiert werden",
   "actionRetry": "Erneut versuchen",
   "errorPageNotFound": "Seite nicht gefunden",
+  "errorNoScreensRegistered": "Keine Bildschirme registriert",
   "actionGoHome": "Zur Startseite",
   "titleError": "Fehler",
   "unreadCount": "{count} ungelesen",

--- a/packages/trufi_core_ui/lib/l10n/core_en.arb
+++ b/packages/trufi_core_ui/lib/l10n/core_en.arb
@@ -75,6 +75,10 @@
   "@errorPageNotFound": {
     "description": "Error message for 404 pages"
   },
+  "errorNoScreensRegistered": "No screens registered",
+  "@errorNoScreensRegistered": {
+    "description": "Shown on the default home route when the app was configured with no screens"
+  },
 
   "actionGoHome": "Go Home",
   "@actionGoHome": {

--- a/packages/trufi_core_ui/lib/l10n/core_es.arb
+++ b/packages/trufi_core_ui/lib/l10n/core_es.arb
@@ -16,6 +16,7 @@
   "errorInitialization": "Error al inicializar la aplicación",
   "actionRetry": "Reintentar",
   "errorPageNotFound": "Página no encontrada",
+  "errorNoScreensRegistered": "No hay pantallas registradas",
   "actionGoHome": "Ir al inicio",
   "titleError": "Error",
   "unreadCount": "{count} sin leer",

--- a/packages/trufi_core_ui/lib/src/app_initializer/default_init_screen.dart
+++ b/packages/trufi_core_ui/lib/src/app_initializer/default_init_screen.dart
@@ -85,11 +85,21 @@ class _DefaultInitScreenState extends State<DefaultInitScreen>
     return _steps.indexOf(widget.currentStep!);
   }
 
-  /// Resolves [CoreLocalizations], falling back to English when this screen
-  /// is mounted without the CoreLocalizations delegate registered.
-  CoreLocalizations get _l10n =>
-      Localizations.of<CoreLocalizations>(context, CoreLocalizations) ??
-      lookupCoreLocalizations(const Locale('en'));
+  /// Resolves [CoreLocalizations], falling back to the ambient locale — or
+  /// English when that locale is unsupported — when this screen is mounted
+  /// without the CoreLocalizations delegate registered.
+  CoreLocalizations get _l10n {
+    final scoped = Localizations.of<CoreLocalizations>(
+      context,
+      CoreLocalizations,
+    );
+    if (scoped != null) return scoped;
+    final locale = Localizations.maybeLocaleOf(context);
+    if (locale != null && CoreLocalizations.delegate.isSupported(locale)) {
+      return lookupCoreLocalizations(locale);
+    }
+    return lookupCoreLocalizations(const Locale('en'));
+  }
 
   String _stepToDisplayText(AppInitStep step) {
     if (widget.stepTextBuilder != null) {

--- a/packages/trufi_core_ui/lib/src/l10n/core_localizations.dart
+++ b/packages/trufi_core_ui/lib/src/l10n/core_localizations.dart
@@ -190,6 +190,12 @@ abstract class CoreLocalizations {
   /// **'Page not found'**
   String get errorPageNotFound;
 
+  /// Shown on the default home route when the app was configured with no screens
+  ///
+  /// In en, this message translates to:
+  /// **'No screens registered'**
+  String get errorNoScreensRegistered;
+
   /// Go to home page button
   ///
   /// In en, this message translates to:

--- a/packages/trufi_core_ui/lib/src/l10n/core_localizations_de.dart
+++ b/packages/trufi_core_ui/lib/src/l10n/core_localizations_de.dart
@@ -55,6 +55,9 @@ class CoreLocalizationsDe extends CoreLocalizations {
   String get errorPageNotFound => 'Seite nicht gefunden';
 
   @override
+  String get errorNoScreensRegistered => 'Keine Bildschirme registriert';
+
+  @override
   String get actionGoHome => 'Zur Startseite';
 
   @override

--- a/packages/trufi_core_ui/lib/src/l10n/core_localizations_en.dart
+++ b/packages/trufi_core_ui/lib/src/l10n/core_localizations_en.dart
@@ -54,6 +54,9 @@ class CoreLocalizationsEn extends CoreLocalizations {
   String get errorPageNotFound => 'Page not found';
 
   @override
+  String get errorNoScreensRegistered => 'No screens registered';
+
+  @override
   String get actionGoHome => 'Go Home';
 
   @override

--- a/packages/trufi_core_ui/lib/src/l10n/core_localizations_es.dart
+++ b/packages/trufi_core_ui/lib/src/l10n/core_localizations_es.dart
@@ -54,6 +54,9 @@ class CoreLocalizationsEs extends CoreLocalizations {
   String get errorPageNotFound => 'Página no encontrada';
 
   @override
+  String get errorNoScreensRegistered => 'No hay pantallas registradas';
+
+  @override
   String get actionGoHome => 'Ir al inicio';
 
   @override

--- a/packages/trufi_core_ui/lib/src/router/app_router.dart
+++ b/packages/trufi_core_ui/lib/src/router/app_router.dart
@@ -75,8 +75,12 @@ class AppRouter {
       );
     }).toList();
 
-    // Add the /route deep link handler to the routes list
+    // Add the /route deep link handler to the routes list. The fallback
+    // home is keyed on the screen-derived routes: the deep-link handler
+    // below is always present, so `allRoutes` itself is never empty and
+    // '/' would otherwise 404 in a screen-less app.
     final allRoutes = [
+      if (routes.isEmpty) _defaultHomeRoute(),
       ...routes,
       // Special route for web deep linking (shared routes)
       GoRoute(
@@ -118,7 +122,7 @@ class AppRouter {
               child: child,
             );
           },
-          routes: allRoutes.isEmpty ? [_defaultHomeRoute()] : allRoutes,
+          routes: allRoutes,
         ),
       ],
       errorBuilder: (context, state) => ErrorScreen(error: state.error),
@@ -165,14 +169,20 @@ class AppShell extends StatelessWidget {
     this.logo,
   });
 
+  /// First screen matching [test], the first screen otherwise, or null
+  /// when the app has no screens at all (the fallback-home case).
+  TrufiScreen? _findScreen(bool Function(TrufiScreen) test) {
+    for (final s in screens) {
+      if (test(s)) return s;
+    }
+    return screens.isEmpty ? null : screens.first;
+  }
+
   @override
   Widget build(BuildContext context) {
     // Verificar si la pantalla actual tiene su propio AppBar
-    final currentScreen = screens.firstWhere(
-      (s) => s.path == currentPath,
-      orElse: () => screens.first,
-    );
-    final hasOwnAppBar = currentScreen.hasOwnAppBar;
+    final currentScreen = _findScreen((s) => s.path == currentPath);
+    final hasOwnAppBar = currentScreen?.hasOwnAppBar ?? false;
 
     return Scaffold(
       appBar: hasOwnAppBar
@@ -186,11 +196,10 @@ class AppShell extends StatelessWidget {
                   icon: const Icon(Icons.info_outline),
                   tooltip: CoreLocalizations.of(context).navAbout,
                   onPressed: () {
-                    final aboutScreen = screens.firstWhere(
-                      (s) => s.id == 'about',
-                      orElse: () => screens.first,
-                    );
-                    _navigateToSection(context, aboutScreen.path);
+                    final aboutScreen = _findScreen((s) => s.id == 'about');
+                    if (aboutScreen != null) {
+                      _navigateToSection(context, aboutScreen.path);
+                    }
                   },
                 ),
               ],

--- a/packages/trufi_core_ui/lib/src/router/app_router.dart
+++ b/packages/trufi_core_ui/lib/src/router/app_router.dart
@@ -130,8 +130,9 @@ class AppRouter {
     return GoRoute(
       path: '/',
       name: 'home',
-      builder: (context, state) =>
-          const Center(child: Text('No screens registered')),
+      builder: (context, state) => Center(
+        child: Text(CoreLocalizations.of(context).errorNoScreensRegistered),
+      ),
     );
   }
 

--- a/packages/trufi_core_ui/test/app_router_no_screens_test.dart
+++ b/packages/trufi_core_ui/test/app_router_no_screens_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
+import 'package:trufi_core_ui/src/l10n/core_localizations.dart';
+import 'package:trufi_core_ui/src/router/app_router.dart';
+
+/// An app configured with zero screens must land on the fallback home —
+/// not 404 on '/'. The deep-link route is always registered, so the
+/// fallback has to key on the screen-derived routes, and its text must be
+/// localized (#945).
+void main() {
+  Widget appWithNoScreens(Locale locale) {
+    return ChangeNotifierProvider(
+      create: (_) => SharedRouteNotifier(),
+      child: MaterialApp.router(
+        locale: locale,
+        supportedLocales: CoreLocalizations.supportedLocales,
+        localizationsDelegates: CoreLocalizations.localizationsDelegates,
+        routerConfig: AppRouter(screens: const []).router,
+      ),
+    );
+  }
+
+  testWidgets('zero screens lands on the fallback home, localized', (
+    tester,
+  ) async {
+    await tester.pumpWidget(appWithNoScreens(const Locale('es')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No hay pantallas registradas'), findsOneWidget);
+    expect(find.text('Página no encontrada'), findsNothing);
+  });
+
+  testWidgets('the fallback home is English for English apps', (tester) async {
+    await tester.pumpWidget(appWithNoScreens(const Locale('en')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No screens registered'), findsOneWidget);
+  });
+}

--- a/packages/trufi_core_ui/test/app_router_no_screens_test.dart
+++ b/packages/trufi_core_ui/test/app_router_no_screens_test.dart
@@ -10,14 +10,14 @@ import 'package:trufi_core_ui/src/router/app_router.dart';
 /// fallback has to key on the screen-derived routes, and its text must be
 /// localized (#945).
 void main() {
-  Widget appWithNoScreens(Locale locale) {
+  Widget appWithNoScreens(Locale locale, {AppRouter? appRouter}) {
     return ChangeNotifierProvider(
       create: (_) => SharedRouteNotifier(),
       child: MaterialApp.router(
         locale: locale,
         supportedLocales: CoreLocalizations.supportedLocales,
         localizationsDelegates: CoreLocalizations.localizationsDelegates,
-        routerConfig: AppRouter(screens: const []).router,
+        routerConfig: (appRouter ?? AppRouter(screens: const [])).router,
       ),
     );
   }
@@ -37,5 +37,20 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('No screens registered'), findsOneWidget);
+  });
+
+  testWidgets('the /route deep link still redirects onto the fallback home', (
+    tester,
+  ) async {
+    final appRouter = AppRouter(screens: const []);
+    await tester.pumpWidget(
+      appWithNoScreens(const Locale('es'), appRouter: appRouter),
+    );
+    await tester.pumpAndSettle();
+
+    appRouter.router.go('/route');
+    await tester.pumpAndSettle();
+
+    expect(find.text('No hay pantallas registradas'), findsOneWidget);
   });
 }

--- a/packages/trufi_core_ui/test/default_init_screen_l10n_test.dart
+++ b/packages/trufi_core_ui/test/default_init_screen_l10n_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_ui/src/app_initializer/default_init_screen.dart';
+import 'package:trufi_core_ui/src/l10n/core_localizations.dart';
+
+/// DefaultInitScreen renders before app initialization completes, so it can
+/// be mounted without the CoreLocalizations delegate. Its fallback must
+/// follow the ambient locale instead of always speaking English (#945).
+void main() {
+  Widget appWithoutCoreDelegate(Locale locale) {
+    return MaterialApp(
+      locale: locale,
+      supportedLocales: [locale],
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      home: DefaultInitScreen(onRetry: () {}),
+    );
+  }
+
+  group('CoreLocalizations fallback without the delegate registered', () {
+    testWidgets('a Spanish app shows Spanish, not English', (tester) async {
+      await tester.pumpWidget(appWithoutCoreDelegate(const Locale('es')));
+      await tester.pump();
+
+      expect(find.text('Cargando...'), findsOneWidget);
+      expect(find.text('Loading...'), findsNothing);
+    });
+
+    testWidgets('an unsupported locale falls back to English', (tester) async {
+      await tester.pumpWidget(appWithoutCoreDelegate(const Locale('fr')));
+      await tester.pump();
+
+      expect(find.text('Loading...'), findsOneWidget);
+    });
+
+    testWidgets('the error state follows the ambient locale too', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('es'),
+          supportedLocales: const [Locale('es')],
+          localizationsDelegates: const [
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          home: DefaultInitScreen(errorMessage: 'boom', onRetry: () {}),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('No se pudo iniciar'), findsOneWidget);
+    });
+  });
+
+  group('with the delegate registered (the normal path)', () {
+    testWidgets('the registered delegate wins', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          locale: const Locale('de'),
+          supportedLocales: CoreLocalizations.supportedLocales,
+          localizationsDelegates: CoreLocalizations.localizationsDelegates,
+          home: DefaultInitScreen(onRetry: () {}),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Laden...'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #945 — the last batch of the N-language audit: the remaining fixed-language literals, plus two latent crashes the evidence pass exposed.

## What

- **Init screen** (`trufi_core_ui`): the `CoreLocalizations` fallback used when the delegate isn't registered yet now resolves the ambient locale first, English only for unsupported locales — early-boot text follows the app language.
- **Screen-less fallback home** (`trufi_core_ui`): two fixes in one path.
  - `'No screens registered'` is now a localized key (`errorNoScreensRegistered`, en/es/de).
  - The route was **unreachable**: the `/route` deep-link handler is always registered, so `allRoutes.isEmpty` never held and a zero-screen app 404'd on `/`. The fallback is now keyed on the screen-derived routes. Making it reachable exposed a latent `StateError` in `AppShell` (`orElse: () => screens.first`) — unreachable on `main` because the 404 rendered outside the shell — so the shell's screen lookups are now null-safe too.
- **MapLibre engine** (`trufi_core_maps`): `localizedName` no longer falls back to the hardcoded English `'Vector (MapLibre)'` — new `vectorMapName` key (en/es/de), mirroring the existing `localizedDescription`/`vectorMapDescription` pattern.
- **Dead code** (`trufi_core_interfaces`): `LocationModel`/`Geometry` removed — unused across the workspace and downstream apps; their only user-visible artifact was the untranslatable `'Not description'` literal.
- **Docs**: `docs/l10n-standards.md` gains an "Adding a new language" section (the N-language model + the intl/Photon/OTP traps from this audit).

## Evidence (Android emulator, example app)

| Case | Before | After |
|---|---|---|
| Engine picker, app in Spanish | title **"Vector (MapLibre)"** in English over a Spanish description | "Mapa vectorial (MapLibre)" |
| Engine picker, app in English | "Vector (MapLibre)" | identical — no behavior change |
| App built with zero screens | **404 ErrorScreen** ("GoException: no routes for location: /") | fallback home renders, localized |

## Tests

- `default_init_screen_l10n_test.dart`: ambient-locale fallback (es), unsupported-locale fallback (fr→en), delegate-registered path (de).
- `app_router_no_screens_test.dart`: zero-screen app lands on the fallback home (es + en), not the 404.
- `maplibre_engine_l10n_test.dart`: localized default (es/en), `displayName` and `nameBuilder` precedence.
- Full suites: `trufi_core_ui` 16/16, `trufi_core_maps` 44/44; workspace run green (CI runs `melos ci:test` since #966).

Note for v5.21 release notes: `LocationModel`/`Geometry` removal is technically breaking for `trufi_core_interfaces`, but no consumer exists (verified in-repo and in trufi-app/trufi-sanaa).
