### PR TITLE
Re-extract offline map assets when the app build changes

### DIFF
--- a/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
+++ b/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
@@ -101,14 +101,15 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
     return targetPath;
   }
 
-  /// Identifier of the app build the extraction belongs to. Falls back to
-  /// a constant when package info is unavailable (e.g. plain unit tests),
-  /// which degrades to the old extract-once behavior.
-  Future<String> _appBuildStamp() async {
+  /// Identifier of the app build the extraction belongs to, or null when
+  /// package info is unavailable (e.g. plain unit tests, a transient
+  /// platform-channel failure). Null means "can't tell" — the caller keeps
+  /// whatever extraction exists rather than flapping between wipes.
+  Future<String?> _appBuildStamp() async {
     try {
       return await PackageInfoPlatform.fullVersion();
     } catch (_) {
-      return 'unknown';
+      return null;
     }
   }
 
@@ -135,7 +136,9 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
       final extractedFor = await marker.exists()
           ? await marker.readAsString()
           : null;
-      if (extractedFor != buildStamp) {
+      // A null stamp means the build is unknowable right now: keep the
+      // existing extraction instead of wiping on guesswork.
+      if (buildStamp != null && extractedFor != buildStamp) {
         await offlineDir.delete(recursive: true);
       }
     }
@@ -244,7 +247,9 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
 
     // Stamp last: a crash mid-extraction leaves no marker, so the next
     // boot wipes the partial copy and starts over.
-    await marker.writeAsString(buildStamp);
+    if (buildStamp != null) {
+      await marker.writeAsString(buildStamp);
+    }
 
     _cachedStylePath = stylePath;
     _initialized = true;

--- a/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
+++ b/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:trufi_core_utils/packge_info_platform.dart';
 
 import '../../../l10n/maps_localizations.dart';
 import '../../domain/controller/map_controller.dart';
@@ -100,6 +101,17 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
     return targetPath;
   }
 
+  /// Identifier of the app build the extraction belongs to. Falls back to
+  /// a constant when package info is unavailable (e.g. plain unit tests),
+  /// which degrades to the old extract-once behavior.
+  Future<String> _appBuildStamp() async {
+    try {
+      return await PackageInfoPlatform.fullVersion();
+    } catch (_) {
+      return 'unknown';
+    }
+  }
+
   @override
   Future<void> initialize() async {
     if (_initialized && _cachedStylePath != null) return;
@@ -111,6 +123,22 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
 
     final cacheDir = await getApplicationCacheDirectory();
     final offlineDir = Directory('${cacheDir.path}/offline_maps/$id');
+
+    // The extraction is tied to the app build. [_copyAsset] skips files
+    // that already exist, so without this stamp an app update shipping
+    // new offline assets (tiles, style, glyphs) would keep serving the
+    // old extraction forever — only clearing app data refreshed it
+    // (#973). On mismatch — update or downgrade — wipe and re-extract.
+    final marker = File('${offlineDir.path}/.extracted-for');
+    final buildStamp = await _appBuildStamp();
+    if (await offlineDir.exists()) {
+      final extractedFor = await marker.exists()
+          ? await marker.readAsString()
+          : null;
+      if (extractedFor != buildStamp) {
+        await offlineDir.delete(recursive: true);
+      }
+    }
     await offlineDir.create(recursive: true);
 
     final mbtilesPath = await _copyAsset(
@@ -213,6 +241,10 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
 
     final stylePath = '${offlineDir.path}/style.json';
     await File(stylePath).writeAsString(json.encode(style));
+
+    // Stamp last: a crash mid-extraction leaves no marker, so the next
+    // boot wipes the partial copy and starts over.
+    await marker.writeAsString(buildStamp);
 
     _cachedStylePath = stylePath;
     _initialized = true;

--- a/packages/trufi_core_maps/pubspec.yaml
+++ b/packages/trufi_core_maps/pubspec.yaml
@@ -38,6 +38,11 @@ dependencies:
 dev_dependencies:
   # used by the choose-on-map widget test to provide MapEngineManager
   provider: ^6.1.2
+  # used by the offline-refresh test to stamp fake builds and fake the
+  # cache directory (#973)
+  package_info_plus: ^10.0.0
+  path_provider_platform_interface: ^2.1.0
+  plugin_platform_interface: ^2.1.0
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0

--- a/packages/trufi_core_maps/test/offline_engine_refresh_test.dart
+++ b/packages/trufi_core_maps/test/offline_engine_refresh_test.dart
@@ -1,0 +1,124 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:trufi_core_maps/trufi_core_maps.dart';
+
+/// #973: the offline extraction must follow app updates. _copyAsset skips
+/// existing files, so the extraction is stamped with the app build and
+/// wiped on mismatch — otherwise users keep the old tiles/style/glyphs
+/// until they clear app data.
+class _FakePathProvider extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProvider(this.root);
+  final String root;
+
+  @override
+  Future<String?> getApplicationCachePath() async => root;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late Map<String, ByteData> assets;
+
+  OfflineMapLibreEngine makeEngine() => OfflineMapLibreEngine(
+    engineId: 'test_engine',
+    displayName: 'Test',
+    displayDescription: 'Test',
+    config: OfflineMapConfig(
+      mbtilesAsset: 'assets/test.mbtiles',
+      styleAsset: 'assets/style.json',
+      spritesAssetDir: 'assets/sprites/',
+      fontsAssetDir: 'assets/fonts/',
+      fontMapping: const {},
+      fontRanges: const [],
+    ),
+  );
+
+  ByteData bytes(String s) => ByteData.sublistView(utf8.encoder.convert(s));
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('offline-refresh-');
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+    assets = {
+      'assets/test.mbtiles': bytes('tiles-v1'),
+      'assets/style.json': bytes('{"version":8,"sources":{},"layers":[]}'),
+    };
+    TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockMessageHandler('flutter/assets', (message) async {
+          final key = utf8.decode(message!.buffer.asUint8List(
+            message.offsetInBytes,
+            message.lengthInBytes,
+          ));
+          return assets[key];
+        });
+    PackageInfo.setMockInitialValues(
+      appName: 'test',
+      packageName: 'test',
+      version: '1.0.0',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+  });
+
+  tearDown(() async {
+    await tempDir.delete(recursive: true);
+  });
+
+  File extractedTiles() =>
+      File('${tempDir.path}/offline_maps/test_engine/tiles.mbtiles');
+  File markerFile() =>
+      File('${tempDir.path}/offline_maps/test_engine/.extracted-for');
+
+  test('first boot extracts and stamps the build', () async {
+    await makeEngine().initialize();
+
+    expect(extractedTiles().readAsStringSync(), 'tiles-v1');
+    expect(markerFile().readAsStringSync(), '1.0.0+1');
+  });
+
+  test('same build keeps the existing extraction (no useless rework)',
+      () async {
+    await makeEngine().initialize();
+    assets['assets/test.mbtiles'] = bytes('tiles-v2');
+
+    await makeEngine().initialize();
+
+    expect(extractedTiles().readAsStringSync(), 'tiles-v1');
+  });
+
+  test('app update wipes and re-extracts the new assets', () async {
+    await makeEngine().initialize();
+    assets['assets/test.mbtiles'] = bytes('tiles-v2');
+    PackageInfo.setMockInitialValues(
+      appName: 'test',
+      packageName: 'test',
+      version: '1.0.1',
+      buildNumber: '2',
+      buildSignature: '',
+    );
+
+    await makeEngine().initialize();
+
+    expect(extractedTiles().readAsStringSync(), 'tiles-v2');
+    expect(markerFile().readAsStringSync(), '1.0.1+2');
+  });
+
+  test('a pre-fix extraction (no marker) is wiped once and stamped',
+      () async {
+    final legacy = extractedTiles();
+    legacy.createSync(recursive: true);
+    legacy.writeAsStringSync('tiles-legacy');
+
+    await makeEngine().initialize();
+
+    expect(extractedTiles().readAsStringSync(), 'tiles-v1');
+    expect(markerFile().readAsStringSync(), '1.0.0+1');
+  });
+}

--- a/packages/trufi_core_utils/lib/packge_info_platform.dart
+++ b/packages/trufi_core_utils/lib/packge_info_platform.dart
@@ -21,4 +21,12 @@ class PackageInfoPlatform {
     final info = await PackageInfo.fromPlatform();
     return info.appName;
   }
+
+  /// `version+buildNumber` (e.g. `5.2.0+81`) — changes on every release,
+  /// including build-only bumps, so it can stamp on-disk caches that must
+  /// be refreshed when the app updates.
+  static Future<String> fullVersion() async {
+    final info = await PackageInfo.fromPlatform();
+    return '${info.version}+${info.buildNumber}';
+  }
 }


### PR DESCRIPTION
Fixes #973.

## The bug, precisely

`OfflineMapLibreEngine` copies the **mbtiles, sprites and glyph PBFs** into the app cache with `_copyAsset`, which returns early when the target exists — so those never refresh after an app update. (The **style** was the one exception: it's re-read from the bundle and rewritten on every boot.) Existing users kept old tiles and fonts until they cleared app data — hit in practice by trufi-sanaa#4, where the Arabic glyph fix was invisible on update-in-place.

## The fix

The extraction is stamped with the app's `version+buildNumber` (`.extracted-for` marker, written only after a complete extraction). On mismatch — update, downgrade, or a pre-fix extraction with no marker — the engine deletes its folder and re-extracts. Same build → untouched, no wasted I/O. A crash mid-extraction leaves no marker, so the next boot starts over instead of serving a partial copy.

`trufi_core_utils` gains `PackageInfoPlatform.fullVersion()` (`5.2.0+81`-style).

## Evidence

**Unit tests** (4, all passing): first-boot stamp · same-build reuse · update wipes and re-extracts · legacy no-marker extraction upgraded once.

**On-device, both ways** (example app; mbtiles content changed between v1.0.0+1 and v1.0.0+2, verified via `run-as` md5 of the extracted file):

| | APK ships | extracted after update |
|---|---|---|
| main | `cf5057fe…` | `0aab80d8…` (stale) ❌ |
| this PR | `cf5057fe…` | `cf5057fe…` + marker `1.0.0+2` ✅ |

Zero exceptions in logcat; suites green (utils 32/32, maps 48/48 incl. the 4 new).

## Impact

Every offline city app (Sana'a, and Cochabamba mobile's offline maps) picks this up on its next core bump — map data updates finally reach users through normal app updates.