### PR TITLE
Content-aware offline extraction + shared tile sets

### DIFF
--- a/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
+++ b/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
@@ -112,13 +112,21 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
   @visibleForTesting
   static void resetBundleHashCacheForTesting() => _bundleHashMemo.clear();
 
+  /// In-band token for "this asset is not in the bundle". Safe by
+  /// construction: real hashes are lowercase hex, and this token contains
+  /// non-hex letters, so it can never collide with one. It is data, not
+  /// control flow — the only consumer concatenates it into the
+  /// fingerprint, where absence must be representable so that adding or
+  /// removing an asset between builds changes the fingerprint.
+  static const _missingAssetToken = 'missing';
+
   static Future<String> _bundleAssetHash(String assetPath) {
     return _bundleHashMemo.putIfAbsent(assetPath, () async {
       try {
         final data = await rootBundle.load(assetPath);
         return _fnv1a(data.buffer.asUint8List());
       } catch (_) {
-        return 'missing';
+        return _missingAssetToken;
       }
     });
   }

--- a/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
+++ b/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
@@ -103,30 +103,23 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
 
   /// Per-asset content hash, memoized for the process lifetime so several
   /// engines sharing assets (e.g. four styles over one mbtiles) hash each
-  /// bundle asset at most once per run. Missing assets hash to a fixed
-  /// token, so "asset removed" also reads as a content change.
-  static final Map<String, Future<String>> _bundleHashMemo = {};
+  /// bundle asset at most once per run. Null means the asset is not in
+  /// the bundle — absence is part of the fingerprint, so adding or
+  /// removing an asset between builds reads as a content change.
+  static final Map<String, Future<String?>> _bundleHashMemo = {};
 
   /// Tests simulate app updates by swapping mocked assets within one
   /// process; production never needs this (a new build is a new process).
   @visibleForTesting
   static void resetBundleHashCacheForTesting() => _bundleHashMemo.clear();
 
-  /// In-band token for "this asset is not in the bundle". Safe by
-  /// construction: real hashes are lowercase hex, and this token contains
-  /// non-hex letters, so it can never collide with one. It is data, not
-  /// control flow — the only consumer concatenates it into the
-  /// fingerprint, where absence must be representable so that adding or
-  /// removing an asset between builds changes the fingerprint.
-  static const _missingAssetToken = 'missing';
-
-  static Future<String> _bundleAssetHash(String assetPath) {
+  static Future<String?> _bundleAssetHash(String assetPath) {
     return _bundleHashMemo.putIfAbsent(assetPath, () async {
       try {
         final data = await rootBundle.load(assetPath);
         return _fnv1a(data.buffer.asUint8List());
       } catch (_) {
-        return _missingAssetToken;
+        return null;
       }
     });
   }
@@ -147,19 +140,23 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
   /// only when the app build changed (or on first install) — never on a
   /// routine boot.
   Future<String> _bundleFingerprint() async {
+    // Absence must stay representable in the fingerprint text ('-' is not
+    // a hex digit, so it cannot collide with a real hash).
+    Future<String> part(String name, String assetPath) async =>
+        '$name:${await _bundleAssetHash(assetPath) ?? '-'}';
+
     final parts = <String>[];
-    parts.add('tiles:${await _bundleAssetHash(config.mbtilesAsset)}');
-    parts.add('style:${await _bundleAssetHash(config.styleAsset)}');
+    parts.add(await part('tiles', config.mbtilesAsset));
+    parts.add(await part('style', config.styleAsset));
     for (final spriteFile in _spriteFiles) {
       parts.add(
-        '$spriteFile:'
-        '${await _bundleAssetHash('${config.spritesAssetDir}$spriteFile')}',
+        await part(spriteFile, '${config.spritesAssetDir}$spriteFile'),
       );
     }
     for (final assetFontName in config.fontMapping.keys) {
       for (final range in config.fontRanges) {
         final path = '${config.fontsAssetDir}$assetFontName/$range.pbf';
-        parts.add('$assetFontName/$range:${await _bundleAssetHash(path)}');
+        parts.add(await part('$assetFontName/$range', path));
       }
     }
     return _fnv1a(utf8.encode(parts.join('|')));
@@ -199,14 +196,17 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
         return tilesFile.path;
       }
       final bundleHash = await _bundleAssetHash(config.mbtilesAsset);
-      if (await hashFile.readAsString() == bundleHash) {
+      if (bundleHash != null && await hashFile.readAsString() == bundleHash) {
         return tilesFile.path;
       }
     }
     await tilesFile.parent.create(recursive: true);
     final data = await rootBundle.load(config.mbtilesAsset);
-    await tilesFile.writeAsBytes(data.buffer.asUint8List(), flush: true);
-    await hashFile.writeAsString(await _bundleAssetHash(config.mbtilesAsset));
+    final bytes = data.buffer.asUint8List();
+    await tilesFile.writeAsBytes(bytes, flush: true);
+    // Hash the bytes just written — single read, and immune to a stale
+    // memoized failure.
+    await hashFile.writeAsString(_fnv1a(bytes));
     return tilesFile.path;
   }
 

--- a/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
+++ b/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
@@ -101,6 +101,100 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
     return targetPath;
   }
 
+  /// Per-asset content hash, memoized for the process lifetime so several
+  /// engines sharing assets (e.g. four styles over one mbtiles) hash each
+  /// bundle asset at most once per run. Missing assets hash to a fixed
+  /// token, so "asset removed" also reads as a content change.
+  static final Map<String, Future<String>> _bundleHashMemo = {};
+
+  /// Tests simulate app updates by swapping mocked assets within one
+  /// process; production never needs this (a new build is a new process).
+  @visibleForTesting
+  static void resetBundleHashCacheForTesting() => _bundleHashMemo.clear();
+
+  static Future<String> _bundleAssetHash(String assetPath) {
+    return _bundleHashMemo.putIfAbsent(assetPath, () async {
+      try {
+        final data = await rootBundle.load(assetPath);
+        return _fnv1a(data.buffer.asUint8List());
+      } catch (_) {
+        return 'missing';
+      }
+    });
+  }
+
+  /// FNV-1a, masked to 63 bits so the hex form is stable on the VM.
+  /// Non-cryptographic on purpose: the question is "did the bundled file
+  /// change between app builds", not adversarial integrity.
+  static String _fnv1a(Uint8List bytes) {
+    var h = 0xcbf29ce484222325 & 0x7fffffffffffffff;
+    for (final b in bytes) {
+      h ^= b;
+      h = (h * 0x100000001b3) & 0x7fffffffffffffff;
+    }
+    return h.toRadixString(16);
+  }
+
+  /// Fingerprint of every bundled asset this engine extracts. Computed
+  /// only when the app build changed (or on first install) — never on a
+  /// routine boot.
+  Future<String> _bundleFingerprint() async {
+    final parts = <String>[];
+    parts.add('tiles:${await _bundleAssetHash(config.mbtilesAsset)}');
+    parts.add('style:${await _bundleAssetHash(config.styleAsset)}');
+    for (final spriteFile in _spriteFiles) {
+      parts.add(
+        '$spriteFile:'
+        '${await _bundleAssetHash('${config.spritesAssetDir}$spriteFile')}',
+      );
+    }
+    for (final assetFontName in config.fontMapping.keys) {
+      for (final range in config.fontRanges) {
+        final path = '${config.fontsAssetDir}$assetFontName/$range.pbf';
+        parts.add('$assetFontName/$range:${await _bundleAssetHash(path)}');
+      }
+    }
+    return _fnv1a(Uint8List.fromList(parts.join('|').codeUnits));
+  }
+
+  static const _spriteFiles = [
+    'sprite.json',
+    'sprite.png',
+    'sprite@2x.json',
+    'sprite@2x.png',
+  ];
+
+  /// The mbtiles is extracted once per *asset*, not once per engine:
+  /// several visual styles typically share one tile set, and duplicating
+  /// a tens-of-MB file per style quadrupled both the cache footprint and
+  /// the post-update re-extraction (Cochabamba: 4 styles × 25.8 MB).
+  /// The copy carries a sibling `.hash` so a changed bundle refreshes it.
+  Future<String> _ensureSharedTiles(
+    Directory mapsRoot, {
+    required bool verifyContent,
+  }) async {
+    final key = config.mbtilesAsset.replaceAll(RegExp('[^A-Za-z0-9._-]'), '_');
+    final tilesFile = File('${mapsRoot.path}/_shared/$key');
+    final hashFile = File('${tilesFile.path}.hash');
+
+    if (await tilesFile.exists() && await hashFile.exists()) {
+      if (!verifyContent) {
+        // Routine boot: the engine marker already vouches for the bundle
+        // content — do not read megabytes just to re-prove it.
+        return tilesFile.path;
+      }
+      final bundleHash = await _bundleAssetHash(config.mbtilesAsset);
+      if (await hashFile.readAsString() == bundleHash) {
+        return tilesFile.path;
+      }
+    }
+    await tilesFile.parent.create(recursive: true);
+    final data = await rootBundle.load(config.mbtilesAsset);
+    await tilesFile.writeAsBytes(data.buffer.asUint8List(), flush: true);
+    await hashFile.writeAsString(await _bundleAssetHash(config.mbtilesAsset));
+    return tilesFile.path;
+  }
+
   /// Identifier of the app build the extraction belongs to, or null when
   /// package info is unavailable (e.g. plain unit tests, a transient
   /// platform-channel failure). Null means "can't tell" — the caller keeps
@@ -123,31 +217,67 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
     if (_initialized && _cachedStylePath != null) return _cachedStylePath!;
 
     final cacheDir = await getApplicationCacheDirectory();
-    final offlineDir = Directory('${cacheDir.path}/offline_maps/$id');
+    final mapsRoot = Directory('${cacheDir.path}/offline_maps');
+    final offlineDir = Directory('${mapsRoot.path}/$id');
 
-    // The extraction is tied to the app build. [_copyAsset] skips files
-    // that already exist, so without this stamp an app update shipping
-    // new offline assets (tiles, style, glyphs) would keep serving the
-    // old extraction forever — only clearing app data refreshed it
-    // (#973). On mismatch — update or downgrade — wipe and re-extract.
+    // The extraction is invalidated by CONTENT, gated by the app build:
+    //
+    // - Routine boot (build matches the marker): reuse everything, no
+    //   hashing, no I/O beyond one marker read.
+    // - First boot after an update/downgrade (build differs): fingerprint
+    //   the bundled assets (a few seconds of reads, no writes). Most
+    //   updates don't touch map assets — identical fingerprint keeps the
+    //   extraction and only restamps the marker. Only a real asset change
+    //   pays the wipe + re-extraction (#973).
+    // - No/legacy marker: extract from scratch.
+    //
+    // Marker format: line 1 = build stamp, line 2 = bundle fingerprint.
     final marker = File('${offlineDir.path}/.extracted-for');
     final buildStamp = await _appBuildStamp();
-    if (await offlineDir.exists()) {
-      final extractedFor = await marker.exists()
-          ? await marker.readAsString()
-          : null;
-      // A null stamp means the build is unknowable right now: keep the
-      // existing extraction instead of wiping on guesswork.
-      if (buildStamp != null && extractedFor != buildStamp) {
-        await offlineDir.delete(recursive: true);
+
+    String? markerBuild;
+    String? markerFingerprint;
+    if (await marker.exists()) {
+      final lines = (await marker.readAsString()).split('\n');
+      markerBuild = lines.isNotEmpty ? lines[0] : null;
+      if (lines.length > 1) markerFingerprint = lines[1];
+    }
+
+    var reuseExtraction = false;
+    String? fingerprint;
+    if (markerBuild != null && buildStamp != null) {
+      if (markerBuild == buildStamp) {
+        reuseExtraction = true;
+      } else {
+        fingerprint = await _bundleFingerprint();
+        if (markerFingerprint == fingerprint) {
+          // Update that didn't touch the map assets: keep everything,
+          // just record the new build so the next boot is cheap again.
+          await marker.writeAsString('$buildStamp\n$fingerprint');
+          reuseExtraction = true;
+        }
       }
+    } else if (await offlineDir.exists() && buildStamp == null) {
+      // Build unknowable right now: keep the existing extraction instead
+      // of wiping on guesswork.
+      reuseExtraction = true;
+    }
+
+    if (!reuseExtraction && await offlineDir.exists()) {
+      await offlineDir.delete(recursive: true);
     }
     await offlineDir.create(recursive: true);
 
-    final mbtilesPath = await _copyAsset(
-      config.mbtilesAsset,
-      '${offlineDir.path}/tiles.mbtiles',
+    final mbtilesPath = await _ensureSharedTiles(
+      mapsRoot,
+      verifyContent: !reuseExtraction,
     );
+    // Pre-dedup extractions left a per-engine copy of the tile set —
+    // reclaim the space once.
+    final legacyTiles = File('${offlineDir.path}/tiles.mbtiles');
+    if (await legacyTiles.exists()) {
+      await legacyTiles.delete();
+    }
 
     final spritesDir = '${offlineDir.path}/sprites';
     await Directory(spritesDir).create(recursive: true);
@@ -246,9 +376,12 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
     await File(stylePath).writeAsString(json.encode(style));
 
     // Stamp last: a crash mid-extraction leaves no marker, so the next
-    // boot wipes the partial copy and starts over.
-    if (buildStamp != null) {
-      await marker.writeAsString(buildStamp);
+    // boot wipes the partial copy and starts over. Routine boots and
+    // fingerprint-matched updates never reach a state that needs
+    // restamping here.
+    if (!reuseExtraction && buildStamp != null) {
+      fingerprint ??= await _bundleFingerprint();
+      await marker.writeAsString('$buildStamp\n$fingerprint');
     }
 
     _cachedStylePath = stylePath;

--- a/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
+++ b/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
@@ -126,7 +126,7 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
   /// FNV-1a, masked to 63 bits so the hex form is stable on the VM.
   /// Non-cryptographic on purpose: the question is "did the bundled file
   /// change between app builds", not adversarial integrity.
-  static String _fnv1a(Uint8List bytes) {
+  static String _fnv1a(List<int> bytes) {
     var h = 0xcbf29ce484222325 & 0x7fffffffffffffff;
     for (final b in bytes) {
       h ^= b;
@@ -154,7 +154,7 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
         parts.add('$assetFontName/$range:${await _bundleAssetHash(path)}');
       }
     }
-    return _fnv1a(Uint8List.fromList(parts.join('|').codeUnits));
+    return _fnv1a(utf8.encode(parts.join('|')));
   }
 
   static const _spriteFiles = [
@@ -173,7 +173,14 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
     Directory mapsRoot, {
     required bool verifyContent,
   }) async {
-    final key = config.mbtilesAsset.replaceAll(RegExp('[^A-Za-z0-9._-]'), '_');
+    // The readable part can collide after sanitization ('a b' vs 'a_b'),
+    // and a silent collision would render another asset's tiles — the
+    // raw-path hash suffix makes the key injective.
+    final readable = config.mbtilesAsset.replaceAll(
+      RegExp('[^A-Za-z0-9._-]'),
+      '_',
+    );
+    final key = '$readable-${_fnv1a(utf8.encode(config.mbtilesAsset))}';
     final tilesFile = File('${mapsRoot.path}/_shared/$key');
     final hashFile = File('${tilesFile.path}.hash');
 
@@ -222,8 +229,9 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
 
     // The extraction is invalidated by CONTENT, gated by the app build:
     //
-    // - Routine boot (build matches the marker): reuse everything, no
-    //   hashing, no I/O beyond one marker read.
+    // - Routine boot (build matches the marker): reuse everything — no
+    //   hashing; only the marker read plus the pre-existing per-boot work
+    //   (style rewrite, copy-if-missing self-healing).
     // - First boot after an update/downgrade (build differs): fingerprint
     //   the bundled assets (a few seconds of reads, no writes). Most
     //   updates don't touch map assets — identical fingerprint keeps the

--- a/packages/trufi_core_maps/test/offline_engine_refresh_test.dart
+++ b/packages/trufi_core_maps/test/offline_engine_refresh_test.dart
@@ -81,8 +81,18 @@ void main() {
     await tempDir.delete(recursive: true);
   });
 
-  File sharedTiles() =>
-      File('${tempDir.path}/offline_maps/_shared/assets_test.mbtiles');
+  // The shared key carries a raw-path hash suffix (collision hardening),
+  // so tests discover the file instead of hardcoding the name.
+  File sharedTiles() {
+    final dir = Directory('${tempDir.path}/offline_maps/_shared');
+    if (!dir.existsSync()) return File('${dir.path}/absent');
+    return dir
+            .listSync()
+            .whereType<File>()
+            .where((f) => !f.path.endsWith('.hash'))
+            .firstOrNull ??
+        File('${dir.path}/absent');
+  }
   File markerFile([String id = 'test_engine']) =>
       File('${tempDir.path}/offline_maps/$id/.extracted-for');
   File engineTiles([String id = 'test_engine']) =>

--- a/packages/trufi_core_maps/test/offline_engine_refresh_test.dart
+++ b/packages/trufi_core_maps/test/offline_engine_refresh_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -8,10 +9,11 @@ import 'package:path_provider_platform_interface/path_provider_platform_interfac
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:trufi_core_maps/trufi_core_maps.dart';
 
-/// #973: the offline extraction must follow app updates. _copyAsset skips
-/// existing files, so the extraction is stamped with the app build and
-/// wiped on mismatch — otherwise users keep the old tiles/style/glyphs
-/// until they clear app data.
+/// #973 + content-aware refinement: the extraction is invalidated by the
+/// bundled assets' CONTENT, gated by the app build. Most app updates
+/// don't touch map assets — those must keep the extraction untouched.
+/// The mbtiles is also deduplicated across engines (one copy per asset,
+/// not per style).
 class _FakePathProvider extends PathProviderPlatform
     with MockPlatformInterfaceMixin {
   _FakePathProvider(this.root);
@@ -27,98 +29,147 @@ void main() {
   late Directory tempDir;
   late Map<String, ByteData> assets;
 
-  OfflineMapLibreEngine makeEngine() => OfflineMapLibreEngine(
-    engineId: 'test_engine',
-    displayName: 'Test',
-    displayDescription: 'Test',
-    config: OfflineMapConfig(
-      mbtilesAsset: 'assets/test.mbtiles',
-      styleAsset: 'assets/style.json',
-      spritesAssetDir: 'assets/sprites/',
-      fontsAssetDir: 'assets/fonts/',
-      fontMapping: const {},
-      fontRanges: const [],
-    ),
-  );
+  OfflineMapLibreEngine makeEngine([String id = 'test_engine']) =>
+      OfflineMapLibreEngine(
+        engineId: id,
+        displayName: 'Test',
+        displayDescription: 'Test',
+        config: OfflineMapConfig(
+          mbtilesAsset: 'assets/test.mbtiles',
+          styleAsset: 'assets/style.json',
+          spritesAssetDir: 'assets/sprites/',
+          fontsAssetDir: 'assets/fonts/',
+          fontMapping: const {},
+          fontRanges: const [],
+        ),
+      );
 
   ByteData bytes(String s) => ByteData.sublistView(utf8.encoder.convert(s));
+
+  void setBuild(String version, String buildNumber) {
+    PackageInfo.setMockInitialValues(
+      appName: 'test',
+      packageName: 'test',
+      version: version,
+      buildNumber: buildNumber,
+      buildSignature: '',
+    );
+  }
 
   setUp(() async {
     tempDir = await Directory.systemTemp.createTemp('offline-refresh-');
     PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+    OfflineMapLibreEngine.resetBundleHashCacheForTesting();
     assets = {
       'assets/test.mbtiles': bytes('tiles-v1'),
-      'assets/style.json': bytes('{"version":8,"sources":{},"layers":[]}'),
+      'assets/style.json': bytes('{"version":8,"sources":{"omt":{"type":"vector","tiles":["x"]}},"layers":[]}'),
     };
     TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
         .setMockMessageHandler('flutter/assets', (message) async {
-          final key = utf8.decode(message!.buffer.asUint8List(
-            message.offsetInBytes,
-            message.lengthInBytes,
-          ));
+          final key = utf8.decode(
+            message!.buffer.asUint8List(
+              message.offsetInBytes,
+              message.lengthInBytes,
+            ),
+          );
           return assets[key];
         });
-    PackageInfo.setMockInitialValues(
-      appName: 'test',
-      packageName: 'test',
-      version: '1.0.0',
-      buildNumber: '1',
-      buildSignature: '',
-    );
+    setBuild('1.0.0', '1');
   });
 
   tearDown(() async {
     await tempDir.delete(recursive: true);
   });
 
-  File extractedTiles() =>
-      File('${tempDir.path}/offline_maps/test_engine/tiles.mbtiles');
-  File markerFile() =>
-      File('${tempDir.path}/offline_maps/test_engine/.extracted-for');
+  File sharedTiles() =>
+      File('${tempDir.path}/offline_maps/_shared/assets_test.mbtiles');
+  File markerFile([String id = 'test_engine']) =>
+      File('${tempDir.path}/offline_maps/$id/.extracted-for');
+  File engineTiles([String id = 'test_engine']) =>
+      File('${tempDir.path}/offline_maps/$id/tiles.mbtiles');
 
-  test('first boot extracts and stamps the build', () async {
+  test('first boot extracts one shared tile set and stamps build+content',
+      () async {
     await makeEngine().initialize();
 
-    expect(extractedTiles().readAsStringSync(), 'tiles-v1');
-    expect(markerFile().readAsStringSync(), '1.0.0+1');
+    expect(sharedTiles().readAsStringSync(), 'tiles-v1');
+    expect(engineTiles().existsSync(), isFalse,
+        reason: 'no per-engine tile copy anymore');
+    final lines = markerFile().readAsStringSync().split('\n');
+    expect(lines[0], '1.0.0+1');
+    expect(lines[1], isNotEmpty, reason: 'content fingerprint recorded');
   });
 
-  test('same build keeps the existing extraction (no useless rework)',
+  test('routine boot (same build) touches nothing even if assets differ',
       () async {
     await makeEngine().initialize();
     assets['assets/test.mbtiles'] = bytes('tiles-v2');
+    OfflineMapLibreEngine.resetBundleHashCacheForTesting();
 
     await makeEngine().initialize();
 
-    expect(extractedTiles().readAsStringSync(), 'tiles-v1');
+    expect(sharedTiles().readAsStringSync(), 'tiles-v1',
+        reason: 'same build = fast path, by design');
   });
 
-  test('app update wipes and re-extracts the new assets', () async {
+  test('update WITHOUT asset changes keeps the extraction (the common case)',
+      () async {
+    await makeEngine().initialize();
+    // Sentinel proves the file is not rewritten.
+    sharedTiles().writeAsStringSync('disk-sentinel');
+    setBuild('1.0.1', '2');
+    OfflineMapLibreEngine.resetBundleHashCacheForTesting();
+
+    await makeEngine().initialize();
+
+    expect(sharedTiles().readAsStringSync(), 'disk-sentinel',
+        reason: 'identical bundle fingerprint must not re-extract');
+    expect(markerFile().readAsStringSync().split('\n')[0], '1.0.1+2',
+        reason: 'marker restamped so the next boot is cheap again');
+  });
+
+  test('update WITH changed assets wipes and re-extracts', () async {
     await makeEngine().initialize();
     assets['assets/test.mbtiles'] = bytes('tiles-v2');
-    PackageInfo.setMockInitialValues(
-      appName: 'test',
-      packageName: 'test',
-      version: '1.0.1',
-      buildNumber: '2',
-      buildSignature: '',
-    );
+    setBuild('1.1.0', '3');
+    OfflineMapLibreEngine.resetBundleHashCacheForTesting();
 
     await makeEngine().initialize();
 
-    expect(extractedTiles().readAsStringSync(), 'tiles-v2');
-    expect(markerFile().readAsStringSync(), '1.0.1+2');
+    expect(sharedTiles().readAsStringSync(), 'tiles-v2');
+    expect(markerFile().readAsStringSync().split('\n')[0], '1.1.0+3');
   });
 
-  test('a pre-fix extraction (no marker) is wiped once and stamped',
+  test('legacy layout (single-line marker + per-engine tiles) migrates',
       () async {
-    final legacy = extractedTiles();
+    final legacy = engineTiles();
     legacy.createSync(recursive: true);
     legacy.writeAsStringSync('tiles-legacy');
+    markerFile().writeAsStringSync('0.9.0+9');
 
     await makeEngine().initialize();
 
-    expect(extractedTiles().readAsStringSync(), 'tiles-v1');
-    expect(markerFile().readAsStringSync(), '1.0.0+1');
+    expect(sharedTiles().readAsStringSync(), 'tiles-v1');
+    expect(engineTiles().existsSync(), isFalse,
+        reason: 'legacy per-engine copy reclaimed');
+    expect(markerFile().readAsStringSync(), contains('\n'),
+        reason: 'marker upgraded to build+fingerprint format');
+  });
+
+  test('several engines over one mbtiles share a single copy', () async {
+    await makeEngine('style_a').initialize();
+    await makeEngine('style_b').initialize();
+
+    expect(sharedTiles().existsSync(), isTrue);
+    expect(engineTiles('style_a').existsSync(), isFalse);
+    expect(engineTiles('style_b').existsSync(), isFalse);
+
+    for (final id in ['style_a', 'style_b']) {
+      final style =
+          json.decode(File('${tempDir.path}/offline_maps/$id/style.json')
+              .readAsStringSync()) as Map<String, dynamic>;
+      expect(json.encode(style['sources']), contains('_shared'),
+          reason: '$id must point at the shared tile set');
+    }
   });
 }


### PR DESCRIPTION
Refines #975 after the maintainer's design review of the update story: *most app updates don't touch map assets — the engine should detect whether re-extraction is needed at all*.

## What changes

**1. Content fingerprint, gated by build.** The `.extracted-for` marker now stores `build\nfingerprint`. Routine boots read one marker and do nothing else (no hashing — the design constraint). The first boot after an update fingerprints the bundled assets (reads only, memoized per asset per process); identical fingerprint → keep everything, restamp, done. Only real asset changes wipe and re-extract.

**2. One tile set per asset, not per engine.** Visual styles share their mbtiles; extracting a copy per style quadrupled cache and update cost. Tiles now live in `offline_maps/_shared/<asset>` with a content-hash sidecar; styles point at the shared file; legacy per-engine copies are deleted on first contact.

## Measured (example app, 4 styles over one 25.8 MB mbtiles, emulator; baseline boot 12 s)

| scenario | v5.22 today | this PR |
|---|---|---|
| routine boot | baseline | baseline (unchanged) |
| update, maps untouched *(the common case)* | full re-extraction: ~107 MB of writes | **+4 s of reads, zero writes** |
| update with new maps | ~107 MB | **+7 s, ~26 MB** (one copy) — verified: shared file's md5 == new bundle |
| permanent cache | **107 MB** | **33 MB** |

## Tests (6, in `offline_engine_refresh_test.dart`)

First-boot stamp+layout · same-build fast path (documents that assets aren't rehashed) · **update-without-changes keeps extraction and restamps** (sentinel file proves no rewrite) · update-with-changes re-extracts · legacy single-line-marker + per-engine-tiles migration · two engines share one tile copy and both styles reference it. Full maps suite 50/50; analyze clean.