### PR TITLE
JS-representable fingerprint hash + web-compile CI guard

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -37,6 +37,13 @@ jobs:
         # Until now the check only analyzed — a green check ran no tests
         # (issue #756).
         run: melos ci:test
+      - name: Web compile check
+        # dart2js compiles ALL reachable code, with stricter rules than
+        # the VM (e.g. 64-bit integer literals don't exist in JS). Tests
+        # and analyze both run on the VM, so a change can be green here
+        # yet break `flutter build web` for every downstream app — which
+        # is exactly what happened with v5.22.1's fingerprint hash.
+        run: cd apps/example && flutter build web --release
       - name: Translation Check
         run: |
           melos run l10n --no-select

--- a/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
+++ b/packages/trufi_core_maps/lib/src/configuration/map_engine/offline_maplibre_engine.dart
@@ -124,16 +124,30 @@ class OfflineMapLibreEngine implements ITrufiMapEngine {
     });
   }
 
-  /// FNV-1a, masked to 63 bits so the hex form is stable on the VM.
+  /// 32-bit multiply modulo 2^32 with no intermediate above 2^53, so the
+  /// result is identical on the VM and under dart2js. The engine never
+  /// RUNS on web, but web builds must COMPILE every reachable line —
+  /// 64-bit integer literals broke `flutter build web` for every app
+  /// importing this package.
+  static int _mul32(int a, int b) {
+    final hi = (((a >>> 16) & 0xffff) * b) & 0xffff;
+    final lo = (a & 0xffff) * b;
+    return ((hi << 16) + lo) & 0xffffffff;
+  }
+
+  /// Two independent 32-bit FNV-1a streams concatenated: 64 bits of
+  /// change-detection using only JS-representable arithmetic.
   /// Non-cryptographic on purpose: the question is "did the bundled file
   /// change between app builds", not adversarial integrity.
   static String _fnv1a(List<int> bytes) {
-    var h = 0xcbf29ce484222325 & 0x7fffffffffffffff;
+    var h1 = 0x811c9dc5;
+    var h2 = 0xcbf29ce4;
     for (final b in bytes) {
-      h ^= b;
-      h = (h * 0x100000001b3) & 0x7fffffffffffffff;
+      h1 = _mul32(h1 ^ b, 0x01000193);
+      h2 = _mul32(h2 ^ b ^ 0x5f, 0x01000193);
     }
-    return h.toRadixString(16);
+    return h1.toRadixString(16).padLeft(8, '0') +
+        h2.toRadixString(16).padLeft(8, '0');
   }
 
   /// Fingerprint of every bundled asset this engine extracts. Computed


### PR DESCRIPTION
**v5.22.1 is broken for web builds** — caught by trufi-app's deploy build, not by any check:

```
Error: The integer literal 0xcbf29ce484222325 can't be represented exactly in JavaScript.
```

dart2js compiles all reachable code with JS number semantics; the offline engine never *runs* on web, but it must *compile* there. VM tests, analyze and three adversarial reviews were all green because none of them invoke dart2js.

## Fix
The fingerprint hash is now **two independent 32-bit FNV-1a streams** (same 64 bits of change-discrimination) over a JS-safe 32-bit multiply with no intermediate above 2^53 — identical results on VM and web by construction. Hashes are opaque values compared for equality, so nothing else changes; suite 50/50.

## Prevention
CI gains a **web-compile step** (`flutter build web` on the example app): the exact failure mode — green on VM, broken on dart2js — now fails the check before it can reach a tag. Verified locally: the example web build passes on this branch and fails on v5.22.1.

Ships as **v5.22.2**; the app bumps follow immediately (v5.22.1 should be considered web-broken).