### PR TITLE
Fix: live vehicles vanished during search in hybrid deploys (feed-prefix mismatch)

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -1526,13 +1526,20 @@ class _HomeScreenState extends State<HomeScreen>
     if (_realtimeVehiclesProvider != null &&
         _liveVehiclesEnabled.value &&
         _liveVehicles.isNotEmpty) {
-      final toShow = _selectedTransitRouteIds.isEmpty
+      // Feed-agnostic matching: itinerary legs may come from a bundled-GTFS
+      // planner (`1132`) while vehicles come from OTP (`1:1132`) — strict
+      // equality here made every bus vanish the moment a search was active
+      // in hybrid deploys (Lima pilot regression, caught by Sam).
+      final selected = _selectedTransitRouteIds
+          .map(stripGtfsFeedPrefix)
+          .toSet();
+      final toShow = selected.isEmpty
           ? _liveVehicles
           : _liveVehicles
                 .where(
                   (v) =>
                       v.routeId != null &&
-                      _selectedTransitRouteIds.contains(v.routeId),
+                      selected.contains(stripGtfsFeedPrefix(v.routeId!)),
                 )
                 .toList(growable: false);
       if (toShow.isNotEmpty) {

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/live_vehicle_info_panel.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/live_vehicle_info_panel.dart
@@ -25,11 +25,8 @@ class LiveVehicleInfoPanel extends StatelessWidget {
 
   /// GTFS ids arrive as `<feedId>:<id>` (e.g. `1:1132`); the feed prefix
   /// means nothing to a rider.
-  static String displayRoute(String? routeId) {
-    if (routeId == null || routeId.isEmpty) return '';
-    final colon = routeId.indexOf(':');
-    return colon >= 0 ? routeId.substring(colon + 1) : routeId;
-  }
+  static String displayRoute(String? routeId) =>
+      routeId == null ? '' : stripGtfsFeedPrefix(routeId);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/trufi_core_interfaces/lib/src/models/realtime_vehicles_provider.dart
+++ b/packages/trufi_core_interfaces/lib/src/models/realtime_vehicles_provider.dart
@@ -22,16 +22,46 @@ abstract class RealtimeVehiclesProvider {
   void stop();
 }
 
+/// Strips the OTP feed prefix (`<feedId>:<id>`) from a GTFS id.
+///
+/// Different sources disagree on the prefix: OTP's GraphQL emits `1:1132`
+/// while a bundled-GTFS planner emits plain `1132` for the same route, so
+/// any realtime-vs-itinerary route matching must be feed-agnostic or a
+/// hybrid deploy (local routing + OTP vehicles, like the Lima pilot)
+/// silently matches nothing. Within one deploy all feeds belong to one
+/// city, so bare-id collisions across feeds are not a practical concern.
+String stripGtfsFeedPrefix(String gtfsId) {
+  final colon = gtfsId.indexOf(':');
+  return colon >= 0 ? gtfsId.substring(colon + 1) : gtfsId;
+}
+
 /// Convenience queries computed on top of [RealtimeVehiclesProvider.latest].
+/// All route matching is feed-prefix agnostic — see [stripGtfsFeedPrefix].
 extension RealtimeVehiclesProviderQueries on RealtimeVehiclesProvider {
-  List<VehiclePosition> vehiclesForRoute(String routeGtfsId) => latest
-      .where((v) => v.routeId == routeGtfsId)
-      .toList(growable: false);
+  List<VehiclePosition> vehiclesForRoute(String routeGtfsId) {
+    final want = stripGtfsFeedPrefix(routeGtfsId);
+    return latest
+        .where(
+          (v) => v.routeId != null && stripGtfsFeedPrefix(v.routeId!) == want,
+        )
+        .toList(growable: false);
+  }
 
-  List<VehiclePosition> vehiclesForRoutes(Set<String> routeGtfsIds) => latest
-      .where((v) => v.routeId != null && routeGtfsIds.contains(v.routeId))
-      .toList(growable: false);
+  List<VehiclePosition> vehiclesForRoutes(Set<String> routeGtfsIds) {
+    final want = routeGtfsIds.map(stripGtfsFeedPrefix).toSet();
+    return latest
+        .where(
+          (v) =>
+              v.routeId != null &&
+              want.contains(stripGtfsFeedPrefix(v.routeId!)),
+        )
+        .toList(growable: false);
+  }
 
-  bool hasDataForRoute(String routeGtfsId) =>
-      latest.any((v) => v.routeId == routeGtfsId);
+  bool hasDataForRoute(String routeGtfsId) {
+    final want = stripGtfsFeedPrefix(routeGtfsId);
+    return latest.any(
+      (v) => v.routeId != null && stripGtfsFeedPrefix(v.routeId!) == want,
+    );
+  }
 }

--- a/packages/trufi_core_interfaces/test/route_matching_test.dart
+++ b/packages/trufi_core_interfaces/test/route_matching_test.dart
@@ -67,6 +67,11 @@ void main() {
     test('hasDataForRoute powers the LIVE badge across prefixes', () {
       expect(provider.hasDataForRoute('1132'), isTrue);
       expect(provider.hasDataForRoute('1:1132'), isTrue);
+      // The fixture only carries '1:1185' — this is the assert that FAILS
+      // under strict equality (review finding: without it, hasDataForRoute
+      // could regress and the suite would stay green because the other
+      // queries find literal matches in the mixed fixture).
+      expect(provider.hasDataForRoute('1185'), isTrue);
       expect(provider.hasDataForRoute('1481'), isFalse);
     });
 

--- a/packages/trufi_core_interfaces/test/route_matching_test.dart
+++ b/packages/trufi_core_interfaces/test/route_matching_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart';
+
+/// Regression: in a hybrid deploy (bundled-GTFS routing + OTP vehicles,
+/// the Lima pilot) itinerary legs carry `1132` while OTP vehicles carry
+/// `1:1132`. Strict-equality matching made every live bus disappear the
+/// moment a search was active, and killed the LIVE badge too.
+class _FakeProvider implements RealtimeVehiclesProvider {
+  _FakeProvider(this.latest);
+
+  @override
+  final List<VehiclePosition> latest;
+
+  @override
+  Stream<List<VehiclePosition>> get positionsStream => const Stream.empty();
+
+  @override
+  Future<void> start() async {}
+
+  @override
+  void stop() {}
+}
+
+VehiclePosition _vehicle(String id, String? routeId) => VehiclePosition(
+  vehicleId: id,
+  position: const TrufiLatLng(-12.0, -77.0),
+  routeId: routeId,
+);
+
+void main() {
+  test('stripGtfsFeedPrefix', () {
+    expect(stripGtfsFeedPrefix('1:1132'), '1132');
+    expect(stripGtfsFeedPrefix('1132'), '1132');
+    expect(stripGtfsFeedPrefix('otp-lima:1481'), '1481');
+  });
+
+  group('feed-agnostic route matching', () {
+    final provider = _FakeProvider([
+      _vehicle('A', '1:1132'),
+      _vehicle('B', '1132'),
+      _vehicle('C', '1:1185'),
+      _vehicle('D', null),
+    ]);
+
+    test('vehiclesForRoute matches across feed prefixes both ways', () {
+      expect(
+        provider.vehiclesForRoute('1132').map((v) => v.vehicleId),
+        ['A', 'B'],
+        reason: 'bare query id must match prefixed vehicle ids',
+      );
+      expect(
+        provider.vehiclesForRoute('1:1132').map((v) => v.vehicleId),
+        ['A', 'B'],
+        reason: 'prefixed query id must match bare vehicle ids',
+      );
+    });
+
+    test('vehiclesForRoutes with a mixed-prefix set', () {
+      expect(
+        provider
+            .vehiclesForRoutes({'1132', 'lima:1185'})
+            .map((v) => v.vehicleId),
+        ['A', 'B', 'C'],
+      );
+    });
+
+    test('hasDataForRoute powers the LIVE badge across prefixes', () {
+      expect(provider.hasDataForRoute('1132'), isTrue);
+      expect(provider.hasDataForRoute('1:1132'), isTrue);
+      expect(provider.hasDataForRoute('1481'), isFalse);
+    });
+
+    test('vehicles without route never match', () {
+      expect(
+        provider.vehiclesForRoute('').map((v) => v.vehicleId),
+        isEmpty,
+        reason: 'null routeId must not match an empty query',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Bug

In a hybrid deploy (bundled-GTFS routing + OTP-fed vehicles — the Lima pilot), starting a route search made **every live bus disappear** and killed the itinerary's LIVE badge. Reported live on the Lima app.

Cause: when results are shown, the home screen filters vehicles by the itinerary's route ids. Legs from the bundled planner carry bare ids (`1132`) while OTP's GraphQL emits feed-prefixed ones (`1:1132`); strict equality matches nothing. Regression from switching the live layer to OTP consumption (previously the endpoint-direct JSON used bare ids, which happened to match).

## Fix

`stripGtfsFeedPrefix()` in `trufi_core_interfaces` as the single normalization point, used by:
- the provider query extensions (`vehiclesForRoute`, `vehiclesForRoutes`, `hasDataForRoute` — the LIVE badge's source),
- the home screen's search-time vehicle filter,
- the info panel's `displayRoute`.

Within one deploy all feeds belong to one city, so bare-id collisions across feeds are not a practical concern (documented in the helper).

## Tests

5 new tests pin matching in both directions (bare↔prefixed, mixed sets, badge path, null routeId). Full workspace suite green (12 packages).

## Evidence

Lima app (local core override, checksum-verified install) against the production feed: with an active search, the 1132 buses render along the corridor **filtered to the itinerary's route**, and the LIVE dot is back on the leg pill. Zero exceptions.