### PR TITLE
Fix: five saved-place icons fell back to the default pin after saving

### DIFF
--- a/packages/screens/trufi_core_saved_places/lib/src/models/saved_place_icons.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/models/saved_place_icons.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+/// Single source of truth for the icons a custom saved place can carry.
+///
+/// The edit dialog offers every entry of [savedPlaceIcons] and the list tile
+/// resolves the persisted `iconName` through [savedPlaceRoundedIcon]. Keeping
+/// both surfaces on this one table is what guarantees that every icon a user
+/// can pick also renders back after saving (#985 — the selector and the tile
+/// used to keep separate lists, and the five keys missing from the tile fell
+/// back to the generic pin).
+class SavedPlaceIcon {
+  const SavedPlaceIcon(this.name, this.outlined, this.rounded);
+
+  /// Stable key persisted in `SavedPlace.iconName`. Never rename existing
+  /// keys: they live in the user's storage.
+  final String name;
+
+  /// Variant shown in the edit dialog selector.
+  final IconData outlined;
+
+  /// Variant shown in lists and tiles.
+  final IconData rounded;
+}
+
+/// Every icon offered by the edit dialog, in display order.
+const List<SavedPlaceIcon> savedPlaceIcons = [
+  SavedPlaceIcon('place', Icons.place_outlined, Icons.place_rounded),
+  SavedPlaceIcon('star', Icons.star_outline, Icons.star_rounded),
+  SavedPlaceIcon('favorite', Icons.favorite_outline, Icons.favorite_rounded),
+  SavedPlaceIcon('bookmark', Icons.bookmark_outline, Icons.bookmark_rounded),
+  SavedPlaceIcon('school', Icons.school_outlined, Icons.school_rounded),
+  SavedPlaceIcon(
+    'shopping',
+    Icons.shopping_bag_outlined,
+    Icons.shopping_bag_rounded,
+  ),
+  SavedPlaceIcon(
+    'restaurant',
+    Icons.restaurant_outlined,
+    Icons.restaurant_rounded,
+  ),
+  SavedPlaceIcon('cafe', Icons.coffee_outlined, Icons.coffee_rounded),
+  SavedPlaceIcon(
+    'gym',
+    Icons.fitness_center_outlined,
+    Icons.fitness_center_rounded,
+  ),
+  SavedPlaceIcon(
+    'hospital',
+    Icons.local_hospital_outlined,
+    Icons.local_hospital_rounded,
+  ),
+  SavedPlaceIcon('park', Icons.park_outlined, Icons.park_rounded),
+  SavedPlaceIcon('airport', Icons.flight_outlined, Icons.flight_rounded),
+  SavedPlaceIcon('train', Icons.train_outlined, Icons.train_rounded),
+  SavedPlaceIcon(
+    'bus',
+    Icons.directions_bus_outlined,
+    Icons.directions_bus_rounded,
+  ),
+  SavedPlaceIcon(
+    'parking',
+    Icons.local_parking_outlined,
+    Icons.local_parking_rounded,
+  ),
+  SavedPlaceIcon(
+    'gas',
+    Icons.local_gas_station_outlined,
+    Icons.local_gas_station_rounded,
+  ),
+];
+
+/// Resolves a persisted icon key to its list variant. Unknown or null keys
+/// fall back to the generic place pin.
+IconData savedPlaceRoundedIcon(String? name) {
+  for (final icon in savedPlaceIcons) {
+    if (icon.name == name) return icon.rounded;
+  }
+  return Icons.place_rounded;
+}

--- a/packages/screens/trufi_core_saved_places/lib/src/widgets/edit_place_dialog.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/widgets/edit_place_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../models/saved_place.dart';
+import '../models/saved_place_icons.dart';
 import '../../l10n/saved_places_localizations.dart';
 
 /// Callback to open a map picker and return coordinates.
@@ -76,24 +77,8 @@ class _EditPlaceDialogState extends State<EditPlaceDialog> {
   bool get _isEditing => widget.place != null;
   bool get _hasLocation => _latitude != 0.0 || _longitude != 0.0;
 
-  static const List<_IconOption> _iconOptions = [
-    _IconOption('place', Icons.place_outlined),
-    _IconOption('star', Icons.star_outline),
-    _IconOption('favorite', Icons.favorite_outline),
-    _IconOption('bookmark', Icons.bookmark_outline),
-    _IconOption('school', Icons.school_outlined),
-    _IconOption('shopping', Icons.shopping_bag_outlined),
-    _IconOption('restaurant', Icons.restaurant_outlined),
-    _IconOption('cafe', Icons.coffee_outlined),
-    _IconOption('gym', Icons.fitness_center_outlined),
-    _IconOption('hospital', Icons.local_hospital_outlined),
-    _IconOption('park', Icons.park_outlined),
-    _IconOption('airport', Icons.flight_outlined),
-    _IconOption('train', Icons.train_outlined),
-    _IconOption('bus', Icons.directions_bus_outlined),
-    _IconOption('parking', Icons.local_parking_outlined),
-    _IconOption('gas', Icons.local_gas_station_outlined),
-  ];
+  // Single source of truth shared with SavedPlaceTile — see #985.
+  static const List<SavedPlaceIcon> _iconOptions = savedPlaceIcons;
 
   @override
   void initState() {
@@ -148,7 +133,7 @@ class _EditPlaceDialogState extends State<EditPlaceDialog> {
       (o) => o.name == _selectedIcon,
       orElse: () => _iconOptions.first,
     );
-    return option.icon;
+    return option.outlined;
   }
 
   Color _getTypeColor() {
@@ -554,7 +539,7 @@ class _EditPlaceDialogState extends State<EditPlaceDialog> {
                         )
                       : null,
                   child: Icon(
-                    option.icon,
+                    option.outlined,
                     size: 22,
                     color: isSelected
                         ? theme.colorScheme.onPrimaryContainer
@@ -624,11 +609,4 @@ class _EditPlaceDialogState extends State<EditPlaceDialog> {
 
     widget.onSave(updatedPlace);
   }
-}
-
-class _IconOption {
-  final String name;
-  final IconData icon;
-
-  const _IconOption(this.name, this.icon);
 }

--- a/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_place_tile.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_place_tile.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../models/saved_place.dart';
+import '../models/saved_place_icons.dart';
 import '../../l10n/saved_places_localizations.dart';
 
 /// A tile widget for displaying a saved place with Material 3 design.
@@ -128,32 +129,8 @@ class SavedPlaceTile extends StatelessWidget {
     );
   }
 
-  IconData _getIconFromName(String? iconName) {
-    switch (iconName) {
-      case 'star':
-        return Icons.star_rounded;
-      case 'school':
-        return Icons.school_rounded;
-      case 'shopping':
-        return Icons.shopping_cart_rounded;
-      case 'restaurant':
-        return Icons.restaurant_rounded;
-      case 'gym':
-        return Icons.fitness_center_rounded;
-      case 'hospital':
-        return Icons.local_hospital_rounded;
-      case 'park':
-        return Icons.park_rounded;
-      case 'airport':
-        return Icons.flight_rounded;
-      case 'train':
-        return Icons.train_rounded;
-      case 'bus':
-        return Icons.directions_bus_rounded;
-      default:
-        return Icons.place_rounded;
-    }
-  }
+  IconData _getIconFromName(String? iconName) =>
+      savedPlaceRoundedIcon(iconName);
 
   String _getDisplayName(SavedPlacesLocalizations localization) {
     if (place.type == SavedPlaceType.home && !place.name.contains('_')) {

--- a/packages/screens/trufi_core_saved_places/lib/trufi_core_saved_places.dart
+++ b/packages/screens/trufi_core_saved_places/lib/trufi_core_saved_places.dart
@@ -31,6 +31,7 @@ library;
 
 // Models
 export 'src/models/saved_place.dart';
+export 'src/models/saved_place_icons.dart';
 
 // Repository
 export 'src/repository/saved_places_repository.dart';

--- a/packages/screens/trufi_core_saved_places/test/saved_place_icons_test.dart
+++ b/packages/screens/trufi_core_saved_places/test/saved_place_icons_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_saved_places/trufi_core_saved_places.dart';
+
+// #985: every icon the edit dialog offers must render back on the tile after
+// saving. The selector and the tile used to keep separate icon lists, and the
+// five keys missing from the tile ('favorite', 'bookmark', 'cafe', 'parking',
+// 'gas') silently fell back to the generic pin.
+
+SavedPlace _place(String? iconName) => SavedPlace(
+  id: 'id-$iconName',
+  name: 'Test place',
+  latitude: -17.39,
+  longitude: -66.16,
+  type: SavedPlaceType.other,
+  iconName: iconName,
+  createdAt: DateTime.utc(2026, 8, 14),
+);
+
+void main() {
+  test('every selectable icon resolves to its own rounded variant', () {
+    for (final icon in savedPlaceIcons) {
+      expect(
+        savedPlaceRoundedIcon(icon.name),
+        icon.rounded,
+        reason: "key '${icon.name}' must resolve to its rounded variant",
+      );
+    }
+  });
+
+  test('no selectable icon other than the pin falls back to the pin', () {
+    for (final icon in savedPlaceIcons.where((i) => i.name != 'place')) {
+      expect(
+        savedPlaceRoundedIcon(icon.name),
+        isNot(Icons.place_rounded),
+        reason: "key '${icon.name}' must not render as the default pin",
+      );
+    }
+  });
+
+  test('selectable icon keys are unique', () {
+    final names = savedPlaceIcons.map((i) => i.name).toSet();
+    expect(names.length, savedPlaceIcons.length);
+  });
+
+  test('unknown and null keys fall back to the pin', () {
+    expect(savedPlaceRoundedIcon('no-such-icon'), Icons.place_rounded);
+    expect(savedPlaceRoundedIcon(null), Icons.place_rounded);
+  });
+
+  testWidgets('SavedPlaceTile renders the icon the user picked', (
+    tester,
+  ) async {
+    for (final icon in savedPlaceIcons) {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [SavedPlacesLocalizations.delegate],
+          home: Scaffold(body: SavedPlaceTile(place: _place(icon.name))),
+        ),
+      );
+
+      expect(
+        find.byIcon(icon.rounded),
+        findsOneWidget,
+        reason: "tile with iconName '${icon.name}' must show ${icon.rounded}",
+      );
+    }
+  });
+
+  testWidgets('SavedPlaceTile falls back to the pin for unknown keys', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: const [SavedPlacesLocalizations.delegate],
+        home: Scaffold(body: SavedPlaceTile(place: _place('legacy-key'))),
+      ),
+    );
+
+    expect(find.byIcon(Icons.place_rounded), findsOneWidget);
+  });
+}

--- a/packages/screens/trufi_core_saved_places/test/saved_place_icons_test.dart
+++ b/packages/screens/trufi_core_saved_places/test/saved_place_icons_test.dart
@@ -43,6 +43,29 @@ void main() {
     expect(names.length, savedPlaceIcons.length);
   });
 
+  test('the key set is pinned — removing or renaming a key breaks storage', () {
+    // Keys live in the user's SharedPreferences: dropping one from the table
+    // silently sends already-saved places back to the pin (the #985 symptom).
+    expect(savedPlaceIcons.map((i) => i.name).toList(), const [
+      'place',
+      'star',
+      'favorite',
+      'bookmark',
+      'school',
+      'shopping',
+      'restaurant',
+      'cafe',
+      'gym',
+      'hospital',
+      'park',
+      'airport',
+      'train',
+      'bus',
+      'parking',
+      'gas',
+    ]);
+  });
+
   test('unknown and null keys fall back to the pin', () {
     expect(savedPlaceRoundedIcon('no-such-icon'), Icons.place_rounded);
     expect(savedPlaceRoundedIcon(null), Icons.place_rounded);


### PR DESCRIPTION
Closes #985

## Problem

Editing a place in "Your places" and picking **Heart, Bookmark/ribbon, Coffee, Parking or Gas station** saved fine but rendered back as the generic pin. The icon preview inside the dialog looked correct, which made it look like a save bug — it is not: the stored `iconName` was always right.

## Root cause

Two divergent sources of truth, both private, born in the same commit and never synchronized:

- `EditPlaceDialog._iconOptions` offers **16** keys.
- `SavedPlaceTile._getIconFromName` only knew **10** of them; the missing five (`favorite`, `bookmark`, `cafe`, `parking`, `gas`) fell into `default: Icons.place_rounded`.

Exact 1:1 match with the five icons reported in the issue. A sixth latent divergence: `shopping` showed a **bag** in the selector but a **cart** in the list.

## Fix

- New shared table `savedPlaceIcons` (`saved_place_icons.dart`): one entry per key with its outlined (selector) and rounded (list) variants, plus resolver `savedPlaceRoundedIcon()` with the pin as explicit fallback.
- The dialog and the tile now both consume that table; the private duplicate list and switch are gone.
- `shopping` unified to the bag variant on both surfaces (what the user picks is what they see).
- **No data migration needed**: storage was always correct, so places already saved with the affected icons render correctly as soon as this ships.

## Tests

New `saved_place_icons_test.dart` (6 tests, all failing on `main` for the affected keys):

- every selectable key resolves to its own rounded variant (mutation-checked: dropping any key kills 3 tests);
- no key other than `place` falls back to the pin; keys are unique;
- unknown/null keys fall back to the pin;
- **widget tests**: `SavedPlaceTile` renders the exact icon for each of the 16 keys, and the pin for a legacy/unknown key.

Package suite: 24/24 green. `flutter analyze`: clean.

## Follow-ups (out of scope, will file separately)

- The search screen ("Your places" inside the location search) drops `iconName` entirely when converting to `SearchLocation` — no custom icon ever shows there, including the 11 that worked. Deserves its own issue.
- `SavedPlace.copyWith` cannot clear `iconName` (uses `??`), harmless today but a latent trap.
