### PR TITLE
Fix: transfer legs lost geometry at repeated stops on circular lines

### DIFF
--- a/packages/trufi_core_planner/lib/src/services/gtfs_routing_service.dart
+++ b/packages/trufi_core_planner/lib/src/services/gtfs_routing_service.dart
@@ -26,6 +26,14 @@ class RoutingSegment {
   /// Computed in O(1) via the pattern's precomputed `cumDist`.
   final double transitDistance;
 
+  /// Board/alight positions in `pattern.stopIds`, recorded at build time.
+  /// `-1` when unknown (e.g. segments deserialized from JSON). They must be
+  /// carried instead of re-derived from the stop IDs: on patterns that visit
+  /// a stop twice (circular lines) `indexOfStop` returns the FIRST occurrence,
+  /// which is not necessarily the one this segment rides through (#986).
+  final int fromIdx;
+  final int toIdx;
+
   const RoutingSegment({
     required this.route,
     required this.fromStop,
@@ -36,6 +44,8 @@ class RoutingSegment {
     this.scheduledDuration,
     this.shapePoints = const [],
     this.transitDistance = 0,
+    this.fromIdx = -1,
+    this.toIdx = -1,
   });
 
   /// Stop IDs for this segment (derived from stops).
@@ -463,6 +473,8 @@ class GtfsRoutingService {
       pattern: pattern,
       transitDistance: transit,
       scheduledDuration: estDuration,
+      fromIdx: fromIdx,
+      toIdx: toIdx,
     );
   }
 
@@ -473,8 +485,16 @@ class GtfsRoutingService {
       originWalkDistance: path.originWalkDistance,
       originStop: path.originStop,
       segments: path.segments.map((seg) {
-        final fromIdx = seg.pattern.indexOfStop(seg.fromStop.id);
-        final toIdx = seg.pattern.indexOfStop(seg.toStop.id);
+        // Prefer the indices recorded at build time: re-deriving them from
+        // stop IDs picks the FIRST occurrence on the pattern, which breaks
+        // segments that board/alight at a repeated stop's later visit (#986 —
+        // the transfer leg lost its geometry and rendered as a straight line).
+        final fromIdx = seg.fromIdx >= 0
+            ? seg.fromIdx
+            : seg.pattern.indexOfStop(seg.fromStop.id);
+        final toIdx = seg.toIdx >= 0
+            ? seg.toIdx
+            : seg.pattern.indexOfStop(seg.toStop.id);
         if (fromIdx >= 0 && toIdx > fromIdx) {
           final ids = seg.pattern.stopIds.sublist(fromIdx, toIdx + 1);
           final stops = ids
@@ -499,6 +519,8 @@ class GtfsRoutingService {
             scheduledDuration: seg.scheduledDuration,
             shapePoints: shapePoints,
             transitDistance: seg.transitDistance,
+            fromIdx: fromIdx,
+            toIdx: toIdx,
           );
         }
         return seg;

--- a/packages/trufi_core_planner/test/repeated_stop_geometry_test.dart
+++ b/packages/trufi_core_planner/test/repeated_stop_geometry_test.dart
@@ -1,0 +1,126 @@
+import 'package:test/test.dart';
+import 'package:trufi_core_planner/trufi_core_planner.dart';
+
+void main() {
+  group('transfer at a repeated stop keeps its geometry (issue #986)', () {
+    // Circular line L visits stop X twice:
+    //   L: S1 → X → S3 → S4 → X → S6      (X at positions 1 and 4)
+    //   M: X → M2 → DEST                   (transfer line)
+    //
+    // Query: origin at S3 (position 2 on L), destination at DEST (only on M).
+    // There is no direct line, so the only itinerary is L → transfer at X → M.
+    //
+    // The valid transfer uses X's SECOND visit (position 4 > 2). The bug:
+    // `_resolvePathStops` re-derived the boarding/alighting indices from stop
+    // IDs via `indexOfStop`, which returns the FIRST occurrence (position 1),
+    // yielding toIdx(1) <= fromIdx(2) — the leg was returned with no stops and
+    // no shape, and the map rendered the itinerary as a straight line.
+    //
+    // Stops sit ~333 m apart (0.003° at the equator): with a 120 m walk
+    // limit the only stop near the origin is S3 and the only one near the
+    // destination is DEST — otherwise "walk to X, ride M" becomes a direct
+    // option and direct results suppress the transfer bucket entirely.
+    final stops = <String, GtfsStop>{
+      'S1': const GtfsStop(id: 'S1', name: 'S1', lat: 0, lon: 0),
+      'X': const GtfsStop(id: 'X', name: 'X', lat: 0, lon: 0.003),
+      'S3': const GtfsStop(id: 'S3', name: 'S3', lat: 0, lon: 0.006),
+      'S4': const GtfsStop(id: 'S4', name: 'S4', lat: 0, lon: 0.009),
+      // The circle comes back to X after S4; then continues to S6.
+      'S6': const GtfsStop(id: 'S6', name: 'S6', lat: 0.003, lon: 0.003),
+      'M2': const GtfsStop(id: 'M2', name: 'M2', lat: -0.003, lon: 0.003),
+      'DEST': const GtfsStop(id: 'DEST', name: 'DEST', lat: -0.006, lon: 0.003),
+    };
+
+    const routeL = GtfsRoute(
+      id: 'rL',
+      shortName: 'L',
+      longName: 'Circular L',
+      type: GtfsRouteType.bus,
+    );
+    const routeM = GtfsRoute(
+      id: 'rM',
+      shortName: 'M',
+      longName: 'M',
+      type: GtfsRouteType.bus,
+    );
+
+    const trips = [
+      GtfsTrip(id: 'tL', routeId: 'rL', serviceId: 's'),
+      GtfsTrip(id: 'tM', routeId: 'rM', serviceId: 's'),
+    ];
+
+    final stopTimes = <GtfsStopTime>[
+      const GtfsStopTime(tripId: 'tL', stopId: 'S1', stopSequence: 1),
+      const GtfsStopTime(tripId: 'tL', stopId: 'X', stopSequence: 2),
+      const GtfsStopTime(tripId: 'tL', stopId: 'S3', stopSequence: 3),
+      const GtfsStopTime(tripId: 'tL', stopId: 'S4', stopSequence: 4),
+      const GtfsStopTime(tripId: 'tL', stopId: 'X', stopSequence: 5),
+      const GtfsStopTime(tripId: 'tL', stopId: 'S6', stopSequence: 6),
+      const GtfsStopTime(tripId: 'tM', stopId: 'X', stopSequence: 1),
+      const GtfsStopTime(tripId: 'tM', stopId: 'M2', stopSequence: 2),
+      const GtfsStopTime(tripId: 'tM', stopId: 'DEST', stopSequence: 3),
+    ];
+
+    final data = GtfsData(
+      agencies: const [],
+      stops: stops,
+      routes: {'rL': routeL, 'rM': routeM},
+      trips: {for (final t in trips) t.id: t},
+      stopTimes: stopTimes,
+      calendars: const {},
+      calendarDates: const [],
+      frequencies: const [],
+      shapes: const {},
+    );
+
+    final service = GtfsRoutingService(
+      data: data,
+      spatialIndex: GtfsSpatialIndex(data.stops),
+      routeIndex: GtfsRouteIndex(data),
+    );
+
+    final paths = service.findRoutes(
+      origin: stops['S3']!.position,
+      destination: stops['DEST']!.position,
+      maxWalkDistance: 120,
+      maxResults: 50,
+    );
+
+    test('the L → M transfer itinerary exists', () {
+      expect(paths, isNotEmpty);
+      expect(
+        paths.any((p) => p.segments.length == 2),
+        isTrue,
+        reason: 'the only way from S3 to DEST is L → transfer at X → M',
+      );
+    });
+
+    test('every transit leg carries stops and geometry', () {
+      for (final p in paths) {
+        for (final seg in p.segments) {
+          expect(
+            seg.stops,
+            isNotEmpty,
+            reason:
+                'leg ${seg.route.shortName} ${seg.fromStop.id}→${seg.toStop.id} '
+                'lost its stops — the map would drop it and draw a straight line',
+          );
+          expect(
+            seg.shapePoints,
+            isNotEmpty,
+            reason:
+                'leg ${seg.route.shortName} ${seg.fromStop.id}→${seg.toStop.id} '
+                'lost its shape polyline',
+          );
+        }
+      }
+    });
+
+    test('the L leg rides S3 → S4 → X (the second visit), not backwards', () {
+      final transfer = paths.firstWhere((p) => p.segments.length == 2);
+      final legL = transfer.segments.first;
+      expect(legL.route.shortName, 'L');
+      expect(legL.stops.map((s) => s.id).toList(), ['S3', 'S4', 'X']);
+    });
+  });
+}


### PR DESCRIPTION
Addresses the client-side part of #986 (the intermittent "route renders as a straight line" report).

## Problem

With Trufi Planner as the routing engine, an itinerary's bus leg sometimes rendered as a straight line between origin and destination instead of following the streets. It only happened on itineraries **with a transfer**, and only for some origin/destination pairs — hence the "intermittent" feel.

## Root cause

Transfer candidates are enumerated from precomputed `PatternConnection`s, whose `myStopIdx`/`otherStopIdx` point at the **actual visit** of the shared stop within each pattern. Those indices are used to score and build the segment — but not stored. Later, `_resolvePathStops` (which attaches stops and shape geometry to the final top-N results) **re-derived** the board/alight positions from the stop IDs via `RoutePattern.indexOfStop`, which returns the **first occurrence** of a stop on the pattern.

On circular lines that visit a stop twice (common in the Cochabamba feed), a leg that boards after the shared stop's first visit re-derives to `toIdx <= fromIdx`, fails the sanity check, and is returned **with no stops and no shape**. The map layer skips legs with empty geometry, so only the two straight 2-point walk legs get drawn: a straight line from origin to destination.

Direct (0-transfer) itineraries were never affected because both endpoints are found with `indexOfStop` consistently.

## Fix

`RoutingSegment` now carries `fromIdx`/`toIdx` recorded at build time, and `_resolvePathStops` prefers them; the ID-based derivation remains only as a fallback for segments deserialized from JSON (which already come with resolved stops). No serialization changes — the remote planner server resolves geometry before serializing.

## Tests

New `repeated_stop_geometry_test.dart`: a synthetic circular feed (`S1 → X → S3 → S4 → X → S6` plus a transfer line at `X`) where the **only** possible itinerary transfers at the repeated stop's second visit:

- the transfer itinerary exists;
- every transit leg carries stops and shape geometry (fails on `main`: the L leg comes back empty);
- the L leg rides `S3 → S4 → X` — the second visit, not backwards.

Reverting the fix kills both geometry tests. Package suite: 18/18, `dart analyze` clean. `trufi_core_routing` suite: same result as `main` (the only failures on both are the pre-existing network-dependent OTP integration tests; CI runs no tests, verified locally).

## Not in scope (same issue, different causes)

- **Web showing fewer routes than mobile**: the deployed web planner server hardcodes `maxResults: 5` — that is trufi-server-planner#4 (same root cause as #929), a deploy, not core code.
- **Walk-only row as a straight line**: for pairs ≤ 1.5 km the planner inserts a walk-only itinerary whose polyline is by design a 2-point line (there is no pedestrian street routing in Trufi Planner). Behaves identically on web and mobile.
