### PR TITLE
Search: interleave sources and merge near-duplicates so places surface next to streets

### DIFF
--- a/packages/trufi_core_search_locations/lib/src/services/composite_search_location_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/composite_search_location_service.dart
@@ -15,9 +15,17 @@ import 'search_location_service.dart';
 /// - services are queried **concurrently**; a service that fails or times
 ///   out is skipped, so losing the network degrades to offline results
 ///   instead of an error screen;
-/// - results keep the order of [services] (put the offline one first if
-///   junctions should lead), deduplicated by coordinates so the same
-///   place found twice appears once;
+/// - results are **interleaved** round-robin across [services] (first
+///   result of each, then second of each, …) so no source can push the
+///   others below the fold — with streets offline and places online, the
+///   old source-by-source concatenation buried every place under up to
+///   ten street rows on a phone screen (#984). Ties inside a round keep
+///   the order of [services] (put the offline one first if junctions
+///   should lead);
+/// - duplicates are merged: same id, or same display name within
+///   [nearDuplicateEpsilon] — geocoders return the same POI or street
+///   several times a few blocks apart, and those near-copies used to eat
+///   the result budget (#984);
 /// - [reverse] returns the first non-null answer, in order.
 class CompositeSearchLocationService
     with SearchLocationDrillDown, LanguageAwareSearch
@@ -31,10 +39,15 @@ class CompositeSearchLocationService
   /// the same place when merging.
   final double dedupeEpsilon;
 
+  /// Results with the same display name closer than this (in degrees,
+  /// ~2e-3 ≈ 220 m) are treated as near-copies of one place and merged.
+  final double nearDuplicateEpsilon;
+
   CompositeSearchLocationService({
     required this.services,
     this.timeout = const Duration(seconds: 8),
     this.dedupeEpsilon = 1e-5,
+    this.nearDuplicateEpsilon = 2e-3,
   }) : assert(services.isNotEmpty, 'at least one service is required');
 
   @override
@@ -50,10 +63,17 @@ class CompositeSearchLocationService
 
     final perService = await Future.wait(futures);
     final merged = <SearchLocation>[];
-    for (final results in perService) {
-      for (final result in results) {
+    var round = 0;
+    var addedAny = true;
+    while (addedAny) {
+      addedAny = false;
+      for (final results in perService) {
+        if (round >= results.length) continue;
+        addedAny = true;
+        final result = results[round];
         if (!_alreadyPresent(merged, result)) merged.add(result);
       }
+      round++;
     }
     return merged;
   }
@@ -118,14 +138,17 @@ class CompositeSearchLocationService
   bool _alreadyPresent(List<SearchLocation> merged, SearchLocation candidate) {
     for (final existing in merged) {
       if (existing.id == candidate.id) return true;
-      final sameSpot =
-          (existing.latitude - candidate.latitude).abs() < dedupeEpsilon &&
-          (existing.longitude - candidate.longitude).abs() < dedupeEpsilon;
-      if (sameSpot &&
-          existing.displayName.toLowerCase() ==
-              candidate.displayName.toLowerCase()) {
-        return true;
-      }
+      final sameName =
+          existing.displayName.trim().toLowerCase() ==
+          candidate.displayName.trim().toLowerCase();
+      if (!sameName) continue;
+      final epsilon = nearDuplicateEpsilon > dedupeEpsilon
+          ? nearDuplicateEpsilon
+          : dedupeEpsilon;
+      final nearby =
+          (existing.latitude - candidate.latitude).abs() < epsilon &&
+          (existing.longitude - candidate.longitude).abs() < epsilon;
+      if (nearby) return true;
     }
     return false;
   }

--- a/packages/trufi_core_search_locations/lib/src/services/composite_search_location_service.dart
+++ b/packages/trufi_core_search_locations/lib/src/services/composite_search_location_service.dart
@@ -23,9 +23,11 @@ import 'search_location_service.dart';
 ///   the order of [services] (put the offline one first if junctions
 ///   should lead);
 /// - duplicates are merged: same id, or same display name within
-///   [nearDuplicateEpsilon] — geocoders return the same POI or street
-///   several times a few blocks apart, and those near-copies used to eat
-///   the result budget (#984);
+///   `max(`[nearDuplicateEpsilon]`, `[dedupeEpsilon]`)` per axis —
+///   geocoders return the same POI or street several times a few blocks
+///   apart, and those near-copies used to eat the result budget (#984).
+///   The earliest arrival keeps the slot, except that a drillable row
+///   (an offline street with corners) always wins over a plain pin;
 /// - [reverse] returns the first non-null answer, in order.
 class CompositeSearchLocationService
     with SearchLocationDrillDown, LanguageAwareSearch
@@ -35,8 +37,10 @@ class CompositeSearchLocationService
   /// How long to wait for each service before dropping its results.
   final Duration timeout;
 
-  /// Coordinates closer than this (in degrees, ~1e-5 ≈ 1 m) are treated as
-  /// the same place when merging.
+  /// Legacy floor for the near-duplicate radius: the effective radius is
+  /// `max(nearDuplicateEpsilon, dedupeEpsilon)` per axis, so with the
+  /// defaults this field is inert. Passing `nearDuplicateEpsilon: 0`
+  /// restores the old exact-spot-only merging (~1e-5 ≈ 1 m).
   final double dedupeEpsilon;
 
   /// Results with the same display name closer than this (in degrees,
@@ -64,14 +68,22 @@ class CompositeSearchLocationService
     final perService = await Future.wait(futures);
     final merged = <SearchLocation>[];
     var round = 0;
-    var addedAny = true;
-    while (addedAny) {
-      addedAny = false;
+    var anyRemaining = true;
+    while (anyRemaining) {
+      anyRemaining = false;
       for (final results in perService) {
         if (round >= results.length) continue;
-        addedAny = true;
+        anyRemaining = true;
         final result = results[round];
-        if (!_alreadyPresent(merged, result)) merged.add(result);
+        final dup = _indexOfDuplicate(merged, result);
+        if (dup < 0) {
+          merged.add(result);
+        } else if (canDrillDown(result) && !canDrillDown(merged[dup])) {
+          // Keep the richer row: a drillable street (with its corners)
+          // must not be swallowed by a plain pin for the same place that
+          // happened to arrive in an earlier round.
+          merged[dup] = result;
+        }
       }
       round++;
     }
@@ -135,9 +147,11 @@ class CompositeSearchLocationService
     }
   }
 
-  bool _alreadyPresent(List<SearchLocation> merged, SearchLocation candidate) {
-    for (final existing in merged) {
-      if (existing.id == candidate.id) return true;
+  /// Index in [merged] of an entry this candidate duplicates, or -1.
+  int _indexOfDuplicate(List<SearchLocation> merged, SearchLocation candidate) {
+    for (var i = 0; i < merged.length; i++) {
+      final existing = merged[i];
+      if (existing.id == candidate.id) return i;
       final sameName =
           existing.displayName.trim().toLowerCase() ==
           candidate.displayName.trim().toLowerCase();
@@ -148,8 +162,8 @@ class CompositeSearchLocationService
       final nearby =
           (existing.latitude - candidate.latitude).abs() < epsilon &&
           (existing.longitude - candidate.longitude).abs() < epsilon;
-      if (nearby) return true;
+      if (nearby) return i;
     }
-    return false;
+    return -1;
   }
 }

--- a/packages/trufi_core_search_locations/test/unit/composite_search_location_service_test.dart
+++ b/packages/trufi_core_search_locations/test/unit/composite_search_location_service_test.dart
@@ -97,6 +97,66 @@ void main() {
       expect(results.length, 2);
     });
 
+    test('results interleave round-robin across services (#984)', () async {
+      // Concatenating source-by-source buried every online place under up
+      // to ten offline street rows — more than a phone screen shows.
+      final offline = _FakeService([
+        _loc('street:1', 'Calle Universidad A', lat: -17.391),
+        _loc('street:2', 'Calle Universidad B', lat: -17.392),
+        _loc('street:3', 'Calle Universidad C', lat: -17.393),
+      ]);
+      final online = _FakeService([
+        _loc('photon:1', 'Universidad Mayor de San Simón', lat: -17.394),
+        _loc('photon:2', 'Universidad del Valle', lat: -17.395),
+      ]);
+
+      final results = await CompositeSearchLocationService(
+        services: [offline, online],
+      ).search('universidad');
+
+      expect(results.map((r) => r.id), [
+        'street:1',
+        'photon:1',
+        'street:2',
+        'photon:2',
+        'street:3',
+      ]);
+    });
+
+    test('near-copies of the same place a few blocks apart merge (#984)', () async {
+      // Photon returns the same POI several times (per building/entrance),
+      // eating the result budget: Universidad Latinoamericana ×3.
+      final online = _FakeService([
+        _loc('photon:1', 'Universidad Latinoamericana', lat: -17.3900),
+        _loc('photon:2', 'Universidad Latinoamericana', lat: -17.3910),
+        _loc('photon:3', 'universidad latinoamericana ', lat: -17.3905),
+        _loc('photon:4', 'Plaza Colón', lat: -17.3902),
+      ]);
+
+      final results = await CompositeSearchLocationService(
+        services: [online],
+      ).search('universidad');
+
+      expect(results.map((r) => r.id), ['photon:1', 'photon:4']);
+    });
+
+    test('an online near-copy of an offline street collapses into it', () async {
+      // The offline street row keeps the corner drill-down; the online pin
+      // for the same street adds nothing.
+      final offline = _FakeService([
+        _loc('street:1', 'Calle Manuel Virreira', lat: -17.3900),
+      ]);
+      final online = _FakeService([
+        _loc('photon:1', 'Calle Manuel Virreira', lat: -17.3908),
+      ]);
+
+      final results = await CompositeSearchLocationService(
+        services: [offline, online],
+      ).search('virreira');
+
+      expect(results.single.id, 'street:1');
+    });
+
     test('reverse uses the first service that answers', () async {
       final offline = _FakeService(const []); // returns null by design
       final online = _FakeService(const [])

--- a/packages/trufi_core_search_locations/test/unit/composite_search_location_service_test.dart
+++ b/packages/trufi_core_search_locations/test/unit/composite_search_location_service_test.dart
@@ -157,6 +157,53 @@ void main() {
       expect(results.single.id, 'street:1');
     });
 
+    test('a pin arriving an earlier round must not swallow the drillable row',
+        () async {
+      // Fresh-review finding on #984: with interleaving, "first arrival
+      // wins" would let photon's round-0 pin eat the drillable offline
+      // street that only shows up in round 2 — losing the corner
+      // drill-down. The richer row must keep the slot.
+      final offline = _FakeDrillDownService(
+        [
+          _loc('street:1', 'Calle América Oeste', lat: -17.3901),
+          _loc('street:2', 'Avenida América Este', lat: -17.3902),
+          _loc('street:3', 'Calle América', lat: -17.3903),
+        ],
+        corners: {
+          'street:3': [_loc('junction:1', 'América & Libertador')],
+        },
+      );
+      final online = _FakeService([
+        _loc('photon:1', 'Calle América', lat: -17.3904),
+      ]);
+
+      final composite = CompositeSearchLocationService(
+        services: [offline, online],
+      );
+      final results = await composite.search('america');
+
+      expect(results.map((r) => r.id), [
+        'street:1',
+        'street:3', // replaced photon:1 in place, drill-down preserved
+        'street:2',
+      ]);
+      final america = results.firstWhere((r) => r.displayName == 'Calle América');
+      expect(composite.canDrillDown(america), isTrue);
+    });
+
+    test('same name ~450 m apart stays as two results (radius edge)', () async {
+      // Pins the merge radius near its intended ~220 m: a regression that
+      // widens it to a few blocks more would collapse these two.
+      final a = _FakeService([_loc('a', 'Farmacia Bolivia', lat: -17.3900)]);
+      final b = _FakeService([_loc('b', 'Farmacia Bolivia', lat: -17.3940)]);
+
+      final results = await CompositeSearchLocationService(
+        services: [a, b],
+      ).search('farmacia');
+
+      expect(results.length, 2);
+    });
+
     test('reverse uses the first service that answers', () async {
       final offline = _FakeService(const []); // returns null by design
       final online = _FakeService(const [])


### PR DESCRIPTION
Addresses the client-side part of #984 (mobile search showing "only streets").

## What actually happened (two causes)

**Primary — infrastructure, already fixed:** the issue was filed on 2026-08-14 at 03:13 UTC from an Android 13 device — ~12 hours **before** the Cochabamba TLS certificate was re-issued that same day (the Let's Encrypt Gen-Y chain broke HTTPS on Android ≤ 13; same incident as Lima). With Photon unreachable, the composite search silently swallowed the failure and only the offline street index answered: "universidad" → 1 street, "correo" → 0 rows. Photon itself was never filtering anything — today the exact query the app sends returns 10 universities. This PR cannot fix that (it is a certificate-chain rule, documented in ops), but it fixes what made the degradation invisible and what still looks wrong with Photon healthy:

**Secondary — real UX problem in core, this PR:**
1. Results were concatenated **source by source**: up to ten offline street rows always ranked above the first online place. On a phone screen (~5-6 visible rows) that reads as "the app only finds streets" even with Photon healthy — searching "quillacollo" shows 10 street rows before the first place.
2. Geocoders return **near-copies** of the same POI or street a few blocks apart (Universidad Latinoamericana ×3, Calle Manuel Virreira ×4), eating the 10-result budget.

## Fix

- **Round-robin interleave** across services (first result of each, then second of each, …): streets and places share the first screen. Ties keep the `services` order, so offline junctions still lead.
- **Near-duplicate merge**: same display name (case/space-insensitive) within `nearDuplicateEpsilon` (default ~220 m, configurable) collapses into the first hit. A nice side effect: an online pin for a street collapses into the richer offline row that carries the corner drill-down.

No changes to per-service limits, timeouts, failure handling, drill-down, language forwarding or `reverse`.

## Tests

3 new unit tests (interleave order, near-copies merge, online-pin-collapses-into-offline-street), plus the existing 7 composite tests unchanged — including "same name far apart both stay" (different places named "Mercado" 3–5 km apart survive the merge). Mutation-checked: disabling the near-merge kills 2 tests; reverting to concatenation kills the interleave test. Package unit+widget: **130/130**; `flutter analyze` clean. (The 10 Photon *integration* tests hit the live network and fail identically on `main` in this environment; CI runs no tests.)

## Follow-ups (separate issues, out of scope)

- Silent degradation: the composite swallows a failing source (`catch → []`) with no signal to the UI — the TLS outage looked like "search is broken". Deserves a degradation flag + a hint in the search screen.
- Offline POIs: `OfflineSearchDataService` never parses the `pois` key (and trufi-app's slimmed index ships it empty), so there is no place search without network.
- Ops: monitor that every city cert chain keeps ending in ISRG Root X1 (the pending-improvements list already tracks this).
