### PR TITLE
Saved places: duplicate guard at human scale, renamed Home/Work shows its name (#898)

### DIFF
--- a/packages/screens/trufi_core_saved_places/lib/src/cubit/saved_places_cubit.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/cubit/saved_places_cubit.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -101,16 +103,62 @@ class SavedPlacesCubit extends Cubit<SavedPlacesState> {
     }
   }
 
-  /// Whether two places share the same identity: same name (trimmed,
-  /// case-insensitive) at the same coordinates (sub-meter epsilon).
+  /// Two saved places closer than this many metres count as "the same spot"
+  /// when their names match (#898).
+  ///
+  /// The map picker returns the raw camera centre, so two taps on the same
+  /// building differ by a few metres — a sub-metre epsilon only ever matched
+  /// when the map was not moved at all. 50 m is roughly half a city block:
+  /// inside it, a same-named entry is a duplicate; beyond it, the user may
+  /// legitimately have two "Farmacia" in different neighbourhoods.
+  static const double duplicateRadiusMeters = 50;
+
+  /// Great-circle distance in metres between two coordinates (haversine).
+  static double distanceMeters(
+    double lat1,
+    double lon1,
+    double lat2,
+    double lon2,
+  ) {
+    const earthRadius = 6371000.0;
+    double rad(double deg) => deg * math.pi / 180;
+    final dLat = rad(lat2 - lat1);
+    final dLon = rad(lon2 - lon1);
+    final a =
+        math.pow(math.sin(dLat / 2), 2) +
+        math.cos(rad(lat1)) *
+            math.cos(rad(lat2)) *
+            math.pow(math.sin(dLon / 2), 2);
+    return earthRadius * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a));
+  }
+
+  /// Normalises a place name for comparison: trimmed, lower-cased, accents
+  /// folded ("Café" == "cafe", also when the accent arrives as a combining
+  /// mark), inner whitespace collapsed.
+  static String normalizeName(String name) {
+    const from = 'áàäâãéèëêíìïîóòöôõúùüûñç';
+    const to = 'aaaaaeeeeiiiiooooouuuunc';
+    final buffer = StringBuffer();
+    for (final rune in name.toLowerCase().trim().runes) {
+      // Combining diacritical marks (U+0300–U+036F): decomposed accents.
+      if (rune >= 0x0300 && rune <= 0x036F) continue;
+      final char = String.fromCharCode(rune);
+      final index = from.indexOf(char);
+      buffer.write(index >= 0 ? to[index] : char);
+    }
+    return buffer.toString().replaceAll(RegExp(r'\s+'), ' ');
+  }
+
+  /// Whether two places share the same identity: same name (see
+  /// [normalizeName]) within [duplicateRadiusMeters] of each other.
   static bool hasSameIdentity(SavedPlace a, SavedPlace b) =>
-      a.name.trim().toLowerCase() == b.name.trim().toLowerCase() &&
-      (a.latitude - b.latitude).abs() < 1e-6 &&
-      (a.longitude - b.longitude).abs() < 1e-6;
+      normalizeName(a.name) == normalizeName(b.name) &&
+      distanceMeters(a.latitude, a.longitude, b.latitude, b.longitude) <=
+          duplicateRadiusMeters;
 
   /// Whether an equivalent place is already saved — see [hasSameIdentity].
   /// Pass [excludeId] when editing so a place doesn't collide with
-  /// itself (#898).
+  /// itself (#898). History entries never count.
   bool isDuplicatePlace(SavedPlace place, {String? excludeId}) {
     bool same(SavedPlace other) =>
         other.id != excludeId && hasSameIdentity(other, place);
@@ -161,7 +209,25 @@ class SavedPlacesCubit extends Cubit<SavedPlacesState> {
 
   /// Saves a place based on its type.
   /// Handles type changes correctly (e.g., other -> home).
-  Future<void> savePlace(
+  ///
+  /// Returns `false` — and persists nothing — when an equivalent place is
+  /// already saved (#898). The guard lives here, on the path every screen
+  /// saves through, instead of in each screen's dialog wiring; history
+  /// entries are never checked. ([addOtherPlace], [setHome] and [setWork]
+  /// stay unguarded low-level writers.)
+  Future<bool> savePlace(
+    SavedPlace place, {
+    SavedPlaceType? originalType,
+  }) async {
+    if (place.type != SavedPlaceType.history &&
+        isDuplicatePlace(place, excludeId: place.id)) {
+      return false;
+    }
+    await _savePlace(place, originalType: originalType);
+    return true;
+  }
+
+  Future<void> _savePlace(
     SavedPlace place, {
     SavedPlaceType? originalType,
   }) async {
@@ -228,21 +294,37 @@ class SavedPlacesCubit extends Cubit<SavedPlacesState> {
   }
 
   /// Updates any saved place. Handles type changes.
-  Future<void> updatePlace(SavedPlace updatedPlace) async {
+  ///
+  /// Returns `false` when the edit would turn the place into a duplicate of
+  /// another saved place. An edit that keeps the place's own identity (icon,
+  /// type, a nudge of a few metres) is always accepted, so entries that were
+  /// duplicated before the guard existed stay editable.
+  Future<bool> updatePlace(SavedPlace updatedPlace) async {
     // Find original place to detect type change
+    SavedPlace? original;
     SavedPlaceType? originalType;
 
     if (state.home?.id == updatedPlace.id) {
+      original = state.home;
       originalType = SavedPlaceType.home;
     } else if (state.work?.id == updatedPlace.id) {
+      original = state.work;
       originalType = SavedPlaceType.work;
     } else if (state.otherPlaces.any((p) => p.id == updatedPlace.id)) {
+      original = state.otherPlaces.firstWhere((p) => p.id == updatedPlace.id);
       originalType = SavedPlaceType.other;
     } else if (state.history.any((p) => p.id == updatedPlace.id)) {
+      original = state.history.firstWhere((p) => p.id == updatedPlace.id);
       originalType = SavedPlaceType.history;
     }
 
-    await savePlace(updatedPlace, originalType: originalType);
+    final identityChanged =
+        original == null || !hasSameIdentity(updatedPlace, original);
+    if (identityChanged) {
+      return savePlace(updatedPlace, originalType: originalType);
+    }
+    await _savePlace(updatedPlace, originalType: originalType);
+    return true;
   }
 
   /// Deletes any saved place.

--- a/packages/screens/trufi_core_saved_places/lib/src/saved_places_trufi_screen.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/saved_places_trufi_screen.dart
@@ -134,11 +134,8 @@ class _SavedPlacesScreenWidget extends StatelessWidget {
     );
 
     if (place != null && context.mounted) {
-      if (cubit.isDuplicatePlace(place)) {
-        _showDuplicateWarning(context, place);
-        return;
-      }
-      cubit.savePlace(place);
+      final saved = await cubit.savePlace(place);
+      if (!saved && context.mounted) _showDuplicateWarning(context, place);
     }
   }
 
@@ -167,17 +164,10 @@ class _SavedPlacesScreenWidget extends StatelessWidget {
     );
 
     if (updatedPlace != null && context.mounted) {
-      // An edit that keeps the same name and coordinates can't create a
-      // new duplicate — skip the check so places that were duplicated
-      // before this guard existed stay editable (icon, type, ...).
-      final identityChanged =
-          !SavedPlacesCubit.hasSameIdentity(updatedPlace, place);
-      if (identityChanged &&
-          cubit.isDuplicatePlace(updatedPlace, excludeId: place.id)) {
+      final saved = await cubit.updatePlace(updatedPlace);
+      if (!saved && context.mounted) {
         _showDuplicateWarning(context, updatedPlace);
-        return;
       }
-      cubit.updatePlace(updatedPlace);
     }
   }
 

--- a/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_place_tile.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_place_tile.dart
@@ -132,15 +132,47 @@ class SavedPlaceTile extends StatelessWidget {
   IconData _getIconFromName(String? iconName) =>
       savedPlaceRoundedIcon(iconName);
 
-  String _getDisplayName(SavedPlacesLocalizations localization) {
-    if (place.type == SavedPlaceType.home && !place.name.contains('_')) {
-      return localization.home;
-    }
-    if (place.type == SavedPlaceType.work && !place.name.contains('_')) {
-      return localization.work;
-    }
-    return place.name;
+  String _getDisplayName(SavedPlacesLocalizations localization) =>
+      savedPlaceDisplayName(place, localization);
+}
+
+/// The label a list shows for [place].
+///
+/// Home and Work are created with the localized default label as their name
+/// ("Casa", "Home", …); that label keeps following the UI language. Once the
+/// user renames the place, the stored name wins (#898 — the tile used to
+/// hard-code the default label for every home/work, so renames never showed
+/// up in the list while the edit sheet, reading the stored name, did).
+String savedPlaceDisplayName(
+  SavedPlace place,
+  SavedPlacesLocalizations localization,
+) {
+  final name = place.name.trim();
+  switch (place.type) {
+    case SavedPlaceType.home:
+      return name.isEmpty || _isDefaultLabel(name, (l) => l.home)
+          ? localization.home
+          : name;
+    case SavedPlaceType.work:
+      return name.isEmpty || _isDefaultLabel(name, (l) => l.work)
+          ? localization.work
+          : name;
+    case SavedPlaceType.other:
+    case SavedPlaceType.history:
+      return place.name;
   }
+}
+
+/// Whether [name] is the default label of a home/work place in any supported
+/// language (the name is stored in whatever language the app ran in).
+bool _isDefaultLabel(
+  String name,
+  String Function(SavedPlacesLocalizations l10n) label,
+) {
+  final lower = name.toLowerCase();
+  return SavedPlacesLocalizations.supportedLocales
+      .map(lookupSavedPlacesLocalizations)
+      .any((l10n) => label(l10n).toLowerCase() == lower);
 }
 
 /// Favorite toggle button with animation

--- a/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_places_screen.dart
+++ b/packages/screens/trufi_core_saved_places/lib/src/widgets/saved_places_screen.dart
@@ -134,11 +134,8 @@ class _SavedPlacesScreenContent extends StatelessWidget {
     );
 
     if (place != null && context.mounted) {
-      if (cubit.isDuplicatePlace(place)) {
-        _showDuplicateWarning(context, place);
-        return;
-      }
-      cubit.savePlace(place);
+      final saved = await cubit.savePlace(place);
+      if (!saved && context.mounted) _showDuplicateWarning(context, place);
     }
   }
 
@@ -154,17 +151,10 @@ class _SavedPlacesScreenContent extends StatelessWidget {
     );
 
     if (updatedPlace != null && context.mounted) {
-      // An edit that keeps the same name and coordinates can't create a
-      // new duplicate — skip the check so places that were duplicated
-      // before this guard existed stay editable (icon, type, ...).
-      final identityChanged =
-          !SavedPlacesCubit.hasSameIdentity(updatedPlace, place);
-      if (identityChanged &&
-          cubit.isDuplicatePlace(updatedPlace, excludeId: place.id)) {
+      final saved = await cubit.updatePlace(updatedPlace);
+      if (!saved && context.mounted) {
         _showDuplicateWarning(context, updatedPlace);
-        return;
       }
-      cubit.updatePlace(updatedPlace);
     }
   }
 

--- a/packages/screens/trufi_core_saved_places/test/default_place_label_test.dart
+++ b/packages/screens/trufi_core_saved_places/test/default_place_label_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_saved_places/trufi_core_saved_places.dart';
+
+// #898 (second report): renaming Home/Work saved fine and the edit sheet showed
+// the new name, but the list card kept saying "Home"/"Casa" — the tile
+// hard-coded the default label for every home/work place.
+
+SavedPlace _place(String name, SavedPlaceType type) => SavedPlace(
+  id: type.name,
+  name: name,
+  latitude: -17.39,
+  longitude: -66.16,
+  type: type,
+  createdAt: DateTime.utc(2026, 8, 14),
+);
+
+Widget _app(Widget child, {String locale = 'es'}) => MaterialApp(
+  locale: Locale(locale),
+  supportedLocales: SavedPlacesLocalizations.supportedLocales,
+  localizationsDelegates: const [
+    SavedPlacesLocalizations.delegate,
+    ...GlobalMaterialLocalizations.delegates,
+  ],
+  home: Scaffold(body: child),
+);
+
+void main() {
+  testWidgets('a renamed Home shows the user\'s name', (tester) async {
+    await tester.pumpWidget(
+      _app(SavedPlaceTile(place: _place('Casa Cambio', SavedPlaceType.home))),
+    );
+    expect(find.text('Casa Cambio'), findsOneWidget);
+    expect(find.text('Casa'), findsNothing);
+  });
+
+  testWidgets('a renamed Work shows the user\'s name', (tester) async {
+    await tester.pumpWidget(
+      _app(SavedPlaceTile(place: _place('Oficina', SavedPlaceType.work))),
+    );
+    expect(find.text('Oficina'), findsOneWidget);
+  });
+
+  testWidgets('a Home still carrying the default label stays localized', (
+    tester,
+  ) async {
+    // Stored as "Casa" while the app ran in Spanish…
+    await tester.pumpWidget(
+      _app(SavedPlaceTile(place: _place('Casa', SavedPlaceType.home))),
+    );
+    expect(find.text('Casa'), findsOneWidget);
+
+    // …and follows the UI language, as before.
+    await tester.pumpWidget(
+      _app(
+        SavedPlaceTile(place: _place('Casa', SavedPlaceType.home)),
+        locale: 'en',
+      ),
+    );
+    expect(find.text('Home'), findsOneWidget);
+  });
+
+  testWidgets('an empty name falls back to the localized label', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(SavedPlaceTile(place: _place('', SavedPlaceType.work))),
+    );
+    expect(find.text('Trabajo'), findsOneWidget);
+  });
+
+  testWidgets('favourites always show their own name', (tester) async {
+    await tester.pumpWidget(
+      _app(SavedPlaceTile(place: _place('Casa', SavedPlaceType.other))),
+    );
+    expect(find.text('Casa'), findsOneWidget);
+  });
+
+  test('savedPlaceDisplayName is the single source for the label', () {
+    final es = lookupSavedPlacesLocalizations(const Locale('es'));
+    expect(
+      savedPlaceDisplayName(_place('Home', SavedPlaceType.home), es),
+      'Casa',
+    );
+    expect(
+      savedPlaceDisplayName(_place('Zuhause', SavedPlaceType.home), es),
+      'Casa',
+    );
+    expect(
+      savedPlaceDisplayName(_place('Mi depa', SavedPlaceType.home), es),
+      'Mi depa',
+    );
+    expect(
+      savedPlaceDisplayName(_place('  ', SavedPlaceType.work), es),
+      'Trabajo',
+    );
+  });
+}

--- a/packages/screens/trufi_core_saved_places/test/duplicate_places_test.dart
+++ b/packages/screens/trufi_core_saved_places/test/duplicate_places_test.dart
@@ -1,105 +1,111 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:trufi_core_saved_places/trufi_core_saved_places.dart';
 
-class _InMemoryRepository implements SavedPlacesRepository {
-  final Map<String, SavedPlace> _places = {};
+import 'in_memory_repository.dart';
 
-  @override
-  Future<void> initialize() async {}
+// #898: "Your places" accepted the same place twice. The first guard compared
+// coordinates with a sub-metre epsilon, which the map picker never satisfies
+// (two taps on the same building differ by metres) — so the reporter kept
+// getting duplicates. The guard now lives on the cubit's write path and
+// treats same name within ~50 m as the same place.
 
-  @override
-  Future<void> dispose() async {}
-
-  @override
-  Future<List<SavedPlace>> getPlacesByType(SavedPlaceType type) async =>
-      _places.values.where((p) => p.type == type).toList();
-
-  @override
-  Future<List<SavedPlace>> getAllPlaces() async => _places.values.toList();
-
-  @override
-  Future<SavedPlace?> getHome() async =>
-      _places.values.where((p) => p.type == SavedPlaceType.home).firstOrNull;
-
-  @override
-  Future<SavedPlace?> getWork() async =>
-      _places.values.where((p) => p.type == SavedPlaceType.work).firstOrNull;
-
-  @override
-  Future<List<SavedPlace>> getOtherPlaces() async =>
-      getPlacesByType(SavedPlaceType.other);
-
-  @override
-  Future<List<SavedPlace>> getHistory() async =>
-      getPlacesByType(SavedPlaceType.history);
-
-  @override
-  Future<void> savePlace(SavedPlace place) async => _places[place.id] = place;
-
-  @override
-  Future<void> updatePlace(SavedPlace place) async => _places[place.id] = place;
-
-  @override
-  Future<void> deletePlace(String id) async => _places.remove(id);
-
-  @override
-  Future<void> deletePlacesByType(SavedPlaceType type) async =>
-      _places.removeWhere((_, p) => p.type == type);
-
-  @override
-  Future<void> clearHistory() async =>
-      deletePlacesByType(SavedPlaceType.history);
-
-  @override
-  Future<void> addToHistory(SavedPlace place) async => savePlace(place);
-}
+// ~1e-5° of latitude ≈ 1.1 m.
+const _degPerMeterLat = 1 / 111_000;
 
 SavedPlace _place({
   String id = '1',
   String name = 'Prueba',
   double lat = -17.39884,
   double lng = -66.16269,
+  SavedPlaceType type = SavedPlaceType.other,
+  String? iconName,
 }) => SavedPlace(
-      id: id,
-      name: name,
-      latitude: lat,
-      longitude: lng,
-      type: SavedPlaceType.other,
-      createdAt: DateTime(2026, 1, 1),
-    );
+  id: id,
+  name: name,
+  latitude: lat,
+  longitude: lng,
+  type: type,
+  iconName: iconName,
+  createdAt: DateTime(2026, 1, 1),
+);
 
 void main() {
-  group('SavedPlacesCubit.isDuplicatePlace (#898)', () {
+  group('SavedPlacesCubit.distanceMeters', () {
+    test('one thousandth of a degree of latitude is ~111 m', () {
+      final d = SavedPlacesCubit.distanceMeters(-17.0, -66.0, -17.001, -66.0);
+      expect(d, closeTo(111, 1));
+    });
+
+    test('identical points are 0 m apart', () {
+      expect(SavedPlacesCubit.distanceMeters(-17.4, -66.1, -17.4, -66.1), 0);
+    });
+  });
+
+  group('SavedPlacesCubit.normalizeName', () {
+    test('trims, lower-cases and collapses whitespace', () {
+      expect(SavedPlacesCubit.normalizeName('  Mi   Casa '), 'mi casa');
+    });
+
+    test('folds precomposed and combining accents', () {
+      expect(SavedPlacesCubit.normalizeName('Café'), 'cafe');
+      expect(SavedPlacesCubit.normalizeName('Cafe\u0301'), 'cafe'); // NFD
+      expect(SavedPlacesCubit.normalizeName('Peñón'), 'penon');
+    });
+  });
+
+  group('SavedPlacesCubit duplicate guard (#898)', () {
+    late InMemorySavedPlacesRepository repository;
     late SavedPlacesCubit cubit;
 
     setUp(() async {
-      cubit = SavedPlacesCubit(repository: _InMemoryRepository());
+      repository = InMemorySavedPlacesRepository();
+      cubit = SavedPlacesCubit(repository: repository);
       await cubit.initialize();
       await cubit.addOtherPlace(_place());
     });
 
     tearDown(() => cubit.close());
 
-    test('same name and same coordinates is a duplicate', () {
-      expect(cubit.isDuplicatePlace(_place(id: '2')), isTrue);
+    test('the reporter\'s case: same name, picker 2 m off, is a duplicate', () {
+      final twoMetresNorth = _place(
+        id: '2',
+        lat: -17.39884 + 2 * _degPerMeterLat,
+      );
+      expect(cubit.isDuplicatePlace(twoMetresNorth), isTrue);
     });
 
-    test('name comparison trims and ignores case', () {
-      expect(cubit.isDuplicatePlace(_place(id: '2', name: '  prueba ')), isTrue);
-    });
-
-    test('same name at a different location is allowed', () {
+    test('radius: 10 m apart is a duplicate, 500 m apart is not', () {
       expect(
-        cubit.isDuplicatePlace(_place(id: '2', lat: -17.5)),
+        cubit.isDuplicatePlace(
+          _place(id: '2', lat: -17.39884 + 10 * _degPerMeterLat),
+        ),
+        isTrue,
+      );
+      expect(
+        cubit.isDuplicatePlace(
+          _place(id: '2', lat: -17.39884 + 500 * _degPerMeterLat),
+        ),
         isFalse,
       );
+    });
+
+    test('name comparison trims, ignores case and accents', () {
+      expect(
+        cubit.isDuplicatePlace(_place(id: '2', name: '  prueba ')),
+        isTrue,
+      );
+      expect(cubit.isDuplicatePlace(_place(id: '2', name: 'PRÚEBA')), isTrue);
+    });
+
+    test('same name far away is allowed', () {
+      expect(cubit.isDuplicatePlace(_place(id: '2', lat: -17.5)), isFalse);
     });
 
     test('different name at the same location is allowed', () {
       expect(cubit.isDuplicatePlace(_place(id: '2', name: 'Otra')), isFalse);
     });
 
-    test('editing a place does not collide with itself', () {
+    test('a place does not collide with itself', () {
       expect(cubit.isDuplicatePlace(_place(), excludeId: '1'), isFalse);
     });
 
@@ -111,26 +117,96 @@ void main() {
       );
     });
 
-    test('epsilon: 1e-7 apart is still a duplicate, 1e-5 is not', () {
-      expect(
-        cubit.isDuplicatePlace(_place(id: '2', lat: -17.39884 + 1e-7)),
-        isTrue,
+    test('history entries never count', () async {
+      await cubit.addToHistory(
+        _place(
+          id: 'hist',
+          name: 'Cine',
+          lat: -17.41,
+          type: SavedPlaceType.history,
+        ),
       );
       expect(
-        cubit.isDuplicatePlace(_place(id: '2', lat: -17.39884 + 1e-5)),
+        cubit.isDuplicatePlace(_place(id: '2', name: 'Cine', lat: -17.41)),
         isFalse,
       );
     });
 
-    test('hasSameIdentity: unchanged edit keeps identity (pre-fix dupes stay editable)', () {
-      final original = _place(id: '1');
-      final editedIconOnly = original.copyWith(iconName: 'star');
-      expect(
-        SavedPlacesCubit.hasSameIdentity(editedIconOnly, original),
-        isTrue,
+    test('savePlace rejects a duplicate and persists nothing', () async {
+      final before = (await repository.getAllPlaces()).length;
+
+      final saved = await cubit.savePlace(
+        _place(id: '2', lat: -17.39884 + 2 * _degPerMeterLat),
       );
-      final renamed = original.copyWith(name: 'Otro nombre');
-      expect(SavedPlacesCubit.hasSameIdentity(renamed, original), isFalse);
+
+      expect(saved, isFalse);
+      expect((await repository.getAllPlaces()).length, before);
+      expect(cubit.state.otherPlaces.map((p) => p.id), ['1']);
+    });
+
+    test('savePlace accepts a distinct place', () async {
+      final saved = await cubit.savePlace(_place(id: '2', name: 'Otra'));
+      expect(saved, isTrue);
+      expect(cubit.state.otherPlaces.map((p) => p.id), ['1', '2']);
+    });
+
+    test('savePlace as Home collides with an equal favourite', () async {
+      final saved = await cubit.savePlace(
+        _place(id: 'home_placeholder', type: SavedPlaceType.home),
+      );
+      expect(saved, isFalse);
+      expect(cubit.state.home, isNull);
+    });
+
+    test('savePlace never blocks history', () async {
+      final saved = await cubit.savePlace(
+        _place(id: 'hist', type: SavedPlaceType.history),
+      );
+      expect(saved, isTrue);
+    });
+
+    group('updatePlace', () {
+      setUp(() async {
+        // A duplicate that slipped in before the guard existed.
+        await cubit.addOtherPlace(_place(id: '2'));
+      });
+
+      test('pre-existing duplicates stay editable (icon only)', () async {
+        final saved = await cubit.updatePlace(
+          _place(id: '2', iconName: 'star'),
+        );
+        expect(saved, isTrue);
+        expect(
+          cubit.state.otherPlaces.firstWhere((p) => p.id == '2').iconName,
+          'star',
+        );
+      });
+
+      test('a nudge within the radius keeps the identity', () async {
+        final saved = await cubit.updatePlace(
+          _place(id: '2', lat: -17.39884 + 10 * _degPerMeterLat),
+        );
+        expect(saved, isTrue);
+      });
+
+      test('renaming onto another saved place is rejected', () async {
+        await cubit.updatePlace(_place(id: '2', name: 'Otra'));
+        final saved = await cubit.updatePlace(_place(id: '2', name: 'prueba'));
+        expect(saved, isFalse);
+        expect(
+          cubit.state.otherPlaces.firstWhere((p) => p.id == '2').name,
+          'Otra',
+        );
+      });
+
+      test('renaming to a free name is accepted', () async {
+        final saved = await cubit.updatePlace(_place(id: '2', name: 'Otra'));
+        expect(saved, isTrue);
+        expect(
+          (await repository.getAllPlaces()).any((p) => p.name == 'Otra'),
+          isTrue,
+        );
+      });
     });
   });
 }

--- a/packages/screens/trufi_core_saved_places/test/in_memory_repository.dart
+++ b/packages/screens/trufi_core_saved_places/test/in_memory_repository.dart
@@ -1,0 +1,55 @@
+import 'package:trufi_core_saved_places/trufi_core_saved_places.dart';
+
+/// Test double: keeps places in a map, no platform channels.
+class InMemorySavedPlacesRepository implements SavedPlacesRepository {
+  final Map<String, SavedPlace> _places = {};
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<List<SavedPlace>> getPlacesByType(SavedPlaceType type) async =>
+      _places.values.where((p) => p.type == type).toList();
+
+  @override
+  Future<List<SavedPlace>> getAllPlaces() async => _places.values.toList();
+
+  @override
+  Future<SavedPlace?> getHome() async =>
+      _places.values.where((p) => p.type == SavedPlaceType.home).firstOrNull;
+
+  @override
+  Future<SavedPlace?> getWork() async =>
+      _places.values.where((p) => p.type == SavedPlaceType.work).firstOrNull;
+
+  @override
+  Future<List<SavedPlace>> getOtherPlaces() async =>
+      getPlacesByType(SavedPlaceType.other);
+
+  @override
+  Future<List<SavedPlace>> getHistory() async =>
+      getPlacesByType(SavedPlaceType.history);
+
+  @override
+  Future<void> savePlace(SavedPlace place) async => _places[place.id] = place;
+
+  @override
+  Future<void> updatePlace(SavedPlace place) async => _places[place.id] = place;
+
+  @override
+  Future<void> deletePlace(String id) async => _places.remove(id);
+
+  @override
+  Future<void> deletePlacesByType(SavedPlaceType type) async =>
+      _places.removeWhere((_, p) => p.type == type);
+
+  @override
+  Future<void> clearHistory() async =>
+      deletePlacesByType(SavedPlaceType.history);
+
+  @override
+  Future<void> addToHistory(SavedPlace place) async => savePlace(place);
+}

--- a/packages/screens/trufi_core_saved_places/test/saved_places_screen_duplicate_test.dart
+++ b/packages/screens/trufi_core_saved_places/test/saved_places_screen_duplicate_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:trufi_core_saved_places/trufi_core_saved_places.dart';
+
+import 'in_memory_repository.dart';
+
+// #898 end-to-end through the real widgets: "+" → name → pick on map → Save,
+// twice, with the picker returning points 2 m apart (what a human does when
+// re-picking "the same spot"). The first guard only ever fired for
+// byte-identical coordinates, so this flow produced two entries.
+
+const _lat = -17.39884;
+const _lng = -66.16269;
+const _degPerMeterLat = 1 / 111_000;
+
+void main() {
+  Future<void> addPlace(WidgetTester tester, String name) async {
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextFormField), name);
+    await tester.tap(find.text('Tap to select on map'));
+    await tester.pumpAndSettle();
+    expect(find.text('Location selected'), findsOneWidget);
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+    expect(find.byType(EditPlaceDialog), findsNothing, reason: 'sheet closed');
+  }
+
+  Finder tilesNamed(String name) => find.widgetWithText(SavedPlaceTile, name);
+
+  testWidgets('saving the same place twice keeps one entry and warns', (
+    tester,
+  ) async {
+    final picks = <({double latitude, double longitude})>[
+      (latitude: _lat, longitude: _lng),
+      (latitude: _lat + 2 * _degPerMeterLat, longitude: _lng),
+      (latitude: _lat + 500 * _degPerMeterLat, longitude: _lng),
+    ];
+    var pick = 0;
+
+    // Phone-sized surface: on the default 800x600 the sheet's Save button
+    // sits below the fold and the tap silently misses.
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 3;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: const [SavedPlacesLocalizations.delegate],
+        home: SavedPlacesScreen(
+          repository: InMemorySavedPlacesRepository(),
+          onChooseOnMap: ({initialLatitude, initialLongitude}) async =>
+              picks[pick++],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await addPlace(tester, 'Prueba');
+    expect(tilesNamed('Prueba'), findsOneWidget);
+
+    await addPlace(tester, 'Prueba'); // 2 m away
+    expect(tilesNamed('Prueba'), findsOneWidget, reason: 'no second entry');
+    expect(
+      find.text('"Prueba" is already saved at that location'),
+      findsOneWidget,
+      reason: 'the user is told why nothing happened',
+    );
+
+    await tester.pumpAndSettle(const Duration(seconds: 5)); // snackbar gone
+    await addPlace(tester, 'Prueba'); // 500 m away: a different place
+    expect(tilesNamed('Prueba'), findsNWidgets(2));
+  });
+}


### PR DESCRIPTION
Addresses the two reports on the reopened #898 (v5.3.0). Both live in `trufi_core_saved_places`.

## 1. Duplicates were still accepted

**Why the fix from #956 did not hold.** The guard compared coordinates with a `1e-6°` epsilon (~11 cm). The map picker returns the raw camera centre, and one screen pixel at zoom 15 is ~4.5 m — about 40× the epsilon — so two taps on "the same spot" never matched. It only fired when the map was not moved at all, which is exactly what the emulator repro did (coordinates differing at 1e-14). In the reporter's hands it never triggered.

**Fix.**
- Same name within **50 m** counts as the same place (`SavedPlacesCubit.duplicateRadiusMeters`, haversine). Names compare trimmed, case- and accent-insensitive, with combining marks stripped ("Café" == "cafe", also as NFD).
- The guard moved from the two screen copies into the cubit's single write path: `savePlace` / `updatePlace` now return `bool` and persist nothing on a duplicate; the screens only show the existing `placeAlreadySaved` snackbar. No new l10n keys.
- Edits that keep a place's own identity (icon, type, a nudge inside the radius) are always accepted, so entries duplicated before the guard existed stay editable (the #956 fresh-review finding is preserved). History entries are never checked.
- Semantics kept from #956: same name **far** away is a different place (two "Farmacia" in different neighbourhoods); a different name at the same spot is allowed.

## 2. Renaming Home/Work did not show in the list

`SavedPlaceTile._getDisplayName` replaced the stored name with the localized "Home"/"Work" for every home/work place whose name had no `_` — a stale heuristic that never matched real data, so the rename was saved (the edit sheet showed it) but the card never did. The label now falls back to the localized default **only** when the stored name is empty or is itself a default label in any supported language (`Home`/`Casa`/`Zuhause`, `Work`/`Trabajo`/`Arbeit`), so existing entries keep following the UI language and a renamed Home shows the user's text. The helper `savedPlaceDisplayName()` is exported for other surfaces.

## Tests (44/44 locally — CI does not run tests)

- `duplicate_places_test.dart` (20): haversine sanity, name normalisation (incl. NFD), the reporter's case (2 m off → duplicate), 10 m / 500 m radius edges, home/work count, history never counts, `savePlace` rejects and persists nothing, `updatePlace` keeps pre-existing duplicates editable and rejects renaming onto another place.
- `default_place_label_test.dart` (6): renamed Home/Work shows the name; default label stays localized and follows the language; empty name falls back; favourites unaffected.
- `saved_places_screen_duplicate_test.dart`: drives the real `SavedPlacesScreen` — "+" → name → pick on map → Save, twice with the picker 2 m apart → one entry + the warning; a third pick 500 m away is a new entry.

Mutation-checked: radius back to 10 cm kills 4 tests (incl. the screen flow); the old label logic kills 3.

## Design decisions worth knowing (surfaced by the fresh-eyes audit)

- **Radius trade-off.** Two genuinely different places with the same name closer than 50 m (two "Farmacia" on one corner) can no longer both be saved under that name — rename one. The alternative the issue title suggests (block by name only, anywhere) is a one-line change if preferred.
- **Setting Home/Work for the first time on top of an existing favourite with the same name (within 50 m) is rejected**, same as under #956. To "promote" a favourite to Home, edit the favourite and change its type (identity kept → accepted).
- **A Home renamed to exactly a default label of another language ("Home" while in Spanish) keeps following the UI language.** Price of keeping existing default entries localized; favourites always show their own name.
