### PR TITLE
Planner: persist the built index so cold starts load a snapshot instead of rebuilding (#993)

### DIFF
--- a/packages/trufi_core_planner/lib/src/index/gtfs_route_index.dart
+++ b/packages/trufi_core_planner/lib/src/index/gtfs_route_index.dart
@@ -209,6 +209,11 @@ class PatternConnections extends ListBase<PatternConnection> {
 }
 
 /// Index for fast route lookups.
+///
+/// Persisted by the planner index snapshot (#993): whenever a change here
+/// makes this build different patterns, connections or line keys from the
+/// same GTFS, bump `PlannerIndexCodec.formatVersion`, or users keep the
+/// previous release's index until the bundled feed changes.
 class GtfsRouteIndex {
   /// Default radius within which two distinct stops count as one transfer
   /// point. Matches MOTIS' `link_stop_distance` (100 m straight-line);

--- a/packages/trufi_core_planner/lib/src/index/gtfs_route_index.dart
+++ b/packages/trufi_core_planner/lib/src/index/gtfs_route_index.dart
@@ -268,6 +268,81 @@ class GtfsRouteIndex {
     );
   }
 
+  /// Restores an index from a snapshot of one built by [GtfsRouteIndex.new]
+  /// over the same [data] with the same knobs: the [patterns] in id order
+  /// and the CSR connection columns exactly as [connectionStarts],
+  /// [connectionOtherPattern], [connectionMyStopIdx], [connectionOtherStopIdx]
+  /// and [connectionWalk] returned them. The cheap per-stop and per-route
+  /// maps are re-derived from the patterns: iterating them in id order
+  /// inserts every (stop, pattern) and (stop, route) pair in the same order
+  /// the build did — a pattern id is the order of first appearance of its
+  /// trip, so the first trip of a route that visits a stop is also its first
+  /// pattern there. Used by the planner index snapshot; the codec validates
+  /// the arrays before calling this.
+  GtfsRouteIndex.restore({
+    required GtfsData data,
+    required List<RoutePattern> patterns,
+    required Int32List connectionStarts,
+    required Int32List connectionOtherPattern,
+    required Int32List connectionMyStopIdx,
+    required Int32List connectionOtherStopIdx,
+    required Float32List connectionWalk,
+    required this.transferRadiusMeters,
+    required this.sameNameRouteLimit,
+  }) : _data = data {
+    if (connectionStarts.length != patterns.length + 1) {
+      throw ArgumentError(
+        'connectionStarts must have patterns.length + 1 entries',
+      );
+    }
+    final total = connectionStarts.isEmpty ? 0 : connectionStarts.last;
+    if (connectionOtherPattern.length != total ||
+        connectionMyStopIdx.length != total ||
+        connectionOtherStopIdx.length != total ||
+        connectionWalk.length != total) {
+      throw ArgumentError('connection columns must have $total entries');
+    }
+    for (var i = 0; i < patterns.length; i++) {
+      if (patterns[i].id != i) {
+        throw ArgumentError('pattern at position $i has id ${patterns[i].id}');
+      }
+    }
+    _patterns = patterns;
+    _routePatterns = {};
+    _stopToPatternIds = {};
+    _stopToRoutes = {};
+    for (final pattern in patterns) {
+      _routePatterns.putIfAbsent(pattern.routeId, () => []).add(pattern);
+      for (final stopId in pattern.stopIds) {
+        _stopToRoutes.putIfAbsent(stopId, () => {}).add(pattern.routeId);
+        _stopToPatternIds.putIfAbsent(stopId, () => {}).add(pattern.id);
+      }
+    }
+    _buildLineKeys();
+    _connStart = connectionStarts;
+    _connOther = connectionOtherPattern;
+    _connMyIdx = connectionMyStopIdx;
+    _connOtherIdx = connectionOtherStopIdx;
+    _connWalk = connectionWalk;
+  }
+
+  /// CSR offsets of the connection table: pattern `p` owns entries
+  /// `[connectionStarts[p], connectionStarts[p + 1])` of the four columns
+  /// below. Exposed for the snapshot codec; treat all five as read-only.
+  Int32List get connectionStarts => _connStart;
+
+  /// Column: id of the pattern boarded (see [PatternConnection.otherPatternId]).
+  Int32List get connectionOtherPattern => _connOther;
+
+  /// Column: alight position in the source pattern.
+  Int32List get connectionMyStopIdx => _connMyIdx;
+
+  /// Column: boarding position in the other pattern.
+  Int32List get connectionOtherStopIdx => _connOtherIdx;
+
+  /// Column: straight-line walk between alight and boarding stop, meters.
+  Float32List get connectionWalk => _connWalk;
+
   void _buildIndices() {
     _patterns = [];
     _stopToPatternIds = {};

--- a/packages/trufi_core_planner/lib/src/index/gtfs_schedule_index.dart
+++ b/packages/trufi_core_planner/lib/src/index/gtfs_schedule_index.dart
@@ -60,6 +60,32 @@ class GtfsScheduleIndex {
     _buildIndices();
   }
 
+  /// Restores an index from the already grouped and sorted
+  /// [stopTimesByStop] of an index built over the same data (see
+  /// [stopTimesByStop]); the per-route trip lists are re-derived from
+  /// [trips], whose order is preserved by the snapshot. Used by the planner
+  /// index snapshot.
+  GtfsScheduleIndex.restore({
+    required Map<String, GtfsTrip> trips,
+    required List<GtfsStopTime> stopTimes,
+    required Map<String, GtfsCalendar> calendars,
+    required List<GtfsCalendarDate> calendarDates,
+    required List<GtfsFrequency> frequencies,
+    required Map<String, List<GtfsStopTime>> stopTimesByStop,
+  }) : _trips = trips,
+       _stopTimes = stopTimes,
+       _calendars = calendars,
+       _calendarDates = calendarDates,
+       _frequencies = frequencies {
+    _stopTimesByStop = stopTimesByStop;
+    _indexTripsByRoute();
+  }
+
+  /// Stop times grouped by stop id, each list sorted by departure time —
+  /// the index's own working table, exposed for the snapshot codec. Treat
+  /// as read-only.
+  Map<String, List<GtfsStopTime>> get stopTimesByStop => _stopTimesByStop;
+
   void _buildIndices() {
     // Index stop times by stop ID
     _stopTimesByStop = {};
@@ -67,11 +93,7 @@ class GtfsScheduleIndex {
       _stopTimesByStop.putIfAbsent(st.stopId, () => []).add(st);
     }
 
-    // Index trips by route ID
-    _tripsByRoute = {};
-    for (final trip in _trips.values) {
-      _tripsByRoute.putIfAbsent(trip.routeId, () => []).add(trip);
-    }
+    _indexTripsByRoute();
 
     // Sort stop times by departure time
     for (final stopTimes in _stopTimesByStop.values) {
@@ -80,6 +102,13 @@ class GtfsScheduleIndex {
         final timeB = b.departureTime ?? b.arrivalTime ?? Duration.zero;
         return timeA.compareTo(timeB);
       });
+    }
+  }
+
+  void _indexTripsByRoute() {
+    _tripsByRoute = {};
+    for (final trip in _trips.values) {
+      _tripsByRoute.putIfAbsent(trip.routeId, () => []).add(trip);
     }
   }
 

--- a/packages/trufi_core_planner/lib/src/index/gtfs_schedule_index.dart
+++ b/packages/trufi_core_planner/lib/src/index/gtfs_schedule_index.dart
@@ -34,6 +34,11 @@ class RouteFrequencyInfo {
 }
 
 /// Index for schedule-based queries (departures, frequencies).
+///
+/// Persisted by the planner index snapshot (#993): whenever a change here
+/// makes this build different groups or order from the same GTFS, bump
+/// `PlannerIndexCodec.formatVersion`, or users keep the previous release's
+/// index until the bundled feed changes.
 class GtfsScheduleIndex {
   final Map<String, GtfsTrip> _trips;
   final List<GtfsStopTime> _stopTimes;

--- a/packages/trufi_core_planner/lib/src/index/gtfs_spatial_index.dart
+++ b/packages/trufi_core_planner/lib/src/index/gtfs_spatial_index.dart
@@ -13,6 +13,11 @@ class NearbyStop {
 }
 
 /// Spatial index for fast nearest-stop queries using a KD-Tree.
+///
+/// Persisted by the planner index snapshot (#993): whenever a change here
+/// makes this build a different tree from the same GTFS, bump
+/// `PlannerIndexCodec.formatVersion`, or users keep the previous release's
+/// index until the bundled feed changes.
 class GtfsSpatialIndex {
   final Map<String, GtfsStop> _stops;
   late final _KdTree _tree;

--- a/packages/trufi_core_planner/lib/src/index/gtfs_spatial_index.dart
+++ b/packages/trufi_core_planner/lib/src/index/gtfs_spatial_index.dart
@@ -21,6 +21,19 @@ class GtfsSpatialIndex {
     _tree = _KdTree(_stops.values.toList());
   }
 
+  /// Restores an index from the pre-order traversal of a tree built by
+  /// [GtfsSpatialIndex.new] over the same stops (see [preorder]). The tree
+  /// shape is a function of the stop count alone (median split), so the
+  /// result is the very same tree — same answers, same result order —
+  /// without sorting anything. Used by the planner index snapshot.
+  GtfsSpatialIndex.restore(this._stops, List<GtfsStop> preorder) {
+    _tree = _KdTree.fromPreorder(preorder);
+  }
+
+  /// The tree's stops in pre-order (node, left subtree, right subtree);
+  /// feeds [GtfsSpatialIndex.restore].
+  List<GtfsStop> get preorder => _tree.preorder();
+
   /// Find the nearest stops to a location.
   List<NearbyStop> findNearestStops(
     LatLng location, {
@@ -79,6 +92,39 @@ class _KdTree {
     if (stops.isNotEmpty) {
       _root = _buildTree(stops, 0);
     }
+  }
+
+  /// Rebuilds the tree from its pre-order listing. [_buildTree] puts the
+  /// median (`length ~/ 2`) at the node with the `mid` smaller stops on the
+  /// left, so the left subtree of a node covering `count` stops always has
+  /// `count ~/ 2` of them.
+  _KdTree.fromPreorder(List<GtfsStop> preorder) {
+    if (preorder.isNotEmpty) {
+      _root = _fromPreorder(preorder, 0, preorder.length);
+    }
+  }
+
+  _KdNode? _fromPreorder(List<GtfsStop> stops, int start, int count) {
+    if (count == 0) return null;
+    final leftCount = count ~/ 2;
+    return _KdNode(
+      stop: stops[start],
+      left: _fromPreorder(stops, start + 1, leftCount),
+      right: _fromPreorder(stops, start + 1 + leftCount, count - leftCount - 1),
+    );
+  }
+
+  List<GtfsStop> preorder() {
+    final out = <GtfsStop>[];
+    void visit(_KdNode? node) {
+      if (node == null) return;
+      out.add(node.stop);
+      visit(node.left);
+      visit(node.right);
+    }
+
+    visit(_root);
+    return out;
   }
 
   _KdNode? _buildTree(List<GtfsStop> stops, int depth) {

--- a/packages/trufi_core_planner/lib/src/parser/csv_parser.dart
+++ b/packages/trufi_core_planner/lib/src/parser/csv_parser.dart
@@ -1,4 +1,9 @@
 /// Simple CSV parser for GTFS files.
+///
+/// Persisted by the planner index snapshot (#993): whenever a change here
+/// makes this produce different rows from the same GTFS, bump
+/// `PlannerIndexCodec.formatVersion`, or users keep the previous release's
+/// parse until the bundled feed changes.
 class CsvParser {
   /// Parse CSV content into a list of maps.
   /// Each map represents a row with column names as keys.

--- a/packages/trufi_core_planner/lib/src/parser/gtfs_parser.dart
+++ b/packages/trufi_core_planner/lib/src/parser/gtfs_parser.dart
@@ -53,6 +53,11 @@ class GtfsData {
 }
 
 /// Parser for GTFS feeds.
+///
+/// Persisted by the planner index snapshot (#993): whenever a change here
+/// makes this produce different data from the same GTFS, bump
+/// `PlannerIndexCodec.formatVersion`, or users keep the previous release's
+/// parse until the bundled feed changes.
 class GtfsParser {
   /// Parse a GTFS ZIP file from a file path.
   static Future<GtfsData> parseFromFile(String filePath) async {

--- a/packages/trufi_core_planner/lib/src/snapshot/planner_index_bundle.dart
+++ b/packages/trufi_core_planner/lib/src/snapshot/planner_index_bundle.dart
@@ -1,0 +1,106 @@
+import 'dart:typed_data';
+
+import '../index/gtfs_route_index.dart';
+import '../index/gtfs_schedule_index.dart';
+import '../index/gtfs_spatial_index.dart';
+import '../parser/gtfs_parser.dart';
+
+/// Wall-clock split of [PlannerIndexBundle.build], in milliseconds.
+class PlannerBuildTimings {
+  /// Zip inflate + CSV parsing into [GtfsData].
+  final int parseMs;
+
+  /// [GtfsSpatialIndex] (KD-tree over the stops).
+  final int spatialMs;
+
+  /// [GtfsRouteIndex] (patterns, line keys, transfer connections).
+  final int routeIndexMs;
+
+  /// [GtfsScheduleIndex] (stop times per stop, trips per route).
+  final int scheduleMs;
+
+  const PlannerBuildTimings({
+    required this.parseMs,
+    required this.spatialMs,
+    required this.routeIndexMs,
+    required this.scheduleMs,
+  });
+
+  int get totalMs => parseMs + spatialMs + routeIndexMs + scheduleMs;
+
+  @override
+  String toString() =>
+      'parse ${parseMs}ms, spatial ${spatialMs}ms, '
+      'index ${routeIndexMs}ms, schedule ${scheduleMs}ms';
+}
+
+/// Everything the local planner keeps in memory for one GTFS feed: the
+/// parsed data and the three indices built over it.
+///
+/// [build] is the cold path (parse the zip, build every index — what
+/// `TrufiPlannerDataSource` did on every start before #993). A bundle can
+/// also come back from a snapshot written by `PlannerIndexCodec`, in which
+/// case [buildTimings] is null.
+class PlannerIndexBundle {
+  final GtfsData data;
+  final GtfsSpatialIndex spatialIndex;
+  final GtfsRouteIndex routeIndex;
+  final GtfsScheduleIndex scheduleIndex;
+
+  /// How long each build phase took; null for a bundle restored from a
+  /// snapshot.
+  final PlannerBuildTimings? buildTimings;
+
+  const PlannerIndexBundle({
+    required this.data,
+    required this.spatialIndex,
+    required this.routeIndex,
+    required this.scheduleIndex,
+    this.buildTimings,
+  });
+
+  /// Parses [gtfsZip] and builds every index with the given knobs (see
+  /// [GtfsRouteIndex.transferRadiusMeters] and
+  /// [GtfsRouteIndex.sameNameRouteLimit]).
+  static PlannerIndexBundle build(
+    Uint8List gtfsZip, {
+    double transferRadiusMeters = GtfsRouteIndex.defaultTransferRadiusMeters,
+    int sameNameRouteLimit = GtfsRouteIndex.defaultSameNameRouteLimit,
+  }) {
+    final sw = Stopwatch()..start();
+    final data = GtfsParser.parseFromBytes(gtfsZip);
+    final parseMs = sw.elapsedMilliseconds;
+    sw.reset();
+    final spatialIndex = GtfsSpatialIndex(data.stops);
+    final spatialMs = sw.elapsedMilliseconds;
+    sw.reset();
+    final routeIndex = GtfsRouteIndex(
+      data,
+      spatialIndex: spatialIndex,
+      transferRadiusMeters: transferRadiusMeters,
+      sameNameRouteLimit: sameNameRouteLimit,
+    );
+    final routeIndexMs = sw.elapsedMilliseconds;
+    sw.reset();
+    final scheduleIndex = GtfsScheduleIndex(
+      trips: data.trips,
+      stopTimes: data.stopTimes,
+      calendars: data.calendars,
+      calendarDates: data.calendarDates,
+      frequencies: data.frequencies,
+    );
+    final scheduleMs = sw.elapsedMilliseconds;
+    return PlannerIndexBundle(
+      data: data,
+      spatialIndex: spatialIndex,
+      routeIndex: routeIndex,
+      scheduleIndex: scheduleIndex,
+      buildTimings: PlannerBuildTimings(
+        parseMs: parseMs,
+        spatialMs: spatialMs,
+        routeIndexMs: routeIndexMs,
+        scheduleMs: scheduleMs,
+      ),
+    );
+  }
+}

--- a/packages/trufi_core_planner/lib/src/snapshot/planner_index_codec.dart
+++ b/packages/trufi_core_planner/lib/src/snapshot/planner_index_codec.dart
@@ -42,10 +42,16 @@ class PlannerIndexEncodeException implements Exception {
 /// Layout (host byte order — the file is a local cache and never travels):
 ///
 /// ```
-/// 'TPIX' · formatVersion u32 · byte-order marker u32 · reserved u32
+/// 'TPIX' · formatVersion u32 · byte-order marker u32 · stringsOffset u32
 /// transferRadiusMeters f64 · sameNameRouteLimit i32 · fingerprint (u32 + utf8)
 /// payloadLength u32 · payloadChecksum u32 · payload (sections) · 'XIPT'
 /// ```
+///
+/// The payload is the data and index sections followed by the string pool
+/// as its **last** section; `stringsOffset` (from the payload start) lets
+/// [decode] read the pool first. Writing the pool last is what lets
+/// [encode] stream the whole blob into a single buffer: the pool is only
+/// complete once every other section has been written.
 ///
 /// Each section starts 8-byte aligned (typed-data views require offsets
 /// that are multiples of the element size) with a tag and its byte length;
@@ -64,14 +70,24 @@ class PlannerIndexEncodeException implements Exception {
 /// checksum mismatch, truncation, or any index out of range while
 /// restoring — and the caller rebuilds from the GTFS.
 class PlannerIndexCodec {
-  /// Version of the snapshot schema **and** of the index-building rules it
-  /// captures. Bump it whenever the layout changes or when
-  /// [GtfsRouteIndex], [GtfsSpatialIndex] or [GtfsScheduleIndex] would build
-  /// something different from the same GTFS (thinning rule, line keys, tree
-  /// shape, sort order…): a snapshot written by the previous version is then
-  /// rejected and rebuilt instead of serving stale indices — the failure
-  /// mode of the asset-extraction cache in #973. A test pins a digest of the
-  /// integer columns of a fixture snapshot to catch a forgotten bump.
+  /// Version of the snapshot schema **and** of everything the snapshot
+  /// captures: the parsed [GtfsData] and the three indices. Bump it whenever
+  /// the layout changes, when [GtfsParser], `CsvParser` or a model's
+  /// `fromCsv` would parse something different from the same GTFS (trimming
+  /// or normalising a field, colour / time / distance parsing, shape point
+  /// order, BOM handling…), or when [GtfsRouteIndex], [GtfsSpatialIndex] or
+  /// [GtfsScheduleIndex] would build something different (distances,
+  /// thinning rule, line keys, tree shape, sort order…). A snapshot written
+  /// by the previous version is then rejected and rebuilt instead of serving
+  /// stale data — the failure mode of the asset-extraction cache in #973.
+  /// The cache directory survives app updates, so this bump is the only
+  /// thing between a core release and its users keeping the previous
+  /// release's parse for as long as the bundled GTFS does not change.
+  ///
+  /// The `format version guard` test digests every field of the fixture
+  /// bundle (parsed data and indices; calendar instants as year-month-day
+  /// because the parser builds them in local time) and pins the digest, so a
+  /// forgotten bump fails the suite.
   static const int formatVersion = 1;
 
   static const List<int> _magic = [0x54, 0x50, 0x49, 0x58]; // 'TPIX'
@@ -158,15 +174,19 @@ class PlannerIndexCodec {
     PlannerIndexBundle bundle, {
     required String fingerprint,
   }) {
+    // One buffer for the whole blob. The sections stream into it and the
+    // string pool — complete only once every section has been written — goes
+    // last, located through `stringsOffset` in the header. A first draft
+    // wrote the body into a second writer and copied it behind the pool; on
+    // the Cochabamba feed that cost ~150 MB of transient peak in the
+    // first-start isolate on top of the build itself.
     final pool = _StringPool();
-    final body = _Writer();
-    _writeBody(body, bundle, pool);
-
     final out = _Writer();
     out.rawBytes(_magic);
     out.u32(formatVersion);
     out.u32(_byteOrderMarker);
-    out.u32(0); // reserved
+    final stringsOffsetAt = out.position;
+    out.u32(0); // stringsOffset, patched below
     out.f64(bundle.routeIndex.transferRadiusMeters);
     out.i32(_i32(bundle.routeIndex.sameNameRouteLimit, 'sameNameRouteLimit'));
     out.string(fingerprint);
@@ -176,9 +196,11 @@ class PlannerIndexCodec {
     out.u32(0); // payload checksum, patched below
     out.align(8);
     final payloadStart = out.position;
+    _writeBody(out, bundle, pool);
+    final stringsAt = out.position; // 8-aligned: every section ends aligned
     _writeSection(out, _tagStrings, () => pool.write(out));
-    out.rawBytes(body.finish());
     final payloadEnd = out.position;
+    out.patchU32(stringsOffsetAt, stringsAt - payloadStart);
     out.patchU32(payloadLengthAt, payloadEnd - payloadStart);
     final bytes = out.finish(trailer: _trailer);
     final checksum = _checksum(bytes, payloadStart, payloadEnd);
@@ -544,7 +566,7 @@ class PlannerIndexCodec {
       throw _Rejected('format version $version, expected $formatVersion');
     }
     if (r.u32() != _byteOrderMarker) throw const _Rejected('byte order');
-    r.u32(); // reserved
+    final stringsOffset = r.u32();
     final radius = r.f64();
     final limit = r.i32();
     if (radius != transferRadiusMeters || limit != sameNameRouteLimit) {
@@ -565,14 +587,25 @@ class PlannerIndexCodec {
     if (payloadLength % 8 != 0 || payloadEnd + 4 != bytes.length) {
       throw const _Rejected('payload length does not match the file');
     }
+    if (stringsOffset % 8 != 0 || stringsOffset + 8 > payloadLength) {
+      throw const _Rejected('string pool offset out of range');
+    }
     if (_checksum(bytes, payloadStart, payloadEnd) != checksum) {
       throw const _Rejected('checksum mismatch');
     }
 
-    final pool = _StringPool.read(r, _tagStrings);
+    // The string pool is the last section (see the layout); every other
+    // section refers into it, so read it first through its own cursor. It
+    // must close the payload exactly.
+    final poolReader = _Reader(bytes)..skip(payloadStart + stringsOffset);
+    final pool = _StringPool.read(poolReader, _tagStrings);
+    if (poolReader.position != payloadEnd) {
+      throw const _Rejected('string pool does not close the payload');
+    }
 
     final agencies = r.section(_tagAgencies, () {
       final n = r.u32();
+      r.need(n * 32); // eight u32 refs each — bound n before allocating
       return List<GtfsAgency>.generate(n, (_) {
         return GtfsAgency(
           id: pool.required(r.u32()),
@@ -728,6 +761,7 @@ class PlannerIndexCodec {
 
     final calendarList = r.section(_tagCalendars, () {
       final n = r.u32();
+      r.need(n * 24); // u32 + 3 u8, padded to 8, + 2 f64
       return List<GtfsCalendar>.generate(n, (_) {
         final serviceId = pool.required(r.u32());
         final days = r.u8();
@@ -759,6 +793,7 @@ class PlannerIndexCodec {
 
     final calendarDates = r.section(_tagCalendarDates, () {
       final n = r.u32();
+      r.need(n * 16); // u32 + 2 u8, padded to 8, + f64
       return List<GtfsCalendarDate>.generate(n, (_) {
         final serviceId = pool.required(r.u32());
         final exception = r.u8();
@@ -868,7 +903,7 @@ class PlannerIndexCodec {
             stopIds: stopIds,
             headsign: pool.optional(headsign[i]),
             shapeId: pool.optional(shape[i]),
-            cumDist: Float64List.fromList(cumDist.sublist(at, at + count)),
+            cumDist: cumDist.sublist(at, at + count),
             minLat: minLat[i],
             minLon: minLon[i],
             maxLat: maxLat[i],
@@ -971,7 +1006,7 @@ class PlannerIndexCodec {
     });
 
     r.align(8);
-    if (r.position != payloadEnd) {
+    if (r.position != payloadStart + stringsOffset) {
       throw const _Rejected('trailing bytes after the last section');
     }
 
@@ -1230,40 +1265,43 @@ class _Reader {
 
   int get position => _pos;
 
-  void _need(int n) {
+  /// Rejects unless [n] more bytes exist. Sections whose records are read
+  /// one by one call it with `count * recordSize` before allocating `count`
+  /// objects, so a forged count cannot allocate gigabytes first.
+  void need(int n) {
     if (n < 0 || _pos + n > bytes.length) {
       throw const _Rejected('truncated snapshot');
     }
   }
 
   void skip(int n) {
-    _need(n);
+    need(n);
     _pos += n;
   }
 
   void align(int n) => skip((n - _pos % n) % n);
 
   int u8() {
-    _need(1);
+    need(1);
     return bytes[_pos++];
   }
 
   int u32() {
-    _need(4);
+    need(4);
     final v = _data.getUint32(_pos, Endian.host);
     _pos += 4;
     return v;
   }
 
   int i32() {
-    _need(4);
+    need(4);
     final v = _data.getInt32(_pos, Endian.host);
     _pos += 4;
     return v;
   }
 
   double f64() {
-    _need(8);
+    need(8);
     final v = _data.getFloat64(_pos, Endian.host);
     _pos += 8;
     return v;
@@ -1271,7 +1309,7 @@ class _Reader {
 
   String string() {
     final n = u32();
-    _need(n);
+    need(n);
     final s = utf8.decoder.convert(bytes, _pos, _pos + n);
     _pos += n;
     return s;
@@ -1283,7 +1321,7 @@ class _Reader {
     if (actual != tag) throw _Rejected('expected section $tag, found $actual');
     final length = u32();
     final start = _pos;
-    _need(length);
+    need(length);
     final result = body();
     if (_pos - start != length) {
       throw _Rejected('section $tag length mismatch');
@@ -1300,7 +1338,7 @@ class _Reader {
 
   Uint8List u8List(int expected) {
     final n = _count(expected);
-    _need(n);
+    need(n);
     final view = Uint8List.sublistView(bytes, _pos, _pos + n);
     _pos += n;
     return view;
@@ -1310,7 +1348,7 @@ class _Reader {
   Float64List f64List(int expected) {
     final n = _count(expected);
     align(8);
-    _need(n * 8);
+    need(n * 8);
     final view = Float64List.view(bytes.buffer, bytes.offsetInBytes + _pos, n);
     _pos += n * 8;
     return Float64List.fromList(view);
@@ -1319,7 +1357,7 @@ class _Reader {
   Float32List f32List(int expected) {
     final n = _count(expected);
     align(4);
-    _need(n * 4);
+    need(n * 4);
     final view = Float32List.view(bytes.buffer, bytes.offsetInBytes + _pos, n);
     _pos += n * 4;
     return Float32List.fromList(view);
@@ -1334,7 +1372,7 @@ class _Reader {
       throw const _Rejected('column width');
     }
     align(width);
-    _need(n * width);
+    need(n * width);
     final base = bytes.offsetInBytes + _pos;
     final out = Int32List(n);
     switch (width) {

--- a/packages/trufi_core_planner/lib/src/snapshot/planner_index_codec.dart
+++ b/packages/trufi_core_planner/lib/src/snapshot/planner_index_codec.dart
@@ -1,0 +1,1364 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import '../index/gtfs_route_index.dart';
+import '../index/gtfs_schedule_index.dart';
+import '../index/gtfs_spatial_index.dart';
+import '../models/gtfs_agency.dart';
+import '../models/gtfs_calendar.dart';
+import '../models/gtfs_frequency.dart';
+import '../models/gtfs_route.dart';
+import '../models/gtfs_shape.dart';
+import '../models/gtfs_stop.dart';
+import '../models/gtfs_stop_time.dart';
+import '../models/gtfs_trip.dart';
+import '../parser/gtfs_parser.dart';
+import 'planner_index_bundle.dart';
+
+/// Thrown by [PlannerIndexCodec.encode] when a bundle holds a value the
+/// format cannot represent losslessly (never for data produced by
+/// [GtfsParser]; the caller then simply does not cache).
+class PlannerIndexEncodeException implements Exception {
+  final String message;
+
+  const PlannerIndexEncodeException(this.message);
+
+  @override
+  String toString() => 'PlannerIndexEncodeException: $message';
+}
+
+/// Binary snapshot of a [PlannerIndexBundle], so a cold start can skip the
+/// GTFS parse and every index build (#993).
+///
+/// One blob holds the whole in-memory state: the parsed [GtfsData] in
+/// columnar sections over a deduplicated string pool, the patterns, the CSR
+/// transfer table of [GtfsRouteIndex] as raw columns, the KD-tree of
+/// [GtfsSpatialIndex] as its pre-order, and the sorted stop-time groups of
+/// [GtfsScheduleIndex]. Restoring is a linear pass that allocates the model
+/// objects and calls the `restore` constructors; nothing is parsed, sorted
+/// or searched. On the desktop VM the Cochabamba feed shipped by trufi-app
+/// builds in ~1.6 s (parse 1.1 s of it) and decodes in a fraction of that.
+///
+/// Layout (host byte order — the file is a local cache and never travels):
+///
+/// ```
+/// 'TPIX' · formatVersion u32 · byte-order marker u32 · reserved u32
+/// transferRadiusMeters f64 · sameNameRouteLimit i32 · fingerprint (u32 + utf8)
+/// payloadLength u32 · payloadChecksum u32 · payload (sections) · 'XIPT'
+/// ```
+///
+/// Each section starts 8-byte aligned (typed-data views require offsets
+/// that are multiples of the element size) with a tag and its byte length;
+/// integer columns are stored with the narrowest width their maximum fits
+/// (1, 2 or 4 bytes) and widened to `Int32List` on load. Coordinates,
+/// `cumDist` and `shape_dist_traveled` are `Float64`, GTFS times are
+/// `Int32` seconds, dates are microseconds since the epoch as `Float64`
+/// (exact below 2^53) plus a UTC flag — the round trip is lossless.
+///
+/// Every integer operation is 32-bit (`_mul32`, masks), because dart2js
+/// compiles all reachable code and 64-bit literals broke `flutter build web`
+/// once already (#980); the codec never runs on web, but it must compile.
+///
+/// [decode] answers `null` for anything it will not vouch for — wrong magic
+/// or trailer, another [formatVersion], different knobs or fingerprint,
+/// checksum mismatch, truncation, or any index out of range while
+/// restoring — and the caller rebuilds from the GTFS.
+class PlannerIndexCodec {
+  /// Version of the snapshot schema **and** of the index-building rules it
+  /// captures. Bump it whenever the layout changes or when
+  /// [GtfsRouteIndex], [GtfsSpatialIndex] or [GtfsScheduleIndex] would build
+  /// something different from the same GTFS (thinning rule, line keys, tree
+  /// shape, sort order…): a snapshot written by the previous version is then
+  /// rejected and rebuilt instead of serving stale indices — the failure
+  /// mode of the asset-extraction cache in #973. A test pins a digest of the
+  /// integer columns of a fixture snapshot to catch a forgotten bump.
+  static const int formatVersion = 1;
+
+  static const List<int> _magic = [0x54, 0x50, 0x49, 0x58]; // 'TPIX'
+  static const List<int> _trailer = [0x58, 0x49, 0x50, 0x54]; // 'XIPT'
+  static const int _byteOrderMarker = 0x01020304;
+
+  static const int _tagStrings = 1;
+  static const int _tagAgencies = 2;
+  static const int _tagStops = 3;
+  static const int _tagRoutes = 4;
+  static const int _tagTrips = 5;
+  static const int _tagStopTimes = 6;
+  static const int _tagCalendars = 7;
+  static const int _tagCalendarDates = 8;
+  static const int _tagFrequencies = 9;
+  static const int _tagShapes = 10;
+  static const int _tagPatterns = 11;
+  static const int _tagConnections = 12;
+  static const int _tagSpatial = 13;
+  static const int _tagSchedule = 14;
+
+  static const int _int32Max = 0x7fffffff;
+  static const int _int32Min = -0x80000000;
+
+  /// Content fingerprint of a GTFS asset: two independent 32-bit FNV-1a
+  /// streams over 32-bit words (plus the byte length), as 16 hex digits.
+  /// JS-safe arithmetic only (see [_mul32]). Word-wise hashing keeps it at
+  /// ~6 ms for a 5 MB zip on the desktop VM (per-byte FNV takes 20 ms).
+  /// Non-cryptographic on purpose: the question is "is this the same
+  /// bundled file", not adversarial integrity.
+  static String fingerprint(Uint8List bytes) {
+    var h1 = 0x811c9dc5;
+    var h2 = 0xcbf29ce4;
+    final data = ByteData.sublistView(bytes);
+    final words = bytes.length & ~3;
+    for (var i = 0; i < words; i += 4) {
+      final w = data.getUint32(i, Endian.little);
+      h1 = _mul32(h1 ^ w, 0x01000193);
+      h2 = _mul32(h2 ^ (w ^ 0x5f5f5f5f), 0x01000193);
+    }
+    for (var i = words; i < bytes.length; i++) {
+      h1 = _mul32(h1 ^ bytes[i], 0x01000193);
+      h2 = _mul32(h2 ^ bytes[i] ^ 0x5f, 0x01000193);
+    }
+    h1 = _mul32(h1 ^ (bytes.length & 0xffffffff), 0x01000193);
+    h2 = _mul32(h2 ^ (bytes.length & 0xffffffff), 0x01000193);
+    return h1.toRadixString(16).padLeft(8, '0') +
+        h2.toRadixString(16).padLeft(8, '0');
+  }
+
+  /// 32-bit multiply modulo 2^32 with no intermediate above 2^53, identical
+  /// on the VM and under dart2js (same trick as trufi_core_maps, #980).
+  static int _mul32(int a, int b) {
+    final hi = (((a >>> 16) & 0xffff) * b) & 0xffff;
+    final lo = (a & 0xffff) * b;
+    return ((hi << 16) + lo) & 0xffffffff;
+  }
+
+  /// FNV-1a over the 32-bit words of `bytes[start, end)`; `end - start`
+  /// must be a multiple of 4 (payloads are 8-aligned).
+  static int _checksum(Uint8List bytes, int start, int end) {
+    final data = ByteData.sublistView(bytes, start, end);
+    var h = 0x811c9dc5;
+    for (var i = 0; i < data.lengthInBytes; i += 4) {
+      h = _mul32(h ^ data.getUint32(i, Endian.host), 0x01000193);
+    }
+    return h;
+  }
+
+  // ---------------------------------------------------------------------
+  // Encode
+  // ---------------------------------------------------------------------
+
+  /// Serializes [bundle]. [fingerprint] is the [PlannerIndexCodec.fingerprint]
+  /// of the GTFS the bundle was built from; [decode] only accepts the blob
+  /// for the same fingerprint and the same knobs
+  /// ([GtfsRouteIndex.transferRadiusMeters], [GtfsRouteIndex.sameNameRouteLimit]).
+  ///
+  /// Throws [PlannerIndexEncodeException] for values outside the format
+  /// (an `int` beyond 32 bits, a `Duration` that is not whole seconds, a
+  /// pattern whose `cumDist` is missing) — none of which [GtfsParser] and
+  /// the index builders produce.
+  static Uint8List encode(
+    PlannerIndexBundle bundle, {
+    required String fingerprint,
+  }) {
+    final pool = _StringPool();
+    final body = _Writer();
+    _writeBody(body, bundle, pool);
+
+    final out = _Writer();
+    out.rawBytes(_magic);
+    out.u32(formatVersion);
+    out.u32(_byteOrderMarker);
+    out.u32(0); // reserved
+    out.f64(bundle.routeIndex.transferRadiusMeters);
+    out.i32(_i32(bundle.routeIndex.sameNameRouteLimit, 'sameNameRouteLimit'));
+    out.string(fingerprint);
+    out.align(8);
+    final payloadLengthAt = out.position;
+    out.u32(0); // payload length, patched below
+    out.u32(0); // payload checksum, patched below
+    out.align(8);
+    final payloadStart = out.position;
+    _writeSection(out, _tagStrings, () => pool.write(out));
+    out.rawBytes(body.finish());
+    final payloadEnd = out.position;
+    out.patchU32(payloadLengthAt, payloadEnd - payloadStart);
+    final bytes = out.finish(trailer: _trailer);
+    final checksum = _checksum(bytes, payloadStart, payloadEnd);
+    ByteData.sublistView(
+      bytes,
+    ).setUint32(payloadLengthAt + 4, checksum, Endian.host);
+    return bytes;
+  }
+
+  static void _writeBody(
+    _Writer w,
+    PlannerIndexBundle bundle,
+    _StringPool pool,
+  ) {
+    final data = bundle.data;
+
+    _writeSection(w, _tagAgencies, () {
+      w.u32(data.agencies.length);
+      for (final a in data.agencies) {
+        w.u32(pool.ref(a.id));
+        w.u32(pool.ref(a.name));
+        w.u32(pool.ref(a.url));
+        w.u32(pool.ref(a.timezone));
+        w.u32(pool.ref(a.lang));
+        w.u32(pool.ref(a.phone));
+        w.u32(pool.ref(a.fareUrl));
+        w.u32(pool.ref(a.email));
+      }
+    });
+
+    final stops = data.stops.values.toList(growable: false);
+    _writeSection(w, _tagStops, () {
+      final n = stops.length;
+      w.u32(n);
+      w.uintColumn([for (final s in stops) pool.ref(s.id)]);
+      w.uintColumn([for (final s in stops) pool.ref(s.name)]);
+      w.uintColumn([for (final s in stops) pool.ref(s.code)]);
+      w.uintColumn([for (final s in stops) pool.ref(s.description)]);
+      w.uintColumn([for (final s in stops) pool.ref(s.zoneId)]);
+      w.uintColumn([for (final s in stops) pool.ref(s.url)]);
+      w.uintColumn([for (final s in stops) pool.ref(s.parentStation)]);
+      w.uintColumn([for (final s in stops) pool.ref(s.timezone)]);
+      w.uintColumn([for (final s in stops) pool.ref(s.platformCode)]);
+      w.u8List([for (final s in stops) s.locationType.value]);
+      w.u8List([for (final s in stops) s.wheelchairBoarding.value]);
+      w.f64Column(n, (i) => stops[i].lat);
+      w.f64Column(n, (i) => stops[i].lon);
+    });
+
+    final routes = data.routes.values.toList(growable: false);
+    _writeSection(w, _tagRoutes, () {
+      w.u32(routes.length);
+      w.uintColumn([for (final r in routes) pool.ref(r.id)]);
+      w.uintColumn([for (final r in routes) pool.ref(r.agencyId)]);
+      w.uintColumn([for (final r in routes) pool.ref(r.shortName)]);
+      w.uintColumn([for (final r in routes) pool.ref(r.longName)]);
+      w.uintColumn([for (final r in routes) pool.ref(r.description)]);
+      w.uintColumn([for (final r in routes) pool.ref(r.url)]);
+      w.uintColumn([for (final r in routes) pool.ref(r.colorHex)]);
+      w.uintColumn([for (final r in routes) pool.ref(r.textColorHex)]);
+      w.intColumn([for (final r in routes) r.type.value]);
+      w.u8List([for (final r in routes) r.sortOrder == null ? 0 : 1]);
+      w.intColumn([
+        for (final r in routes) _i32(r.sortOrder ?? 0, 'route_sort_order'),
+      ]);
+    });
+
+    final trips = data.trips.values.toList(growable: false);
+    _writeSection(w, _tagTrips, () {
+      w.u32(trips.length);
+      w.uintColumn([for (final t in trips) pool.ref(t.id)]);
+      w.uintColumn([for (final t in trips) pool.ref(t.routeId)]);
+      w.uintColumn([for (final t in trips) pool.ref(t.serviceId)]);
+      w.uintColumn([for (final t in trips) pool.ref(t.headsign)]);
+      w.uintColumn([for (final t in trips) pool.ref(t.shortName)]);
+      w.uintColumn([for (final t in trips) pool.ref(t.blockId)]);
+      w.uintColumn([for (final t in trips) pool.ref(t.shapeId)]);
+      w.u8List([for (final t in trips) t.directionId?.value ?? 0xff]);
+      w.u8List([for (final t in trips) t.wheelchairAccessible.value]);
+      w.u8List([for (final t in trips) t.bikesAllowed.value]);
+    });
+
+    final stopTimes = data.stopTimes;
+    _writeSection(w, _tagStopTimes, () {
+      w.u32(stopTimes.length);
+      w.uintColumn([for (final st in stopTimes) pool.ref(st.tripId)]);
+      w.uintColumn([for (final st in stopTimes) pool.ref(st.stopId)]);
+      w.uintColumn([for (final st in stopTimes) pool.ref(st.stopHeadsign)]);
+      w.intColumn([
+        for (final st in stopTimes) _seconds(st.arrivalTime, 'arrival_time'),
+      ]);
+      w.intColumn([
+        for (final st in stopTimes)
+          _seconds(st.departureTime, 'departure_time'),
+      ]);
+      w.intColumn([
+        for (final st in stopTimes) _i32(st.stopSequence, 'stop_sequence'),
+      ]);
+      w.u8List([for (final st in stopTimes) st.pickupType.value]);
+      w.u8List([for (final st in stopTimes) st.dropOffType.value]);
+      w.u8List([for (final st in stopTimes) st.timepoint.value]);
+      final anyDist = stopTimes.any((st) => st.shapeDistTraveled != null);
+      w.u8(anyDist ? 1 : 0);
+      if (anyDist) {
+        w.u8List([
+          for (final st in stopTimes) st.shapeDistTraveled == null ? 0 : 1,
+        ]);
+        w.f64Column(
+          stopTimes.length,
+          (i) => stopTimes[i].shapeDistTraveled ?? 0,
+        );
+      }
+    });
+
+    final calendars = data.calendars.values.toList(growable: false);
+    _writeSection(w, _tagCalendars, () {
+      w.u32(calendars.length);
+      for (final c in calendars) {
+        w.u32(pool.ref(c.serviceId));
+        w.u8(
+          (c.monday ? 1 : 0) |
+              (c.tuesday ? 2 : 0) |
+              (c.wednesday ? 4 : 0) |
+              (c.thursday ? 8 : 0) |
+              (c.friday ? 16 : 0) |
+              (c.saturday ? 32 : 0) |
+              (c.sunday ? 64 : 0),
+        );
+        w.u8(c.startDate.isUtc ? 1 : 0);
+        w.u8(c.endDate.isUtc ? 1 : 0);
+        w.align(8);
+        w.f64(c.startDate.microsecondsSinceEpoch.toDouble());
+        w.f64(c.endDate.microsecondsSinceEpoch.toDouble());
+      }
+    });
+
+    _writeSection(w, _tagCalendarDates, () {
+      w.u32(data.calendarDates.length);
+      for (final d in data.calendarDates) {
+        w.u32(pool.ref(d.serviceId));
+        w.u8(d.exceptionType.value);
+        w.u8(d.date.isUtc ? 1 : 0);
+        w.align(8);
+        w.f64(d.date.microsecondsSinceEpoch.toDouble());
+      }
+    });
+
+    _writeSection(w, _tagFrequencies, () {
+      final fs = data.frequencies;
+      w.u32(fs.length);
+      w.uintColumn([for (final f in fs) pool.ref(f.tripId)]);
+      w.intColumn([for (final f in fs) _seconds(f.startTime, 'start_time')]);
+      w.intColumn([for (final f in fs) _seconds(f.endTime, 'end_time')]);
+      w.intColumn([for (final f in fs) _i32(f.headwaySecs, 'headway_secs')]);
+      w.u8List([for (final f in fs) f.exactTimes ? 1 : 0]);
+    });
+
+    final shapes = data.shapes.values.toList(growable: false);
+    _writeSection(w, _tagShapes, () {
+      w.u32(shapes.length);
+      w.uintColumn([for (final s in shapes) pool.ref(s.id)]);
+      w.uintColumn([for (final s in shapes) s.points.length]);
+      final points = [for (final s in shapes) ...s.points];
+      w.u32(points.length);
+      w.f64Column(points.length, (i) => points[i].lat);
+      w.f64Column(points.length, (i) => points[i].lon);
+      w.intColumn([for (final p in points) _i32(p.sequence, 'shape_pt_seq')]);
+      final anyDist = points.any((p) => p.distTraveled != null);
+      w.u8(anyDist ? 1 : 0);
+      if (anyDist) {
+        w.u8List([for (final p in points) p.distTraveled == null ? 0 : 1]);
+        w.f64Column(points.length, (i) => points[i].distTraveled ?? 0);
+      }
+      for (var i = 0; i < shapes.length; i++) {
+        for (final p in shapes[i].points) {
+          if (p.shapeId != shapes[i].id) {
+            throw PlannerIndexEncodeException(
+              'shape ${shapes[i].id} holds a point of shape ${p.shapeId}',
+            );
+          }
+        }
+      }
+    });
+
+    final index = bundle.routeIndex;
+    final patterns = index.patterns.toList(growable: false);
+    _writeSection(w, _tagPatterns, () {
+      w.u32(patterns.length);
+      for (var i = 0; i < patterns.length; i++) {
+        final p = patterns[i];
+        if (p.id != i) {
+          throw PlannerIndexEncodeException(
+            'pattern at position $i has id ${p.id}',
+          );
+        }
+        if (p.cumDist.length != p.stopIds.length) {
+          throw PlannerIndexEncodeException(
+            'pattern $i has ${p.cumDist.length} cumDist for '
+            '${p.stopIds.length} stops',
+          );
+        }
+      }
+      w.uintColumn([for (final p in patterns) pool.ref(p.routeId)]);
+      w.uintColumn([for (final p in patterns) pool.ref(p.headsign)]);
+      w.uintColumn([for (final p in patterns) pool.ref(p.shapeId)]);
+      w.uintColumn([for (final p in patterns) p.stopIds.length]);
+      w.f64List([for (final p in patterns) p.minLat]);
+      w.f64List([for (final p in patterns) p.minLon]);
+      w.f64List([for (final p in patterns) p.maxLat]);
+      w.f64List([for (final p in patterns) p.maxLon]);
+      final stopRefs = <int>[];
+      final cumDist = <double>[];
+      for (final p in patterns) {
+        for (final id in p.stopIds) {
+          stopRefs.add(pool.ref(id));
+        }
+        cumDist.addAll(p.cumDist);
+      }
+      w.u32(stopRefs.length);
+      w.uintColumn(stopRefs);
+      w.f64List(cumDist);
+    });
+
+    _writeSection(w, _tagConnections, () {
+      w.uintColumn(index.connectionStarts);
+      w.uintColumn(index.connectionOtherPattern);
+      w.uintColumn(index.connectionMyStopIdx);
+      w.uintColumn(index.connectionOtherStopIdx);
+      w.f32List(index.connectionWalk);
+    });
+
+    _writeSection(w, _tagSpatial, () {
+      final positions = <String, int>{};
+      for (var i = 0; i < stops.length; i++) {
+        positions[stops[i].id] = i;
+      }
+      final preorder = bundle.spatialIndex.preorder;
+      if (preorder.length != stops.length) {
+        throw PlannerIndexEncodeException(
+          'spatial index holds ${preorder.length} stops, data ${stops.length}',
+        );
+      }
+      w.uintColumn([
+        for (final s in preorder)
+          positions[s.id] ??
+              (throw PlannerIndexEncodeException(
+                'spatial index stop ${s.id} is not in the data',
+              )),
+      ]);
+    });
+
+    _writeSection(w, _tagSchedule, () {
+      final positions = Map<GtfsStopTime, int>.identity();
+      for (var i = 0; i < stopTimes.length; i++) {
+        positions[stopTimes[i]] = i;
+      }
+      final groups = bundle.scheduleIndex.stopTimesByStop;
+      w.u32(groups.length);
+      w.uintColumn([for (final key in groups.keys) pool.ref(key)]);
+      w.uintColumn([for (final list in groups.values) list.length]);
+      final order = <int>[];
+      for (final list in groups.values) {
+        for (final st in list) {
+          order.add(
+            positions[st] ??
+                (throw PlannerIndexEncodeException(
+                  'schedule index holds a stop time that is not in the data',
+                )),
+          );
+        }
+      }
+      w.u32(order.length);
+      w.uintColumn(order);
+    });
+  }
+
+  static void _writeSection(_Writer w, int tag, void Function() body) {
+    w.align(8);
+    w.u32(tag);
+    final lengthAt = w.position;
+    w.u32(0);
+    final start = w.position;
+    body();
+    w.patchU32(lengthAt, w.position - start);
+    w.align(8);
+  }
+
+  static int _i32(int value, String what) {
+    if (value < _int32Min || value > _int32Max) {
+      throw PlannerIndexEncodeException('$what $value does not fit 32 bits');
+    }
+    return value;
+  }
+
+  /// GTFS times as whole seconds; `-1` encodes null.
+  static int _seconds(Duration? d, String what) {
+    if (d == null) return -1;
+    final us = d.inMicroseconds;
+    if (us % Duration.microsecondsPerSecond != 0) {
+      throw PlannerIndexEncodeException('$what $d is not whole seconds');
+    }
+    return _i32(d.inSeconds, what);
+  }
+
+  // ---------------------------------------------------------------------
+  // Decode
+  // ---------------------------------------------------------------------
+
+  /// Restores the bundle serialized in [bytes], or `null` when the blob is
+  /// not a valid snapshot for exactly this input: [fingerprint] must equal
+  /// the one given to [encode], [transferRadiusMeters] and
+  /// [sameNameRouteLimit] must equal the index's knobs, [formatVersion] must
+  /// match, and the blob must be intact (magic, trailer, section lengths,
+  /// checksum, every reference in range). Never throws for malformed input;
+  /// [onReject] receives a one-line reason when it returns `null`.
+  static PlannerIndexBundle? decode(
+    Uint8List bytes, {
+    required String fingerprint,
+    required double transferRadiusMeters,
+    required int sameNameRouteLimit,
+    void Function(String reason)? onReject,
+  }) {
+    try {
+      return _decode(
+        bytes,
+        fingerprint: fingerprint,
+        transferRadiusMeters: transferRadiusMeters,
+        sameNameRouteLimit: sameNameRouteLimit,
+      );
+    } on _Rejected catch (e) {
+      onReject?.call(e.reason);
+      return null;
+    } catch (e) {
+      // RangeError, StateError, FormatException… — a truncated or corrupted
+      // blob. The caller rebuilds; the reason is only for the log line.
+      onReject?.call('corrupt snapshot: $e');
+      return null;
+    }
+  }
+
+  static PlannerIndexBundle _decode(
+    Uint8List input, {
+    required String fingerprint,
+    required double transferRadiusMeters,
+    required int sameNameRouteLimit,
+  }) {
+    // Typed views need element-aligned offsets into the underlying buffer.
+    final bytes = input.offsetInBytes % 8 == 0
+        ? input
+        : Uint8List.fromList(input);
+    final r = _Reader(bytes);
+    if (bytes.length < 16) throw const _Rejected('too short');
+    for (var i = 0; i < 4; i++) {
+      if (r.u8() != _magic[i]) throw const _Rejected('not a planner snapshot');
+    }
+    for (var i = 0; i < 4; i++) {
+      if (bytes[bytes.length - 4 + i] != _trailer[i]) {
+        throw const _Rejected('truncated snapshot (no trailer)');
+      }
+    }
+    final version = r.u32();
+    if (version != formatVersion) {
+      throw _Rejected('format version $version, expected $formatVersion');
+    }
+    if (r.u32() != _byteOrderMarker) throw const _Rejected('byte order');
+    r.u32(); // reserved
+    final radius = r.f64();
+    final limit = r.i32();
+    if (radius != transferRadiusMeters || limit != sameNameRouteLimit) {
+      throw _Rejected(
+        'built for transferRadiusMeters $radius / sameNameRouteLimit $limit',
+      );
+    }
+    final storedFingerprint = r.string();
+    if (storedFingerprint != fingerprint) {
+      throw const _Rejected('GTFS fingerprint changed');
+    }
+    r.align(8);
+    final payloadLength = r.u32();
+    final checksum = r.u32();
+    r.align(8);
+    final payloadStart = r.position;
+    final payloadEnd = payloadStart + payloadLength;
+    if (payloadLength % 8 != 0 || payloadEnd + 4 != bytes.length) {
+      throw const _Rejected('payload length does not match the file');
+    }
+    if (_checksum(bytes, payloadStart, payloadEnd) != checksum) {
+      throw const _Rejected('checksum mismatch');
+    }
+
+    final pool = _StringPool.read(r, _tagStrings);
+
+    final agencies = r.section(_tagAgencies, () {
+      final n = r.u32();
+      return List<GtfsAgency>.generate(n, (_) {
+        return GtfsAgency(
+          id: pool.required(r.u32()),
+          name: pool.required(r.u32()),
+          url: pool.required(r.u32()),
+          timezone: pool.required(r.u32()),
+          lang: pool.optional(r.u32()),
+          phone: pool.optional(r.u32()),
+          fareUrl: pool.optional(r.u32()),
+          email: pool.optional(r.u32()),
+        );
+      });
+    });
+
+    final stopList = r.section(_tagStops, () {
+      final n = r.u32();
+      final id = r.uintColumn(n);
+      final name = r.uintColumn(n);
+      final code = r.uintColumn(n);
+      final desc = r.uintColumn(n);
+      final zone = r.uintColumn(n);
+      final url = r.uintColumn(n);
+      final parent = r.uintColumn(n);
+      final tz = r.uintColumn(n);
+      final platform = r.uintColumn(n);
+      final locationType = r.u8List(n);
+      final wheelchair = r.u8List(n);
+      final lat = r.f64List(n);
+      final lon = r.f64List(n);
+      return List<GtfsStop>.generate(n, (i) {
+        return GtfsStop(
+          id: pool.required(id[i]),
+          code: pool.optional(code[i]),
+          name: pool.required(name[i]),
+          description: pool.optional(desc[i]),
+          lat: lat[i],
+          lon: lon[i],
+          zoneId: pool.optional(zone[i]),
+          url: pool.optional(url[i]),
+          locationType: GtfsLocationType.fromValue(locationType[i]),
+          parentStation: pool.optional(parent[i]),
+          timezone: pool.optional(tz[i]),
+          wheelchairBoarding: GtfsWheelchairBoarding.fromValue(wheelchair[i]),
+          platformCode: pool.optional(platform[i]),
+        );
+      }, growable: false);
+    });
+    final stops = <String, GtfsStop>{for (final s in stopList) s.id: s};
+    if (stops.length != stopList.length) {
+      throw const _Rejected('duplicate stop ids');
+    }
+
+    final routeList = r.section(_tagRoutes, () {
+      final n = r.u32();
+      final id = r.uintColumn(n);
+      final agency = r.uintColumn(n);
+      final short = r.uintColumn(n);
+      final long = r.uintColumn(n);
+      final desc = r.uintColumn(n);
+      final url = r.uintColumn(n);
+      final color = r.uintColumn(n);
+      final textColor = r.uintColumn(n);
+      final type = r.intColumn(n);
+      final hasSort = r.u8List(n);
+      final sort = r.intColumn(n);
+      return List<GtfsRoute>.generate(n, (i) {
+        return GtfsRoute(
+          id: pool.required(id[i]),
+          agencyId: pool.optional(agency[i]),
+          shortName: pool.required(short[i]),
+          longName: pool.required(long[i]),
+          description: pool.optional(desc[i]),
+          type: GtfsRouteType.fromValue(type[i]),
+          url: pool.optional(url[i]),
+          colorHex: pool.optional(color[i]),
+          textColorHex: pool.optional(textColor[i]),
+          sortOrder: hasSort[i] == 0 ? null : sort[i],
+        );
+      }, growable: false);
+    });
+    final routes = <String, GtfsRoute>{for (final x in routeList) x.id: x};
+    if (routes.length != routeList.length) {
+      throw const _Rejected('duplicate route ids');
+    }
+
+    final tripList = r.section(_tagTrips, () {
+      final n = r.u32();
+      final id = r.uintColumn(n);
+      final route = r.uintColumn(n);
+      final service = r.uintColumn(n);
+      final headsign = r.uintColumn(n);
+      final short = r.uintColumn(n);
+      final block = r.uintColumn(n);
+      final shape = r.uintColumn(n);
+      final direction = r.u8List(n);
+      final wheelchair = r.u8List(n);
+      final bikes = r.u8List(n);
+      return List<GtfsTrip>.generate(n, (i) {
+        return GtfsTrip(
+          id: pool.required(id[i]),
+          routeId: pool.required(route[i]),
+          serviceId: pool.required(service[i]),
+          headsign: pool.optional(headsign[i]),
+          shortName: pool.optional(short[i]),
+          directionId: direction[i] == 0xff
+              ? null
+              : GtfsDirectionId.fromValue(direction[i]),
+          blockId: pool.optional(block[i]),
+          shapeId: pool.optional(shape[i]),
+          wheelchairAccessible: GtfsWheelchairAccessible.fromValue(
+            wheelchair[i],
+          ),
+          bikesAllowed: GtfsBikesAllowed.fromValue(bikes[i]),
+        );
+      }, growable: false);
+    });
+    final trips = <String, GtfsTrip>{for (final t in tripList) t.id: t};
+    if (trips.length != tripList.length) {
+      throw const _Rejected('duplicate trip ids');
+    }
+
+    final stopTimes = r.section(_tagStopTimes, () {
+      final n = r.u32();
+      final trip = r.uintColumn(n);
+      final stop = r.uintColumn(n);
+      final headsign = r.uintColumn(n);
+      final arrival = r.intColumn(n);
+      final departure = r.intColumn(n);
+      final sequence = r.intColumn(n);
+      final pickup = r.u8List(n);
+      final dropOff = r.u8List(n);
+      final timepoint = r.u8List(n);
+      final anyDist = r.u8() != 0;
+      final hasDist = anyDist ? r.u8List(n) : null;
+      final dist = anyDist ? r.f64List(n) : null;
+      return List<GtfsStopTime>.generate(n, (i) {
+        return GtfsStopTime(
+          tripId: pool.required(trip[i]),
+          arrivalTime: _duration(arrival[i]),
+          departureTime: _duration(departure[i]),
+          stopId: pool.required(stop[i]),
+          stopSequence: sequence[i],
+          stopHeadsign: pool.optional(headsign[i]),
+          pickupType: GtfsPickupType.fromValue(pickup[i]),
+          dropOffType: GtfsDropOffType.fromValue(dropOff[i]),
+          shapeDistTraveled: hasDist != null && hasDist[i] != 0
+              ? dist![i]
+              : null,
+          timepoint: GtfsTimepoint.fromValue(timepoint[i]),
+        );
+      }, growable: false);
+    });
+
+    final calendarList = r.section(_tagCalendars, () {
+      final n = r.u32();
+      return List<GtfsCalendar>.generate(n, (_) {
+        final serviceId = pool.required(r.u32());
+        final days = r.u8();
+        final startUtc = r.u8() != 0;
+        final endUtc = r.u8() != 0;
+        r.align(8);
+        final start = _dateTime(r.f64(), startUtc);
+        final end = _dateTime(r.f64(), endUtc);
+        return GtfsCalendar(
+          serviceId: serviceId,
+          monday: days & 1 != 0,
+          tuesday: days & 2 != 0,
+          wednesday: days & 4 != 0,
+          thursday: days & 8 != 0,
+          friday: days & 16 != 0,
+          saturday: days & 32 != 0,
+          sunday: days & 64 != 0,
+          startDate: start,
+          endDate: end,
+        );
+      });
+    });
+    final calendars = <String, GtfsCalendar>{
+      for (final c in calendarList) c.serviceId: c,
+    };
+    if (calendars.length != calendarList.length) {
+      throw const _Rejected('duplicate service ids');
+    }
+
+    final calendarDates = r.section(_tagCalendarDates, () {
+      final n = r.u32();
+      return List<GtfsCalendarDate>.generate(n, (_) {
+        final serviceId = pool.required(r.u32());
+        final exception = r.u8();
+        final utc = r.u8() != 0;
+        r.align(8);
+        return GtfsCalendarDate(
+          serviceId: serviceId,
+          date: _dateTime(r.f64(), utc),
+          exceptionType: GtfsExceptionType.fromValue(exception),
+        );
+      });
+    });
+
+    final frequencies = r.section(_tagFrequencies, () {
+      final n = r.u32();
+      final trip = r.uintColumn(n);
+      final start = r.intColumn(n);
+      final end = r.intColumn(n);
+      final headway = r.intColumn(n);
+      final exact = r.u8List(n);
+      return List<GtfsFrequency>.generate(n, (i) {
+        return GtfsFrequency(
+          tripId: pool.required(trip[i]),
+          startTime: _duration(start[i]) ?? Duration.zero,
+          endTime: _duration(end[i]) ?? Duration.zero,
+          headwaySecs: headway[i],
+          exactTimes: exact[i] != 0,
+        );
+      });
+    });
+
+    final shapes = r.section(_tagShapes, () {
+      final n = r.u32();
+      final id = r.uintColumn(n);
+      final counts = r.uintColumn(n);
+      final total = r.u32();
+      final lat = r.f64List(total);
+      final lon = r.f64List(total);
+      final sequence = r.intColumn(total);
+      final anyDist = r.u8() != 0;
+      final hasDist = anyDist ? r.u8List(total) : null;
+      final dist = anyDist ? r.f64List(total) : null;
+      final out = <String, GtfsShape>{};
+      var at = 0;
+      for (var i = 0; i < n; i++) {
+        final shapeId = pool.required(id[i]);
+        final count = counts[i];
+        if (at + count > total) throw const _Rejected('shape points overflow');
+        final points = List<GtfsShapePoint>.generate(count, (k) {
+          final j = at + k;
+          return GtfsShapePoint(
+            shapeId: shapeId,
+            lat: lat[j],
+            lon: lon[j],
+            sequence: sequence[j],
+            distTraveled: hasDist != null && hasDist[j] != 0 ? dist![j] : null,
+          );
+        });
+        at += count;
+        out[shapeId] = GtfsShape(id: shapeId, points: points);
+      }
+      if (at != total || out.length != n) {
+        throw const _Rejected('shape table inconsistent');
+      }
+      return out;
+    });
+
+    final data = GtfsData(
+      agencies: agencies,
+      stops: stops,
+      routes: routes,
+      trips: trips,
+      stopTimes: stopTimes,
+      calendars: calendars,
+      calendarDates: calendarDates,
+      frequencies: frequencies,
+      shapes: shapes,
+    );
+
+    final patterns = r.section(_tagPatterns, () {
+      final n = r.u32();
+      final route = r.uintColumn(n);
+      final headsign = r.uintColumn(n);
+      final shape = r.uintColumn(n);
+      final counts = r.uintColumn(n);
+      final minLat = r.f64List(n);
+      final minLon = r.f64List(n);
+      final maxLat = r.f64List(n);
+      final maxLon = r.f64List(n);
+      final total = r.u32();
+      final stopRefs = r.uintColumn(total);
+      final cumDist = r.f64List(total);
+      final out = <RoutePattern>[];
+      var at = 0;
+      for (var i = 0; i < n; i++) {
+        final count = counts[i];
+        if (at + count > total) throw const _Rejected('pattern stops overflow');
+        final stopIds = List<String>.generate(
+          count,
+          (k) => pool.required(stopRefs[at + k]),
+          growable: false,
+        );
+        out.add(
+          RoutePattern(
+            id: i,
+            routeId: pool.required(route[i]),
+            stopIds: stopIds,
+            headsign: pool.optional(headsign[i]),
+            shapeId: pool.optional(shape[i]),
+            cumDist: Float64List.fromList(cumDist.sublist(at, at + count)),
+            minLat: minLat[i],
+            minLon: minLon[i],
+            maxLat: maxLat[i],
+            maxLon: maxLon[i],
+          ),
+        );
+        at += count;
+      }
+      if (at != total) throw const _Rejected('pattern table inconsistent');
+      return out;
+    });
+
+    final routeIndex = r.section(_tagConnections, () {
+      final starts = r.uintColumn(patterns.length + 1);
+      final total = starts.isEmpty ? 0 : starts.last;
+      for (var i = 1; i < starts.length; i++) {
+        if (starts[i] < starts[i - 1]) throw const _Rejected('CSR offsets');
+      }
+      final other = r.uintColumn(total);
+      final myIdx = r.uintColumn(total);
+      final otherIdx = r.uintColumn(total);
+      final walk = r.f32List(total);
+      // Every entry must point inside the table it indexes; a corrupted
+      // entry that survived the checksum would otherwise crash a query.
+      for (var p = 0; p < patterns.length; p++) {
+        final stopCount = patterns[p].stopIds.length;
+        for (var k = starts[p]; k < starts[p + 1]; k++) {
+          final q = other[k];
+          if (q < 0 || q >= patterns.length || q == p) {
+            throw const _Rejected('connection to an unknown pattern');
+          }
+          if (myIdx[k] < 0 ||
+              myIdx[k] >= stopCount ||
+              otherIdx[k] < 0 ||
+              otherIdx[k] >= patterns[q].stopIds.length) {
+            throw const _Rejected('connection stop position out of range');
+          }
+        }
+      }
+      return GtfsRouteIndex.restore(
+        data: data,
+        patterns: patterns,
+        connectionStarts: starts,
+        connectionOtherPattern: other,
+        connectionMyStopIdx: myIdx,
+        connectionOtherStopIdx: otherIdx,
+        connectionWalk: walk,
+        transferRadiusMeters: transferRadiusMeters,
+        sameNameRouteLimit: sameNameRouteLimit,
+      );
+    });
+
+    final spatialIndex = r.section(_tagSpatial, () {
+      final positions = r.uintColumn(stopList.length);
+      final seen = Uint8List(stopList.length);
+      final preorder = List<GtfsStop>.generate(stopList.length, (i) {
+        final p = positions[i];
+        if (p < 0 || p >= stopList.length || seen[p] != 0) {
+          throw const _Rejected('spatial pre-order is not a permutation');
+        }
+        seen[p] = 1;
+        return stopList[p];
+      }, growable: false);
+      return GtfsSpatialIndex.restore(stops, preorder);
+    });
+
+    final scheduleIndex = r.section(_tagSchedule, () {
+      final groups = r.u32();
+      final keys = r.uintColumn(groups);
+      final counts = r.uintColumn(groups);
+      final total = r.u32();
+      final order = r.uintColumn(total);
+      final byStop = <String, List<GtfsStopTime>>{};
+      var at = 0;
+      for (var g = 0; g < groups; g++) {
+        final count = counts[g];
+        if (at + count > total) throw const _Rejected('schedule overflow');
+        final list = <GtfsStopTime>[];
+        for (var k = 0; k < count; k++) {
+          final idx = order[at + k];
+          if (idx < 0 || idx >= stopTimes.length) {
+            throw const _Rejected('schedule stop time out of range');
+          }
+          list.add(stopTimes[idx]);
+        }
+        at += count;
+        byStop[pool.required(keys[g])] = list;
+      }
+      if (at != total || byStop.length != groups) {
+        throw const _Rejected('schedule table inconsistent');
+      }
+      return GtfsScheduleIndex.restore(
+        trips: trips,
+        stopTimes: stopTimes,
+        calendars: calendars,
+        calendarDates: calendarDates,
+        frequencies: frequencies,
+        stopTimesByStop: byStop,
+      );
+    });
+
+    r.align(8);
+    if (r.position != payloadEnd) {
+      throw const _Rejected('trailing bytes after the last section');
+    }
+
+    return PlannerIndexBundle(
+      data: data,
+      spatialIndex: spatialIndex,
+      routeIndex: routeIndex,
+      scheduleIndex: scheduleIndex,
+    );
+  }
+
+  static Duration? _duration(int seconds) =>
+      seconds < 0 ? null : Duration(seconds: seconds);
+
+  static DateTime _dateTime(double microseconds, bool isUtc) {
+    if (microseconds.isNaN ||
+        microseconds.isInfinite ||
+        microseconds != microseconds.truncateToDouble()) {
+      throw const _Rejected('date is not a whole number of microseconds');
+    }
+    return DateTime.fromMicrosecondsSinceEpoch(
+      microseconds.toInt(),
+      isUtc: isUtc,
+    );
+  }
+}
+
+/// Internal: a validation failure with a reason for the log line.
+class _Rejected implements Exception {
+  final String reason;
+
+  const _Rejected(this.reason);
+}
+
+/// Deduplicated string table; `0` is the null reference, `i + 1` the
+/// `i`-th string.
+class _StringPool {
+  final Map<String, int> _index;
+  final List<String> _strings;
+
+  _StringPool() : _index = {}, _strings = [];
+
+  /// Read side: only [optional] / [required] are used.
+  _StringPool._restored(this._strings) : _index = const {};
+
+  int ref(String? s) {
+    if (s == null) return 0;
+    final existing = _index[s];
+    if (existing != null) return existing;
+    _strings.add(s);
+    return _index[s] = _strings.length;
+  }
+
+  void write(_Writer w) {
+    final encoded = [for (final s in _strings) utf8.encode(s)];
+    w.u32(encoded.length);
+    var offset = 0;
+    final offsets = <int>[];
+    for (final e in encoded) {
+      offsets.add(offset);
+      offset += e.length;
+    }
+    offsets.add(offset);
+    w.uintColumn(offsets);
+    for (final e in encoded) {
+      w.rawBytes(e);
+    }
+  }
+
+  static _StringPool read(_Reader r, int tag) {
+    return r.section(tag, () {
+      final n = r.u32();
+      final offsets = r.uintColumn(n + 1);
+      final start = r.position;
+      final total = offsets.isEmpty ? 0 : offsets.last;
+      r.skip(total);
+      final strings = List<String>.generate(n, (i) {
+        final from = offsets[i];
+        final to = offsets[i + 1];
+        if (from < 0 || to < from || to > total) {
+          throw const _Rejected('string pool offsets');
+        }
+        return utf8.decoder.convert(r.bytes, start + from, start + to);
+      }, growable: false);
+      return _StringPool._restored(strings);
+    });
+  }
+
+  String? optional(int ref) {
+    if (ref == 0) return null;
+    if (ref < 0 || ref > _strings.length) {
+      throw const _Rejected('string reference out of range');
+    }
+    return _strings[ref - 1];
+  }
+
+  String required(int ref) {
+    final s = optional(ref);
+    if (s == null) throw const _Rejected('missing required string');
+    return s;
+  }
+}
+
+/// Growable little writer over a `Uint8List` with typed-view bulk writes.
+class _Writer {
+  Uint8List _buf = Uint8List(1 << 16);
+  late ByteData _data = ByteData.view(_buf.buffer);
+  int _pos = 0;
+
+  int get position => _pos;
+
+  void _ensure(int extra) {
+    final needed = _pos + extra;
+    if (needed <= _buf.length) return;
+    var capacity = _buf.length;
+    while (capacity < needed) {
+      capacity *= 2;
+    }
+    final grown = Uint8List(capacity);
+    grown.setRange(0, _pos, _buf);
+    _buf = grown;
+    _data = ByteData.view(grown.buffer);
+  }
+
+  void align(int n) {
+    final pad = (n - _pos % n) % n;
+    _ensure(pad);
+    for (var i = 0; i < pad; i++) {
+      _buf[_pos++] = 0;
+    }
+  }
+
+  void u8(int v) {
+    _ensure(1);
+    _buf[_pos++] = v;
+  }
+
+  void u32(int v) {
+    _ensure(4);
+    _data.setUint32(_pos, v, Endian.host);
+    _pos += 4;
+  }
+
+  void i32(int v) {
+    _ensure(4);
+    _data.setInt32(_pos, v, Endian.host);
+    _pos += 4;
+  }
+
+  void f64(double v) {
+    _ensure(8);
+    _data.setFloat64(_pos, v, Endian.host);
+    _pos += 8;
+  }
+
+  void patchU32(int at, int v) => _data.setUint32(at, v, Endian.host);
+
+  void rawBytes(List<int> bytes) {
+    _ensure(bytes.length);
+    _buf.setRange(_pos, _pos + bytes.length, bytes);
+    _pos += bytes.length;
+  }
+
+  void string(String s) {
+    final encoded = utf8.encode(s);
+    u32(encoded.length);
+    rawBytes(encoded);
+  }
+
+  void u8List(List<int> values) {
+    u32(values.length);
+    rawBytes(values);
+  }
+
+  void f64List(List<double> values) {
+    f64Column(values.length, (i) => values[i]);
+  }
+
+  /// Float64 column written straight into the buffer (no boxed list of
+  /// doubles in between — the shape table alone has 357k points on the
+  /// Cochabamba feed).
+  void f64Column(int count, double Function(int index) valueAt) {
+    u32(count);
+    align(8);
+    _ensure(count * 8);
+    final view = Float64List.view(_buf.buffer, _pos, count);
+    for (var i = 0; i < count; i++) {
+      view[i] = valueAt(i);
+    }
+    _pos += count * 8;
+  }
+
+  void f32List(Float32List values) {
+    u32(values.length);
+    align(4);
+    _ensure(values.length * 4);
+    Float32List.view(_buf.buffer, _pos, values.length).setAll(0, values);
+    _pos += values.length * 4;
+  }
+
+  /// Non-negative integers with the narrowest width their maximum fits.
+  void uintColumn(List<int> values) {
+    var max = 0;
+    for (final v in values) {
+      if (v < 0) {
+        throw PlannerIndexEncodeException('negative value $v in uint column');
+      }
+      if (v > max) max = v;
+    }
+    if (max > 0xffffffff) {
+      throw PlannerIndexEncodeException('value $max does not fit 32 bits');
+    }
+    final width = max < 0x100 ? 1 : (max < 0x10000 ? 2 : 4);
+    u32(values.length);
+    u8(width);
+    u8(0); // unsigned
+    align(width);
+    _ensure(values.length * width);
+    switch (width) {
+      case 1:
+        _buf.setRange(_pos, _pos + values.length, values);
+      case 2:
+        Uint16List.view(_buf.buffer, _pos, values.length).setAll(0, values);
+      default:
+        Uint32List.view(_buf.buffer, _pos, values.length).setAll(0, values);
+    }
+    _pos += values.length * width;
+  }
+
+  /// Signed 32-bit integers (always 4 bytes; used where `-1` means null).
+  void intColumn(List<int> values) {
+    u32(values.length);
+    u8(4);
+    u8(1); // signed
+    align(4);
+    _ensure(values.length * 4);
+    Int32List.view(_buf.buffer, _pos, values.length).setAll(0, values);
+    _pos += values.length * 4;
+  }
+
+  Uint8List finish({List<int> trailer = const []}) {
+    rawBytes(trailer);
+    return _buf.sublist(0, _pos);
+  }
+}
+
+/// Cursor over the blob; every read is bounds-checked against the blob
+/// itself (not just the underlying buffer) so truncation surfaces as an
+/// exception that [PlannerIndexCodec.decode] turns into `null`.
+class _Reader {
+  final Uint8List bytes;
+  final ByteData _data;
+  int _pos = 0;
+
+  _Reader(this.bytes) : _data = ByteData.sublistView(bytes);
+
+  int get position => _pos;
+
+  void _need(int n) {
+    if (n < 0 || _pos + n > bytes.length) {
+      throw const _Rejected('truncated snapshot');
+    }
+  }
+
+  void skip(int n) {
+    _need(n);
+    _pos += n;
+  }
+
+  void align(int n) => skip((n - _pos % n) % n);
+
+  int u8() {
+    _need(1);
+    return bytes[_pos++];
+  }
+
+  int u32() {
+    _need(4);
+    final v = _data.getUint32(_pos, Endian.host);
+    _pos += 4;
+    return v;
+  }
+
+  int i32() {
+    _need(4);
+    final v = _data.getInt32(_pos, Endian.host);
+    _pos += 4;
+    return v;
+  }
+
+  double f64() {
+    _need(8);
+    final v = _data.getFloat64(_pos, Endian.host);
+    _pos += 8;
+    return v;
+  }
+
+  String string() {
+    final n = u32();
+    _need(n);
+    final s = utf8.decoder.convert(bytes, _pos, _pos + n);
+    _pos += n;
+    return s;
+  }
+
+  T section<T>(int tag, T Function() body) {
+    align(8);
+    final actual = u32();
+    if (actual != tag) throw _Rejected('expected section $tag, found $actual');
+    final length = u32();
+    final start = _pos;
+    _need(length);
+    final result = body();
+    if (_pos - start != length) {
+      throw _Rejected('section $tag length mismatch');
+    }
+    align(8);
+    return result;
+  }
+
+  int _count(int expected) {
+    final n = u32();
+    if (n != expected) throw const _Rejected('column length mismatch');
+    return n;
+  }
+
+  Uint8List u8List(int expected) {
+    final n = _count(expected);
+    _need(n);
+    final view = Uint8List.sublistView(bytes, _pos, _pos + n);
+    _pos += n;
+    return view;
+  }
+
+  /// A copy, so the blob's buffer is not kept alive by the restored index.
+  Float64List f64List(int expected) {
+    final n = _count(expected);
+    align(8);
+    _need(n * 8);
+    final view = Float64List.view(bytes.buffer, bytes.offsetInBytes + _pos, n);
+    _pos += n * 8;
+    return Float64List.fromList(view);
+  }
+
+  Float32List f32List(int expected) {
+    final n = _count(expected);
+    align(4);
+    _need(n * 4);
+    final view = Float32List.view(bytes.buffer, bytes.offsetInBytes + _pos, n);
+    _pos += n * 4;
+    return Float32List.fromList(view);
+  }
+
+  /// Widens a stored column (any width, signed or not) to an `Int32List`.
+  Int32List _column(int expected) {
+    final n = _count(expected);
+    final width = u8();
+    final signed = u8() != 0;
+    if (width != 1 && width != 2 && width != 4) {
+      throw const _Rejected('column width');
+    }
+    align(width);
+    _need(n * width);
+    final base = bytes.offsetInBytes + _pos;
+    final out = Int32List(n);
+    switch (width) {
+      case 1:
+        out.setAll(0, Uint8List.view(bytes.buffer, base, n));
+      case 2:
+        out.setAll(0, Uint16List.view(bytes.buffer, base, n));
+      default:
+        if (signed) {
+          out.setAll(0, Int32List.view(bytes.buffer, base, n));
+        } else {
+          final view = Uint32List.view(bytes.buffer, base, n);
+          for (var i = 0; i < n; i++) {
+            final v = view[i];
+            if (v > 0x7fffffff) throw const _Rejected('value beyond int32');
+            out[i] = v;
+          }
+        }
+    }
+    _pos += n * width;
+    return out;
+  }
+
+  Int32List uintColumn(int expected) => _column(expected);
+
+  Int32List intColumn(int expected) => _column(expected);
+}

--- a/packages/trufi_core_planner/lib/trufi_core_planner.dart
+++ b/packages/trufi_core_planner/lib/trufi_core_planner.dart
@@ -24,6 +24,10 @@ export 'src/index/gtfs_schedule_index.dart';
 // Services
 export 'src/services/gtfs_routing_service.dart';
 
+// Snapshot (persisted index, #993)
+export 'src/snapshot/planner_index_bundle.dart';
+export 'src/snapshot/planner_index_codec.dart';
+
 // Client
 export 'src/client/planner_routing_client.dart';
 export 'src/client/local_planner_client.dart';

--- a/packages/trufi_core_planner/test/planner_index_codec_test.dart
+++ b/packages/trufi_core_planner/test/planner_index_codec_test.dart
@@ -662,6 +662,62 @@ void main() {
       }
     });
 
+    test('forged counts and offsets (valid checksum) are rejected by their '
+        'bounds before anything is allocated', () {
+      // Header: magic, version, marker, stringsOffset, f64, i32, then the
+      // fingerprint (u32 length + bytes), aligned to 8; then payload
+      // length + checksum, aligned to 8. The checksum covers the payload
+      // only, so a forged header field needs no fix-up; a forged payload
+      // word gets the checksum recomputed here (FNV-1a over u32 words,
+      // like the codec).
+      final data = ByteData.sublistView(blob);
+      var at = 32 + data.getUint32(28, Endian.host);
+      at = (at + 7) & ~7;
+      final payloadLength = data.getUint32(at, Endian.host);
+      final checksumAt = at + 4;
+      final payloadStart = (at + 8 + 7) & ~7;
+      Uint8List forgePayload(int offset, int value) {
+        final other = Uint8List.fromList(blob);
+        final d = ByteData.sublistView(other);
+        d.setUint32(offset, value, Endian.host);
+        var h = 0x811c9dc5;
+        for (var i = payloadStart; i < payloadStart + payloadLength; i += 4) {
+          h = ((h ^ d.getUint32(i, Endian.host)) * 0x01000193) & 0xffffffff;
+        }
+        d.setUint32(checksumAt, h, Endian.host);
+        return other;
+      }
+
+      // Sections are (tag u32, length u32, body) in order, 8-aligned;
+      // agencies = 2, calendars = 7, calendar dates = 8 start with u32 n.
+      int bodyOf(int tag) {
+        var pos = payloadStart;
+        while (pos < payloadStart + payloadLength) {
+          final t = data.getUint32(pos, Endian.host);
+          final len = data.getUint32(pos + 4, Endian.host);
+          if (t == tag) return pos + 8;
+          pos = (pos + 8 + len + 7) & ~7;
+        }
+        fail('section $tag not found');
+      }
+
+      for (final tag in [2, 7, 8]) {
+        final sw = Stopwatch()..start();
+        expect(
+          rejectReason(forgePayload(bodyOf(tag), 0x7fffffff)),
+          contains('truncated'),
+          reason: 'section $tag: the count must fail the byte bound',
+        );
+        expect(sw.elapsedMilliseconds, lessThan(2000));
+      }
+      // String pool offset: beyond the payload, or not 8-aligned.
+      for (final offset in [payloadLength, payloadLength - 4, 12]) {
+        final other = Uint8List.fromList(blob);
+        ByteData.sublistView(other).setUint32(12, offset, Endian.host);
+        expect(rejectReason(other), contains('string pool offset'));
+      }
+    });
+
     test('trailing or missing trailer → null', () {
       final longer = Uint8List(blob.length + 8)..setRange(0, blob.length, blob);
       expect(rejectReason(longer), isNotNull);

--- a/packages/trufi_core_planner/test/planner_index_codec_test.dart
+++ b/packages/trufi_core_planner/test/planner_index_codec_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
@@ -6,6 +7,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:test/test.dart';
 import 'package:trufi_core_planner/trufi_core_planner.dart';
 
+import 'support/bundle_dump.dart';
 import 'support/connection_tables.dart';
 
 /// The persisted planner index (#993): a snapshot must restore exactly the
@@ -633,14 +635,30 @@ void main() {
       }
     });
 
-    test('a single flipped byte anywhere in the payload → null', () {
+    test('a single flipped bit anywhere → null', () {
       final rnd = Random(7);
-      // Header + string pool live in the first KB; the rest is payload.
       for (var i = 0; i < 300; i++) {
         final at = rnd.nextInt(blob.length - 4);
         final other = Uint8List.fromList(blob);
         other[at] ^= 0x01 << rnd.nextInt(8);
         expect(rejectReason(other), isNotNull, reason: 'flip at $at');
+      }
+    });
+
+    test('every bit of the header is validated (no reserved bytes)', () {
+      // The header is 56 bytes; the checksum covers the payload only, so
+      // each header field must be caught by its own check — including the
+      // string pool offset, which is validated against the payload.
+      for (var at = 0; at < 64; at++) {
+        for (var bit = 0; bit < 8; bit++) {
+          final other = Uint8List.fromList(blob);
+          other[at] ^= 1 << bit;
+          expect(
+            rejectReason(other),
+            isNotNull,
+            reason: 'byte $at bit $bit accepted',
+          );
+        }
       }
     });
 
@@ -721,34 +739,38 @@ void main() {
   });
 
   group('format version guard', () {
-    test('the integer skeleton of the fixture snapshot is pinned — if this '
-        'fails, the index build changed: bump PlannerIndexCodec.formatVersion '
-        'and update the digest', () {
-      final loaded = load(blob);
-      final sb = StringBuffer();
-      final index = loaded.routeIndex;
-      for (var p = 0; p < index.patternCount; p++) {
-        final pat = index.patternById(p);
-        sb.writeln('P $p ${pat.routeId} ${pat.stopIds.join(',')}');
-        final c = index.getConnectionsFor(p);
-        for (var k = 0; k < c.length; k++) {
-          sb.writeln(
-            'C ${c.otherPatternIdAt(k)} ${c.myStopIdxAt(k)} '
-            '${c.otherStopIdxAt(k)}',
-          );
-        }
-      }
-      sb.writeln(
-        'S ${loaded.spatialIndex.preorder.map((s) => s.id).join(',')}',
-      );
-      for (final e in loaded.scheduleIndex.stopTimesByStop.entries) {
-        sb.writeln('T ${e.key} ${e.value.map((st) => st.tripId).join(',')}');
-      }
-      final digest = PlannerIndexCodec.fingerprint(
-        Uint8List.fromList(sb.toString().codeUnits),
-      );
-      expect(PlannerIndexCodec.formatVersion, 1);
-      expect(digest, '94eb0e89a69b5fd9');
-    });
+    test(
+      'every field of the fixture bundle is pinned — if this fails, the '
+      'parser or an index build now produces something different from the '
+      'same GTFS: bump PlannerIndexCodec.formatVersion and update the digest',
+      () {
+        // The snapshot persists the parsed data as well as the indices, and
+        // the cache directory survives app updates: a core release that
+        // changes any of it without bumping the version would keep serving
+        // last release's output from the cache (the #973 failure mode).
+        // The dump covers every field of GtfsData (stop names, colours,
+        // times, shape points…), every pattern field (cumDist, bbox,
+        // headsign, shape), all four connection columns, line keys, the
+        // per-stop lookup order, the KD-tree pre-order and the schedule
+        // groups; calendar instants go in as year-month-day (local time).
+        final text = describeBundle(built);
+        expect(
+          describeBundle(load(blob)),
+          text,
+          reason: 'the restored bundle differs from the built one',
+        );
+        expect(text.split('\n').length, greaterThan(3000));
+        final digest = PlannerIndexCodec.fingerprint(utf8.encode(text));
+        expect(PlannerIndexCodec.formatVersion, 1);
+        expect(
+          digest,
+          '4023095d04461e4c',
+          reason:
+              'the planner now builds or parses something different from the '
+              'same GTFS — bump PlannerIndexCodec.formatVersion so cached '
+              'snapshots are rebuilt, then update this digest',
+        );
+      },
+    );
   });
 }

--- a/packages/trufi_core_planner/test/planner_index_codec_test.dart
+++ b/packages/trufi_core_planner/test/planner_index_codec_test.dart
@@ -1,0 +1,754 @@
+import 'dart:io';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:latlong2/latlong.dart';
+import 'package:test/test.dart';
+import 'package:trufi_core_planner/trufi_core_planner.dart';
+
+import 'support/connection_tables.dart';
+
+/// The persisted planner index (#993): a snapshot must restore exactly the
+/// state the build produces, and anything that is not a snapshot for this
+/// very input must be refused — never trusted, never crash.
+void main() {
+  final file = File('test/fixtures/sanaa_issue2_mini.gtfs.zip');
+  late Uint8List zip;
+  late String fingerprint;
+  late PlannerIndexBundle built;
+  late Uint8List blob;
+
+  setUpAll(() {
+    expect(
+      file.existsSync(),
+      isTrue,
+      reason: 'run from the package root: ${file.absolute.path}',
+    );
+    zip = file.readAsBytesSync();
+    fingerprint = PlannerIndexCodec.fingerprint(zip);
+    built = PlannerIndexBundle.build(zip);
+    blob = PlannerIndexCodec.encode(built, fingerprint: fingerprint);
+  });
+
+  PlannerIndexBundle load(
+    Uint8List bytes, {
+    String? fp,
+    double radius = GtfsRouteIndex.defaultTransferRadiusMeters,
+    int limit = GtfsRouteIndex.defaultSameNameRouteLimit,
+  }) {
+    String? reason;
+    final bundle = PlannerIndexCodec.decode(
+      bytes,
+      fingerprint: fp ?? fingerprint,
+      transferRadiusMeters: radius,
+      sameNameRouteLimit: limit,
+      onReject: (r) => reason = r,
+    );
+    expect(bundle, isNotNull, reason: 'rejected: $reason');
+    return bundle!;
+  }
+
+  String? rejectReason(
+    Uint8List bytes, {
+    String? fp,
+    double radius = GtfsRouteIndex.defaultTransferRadiusMeters,
+    int limit = GtfsRouteIndex.defaultSameNameRouteLimit,
+  }) {
+    String? reason;
+    final bundle = PlannerIndexCodec.decode(
+      bytes,
+      fingerprint: fp ?? fingerprint,
+      transferRadiusMeters: radius,
+      sameNameRouteLimit: limit,
+      onReject: (r) => reason = r,
+    );
+    expect(bundle, isNull, reason: 'should have been rejected');
+    return reason;
+  }
+
+  /// Canonical text of an itinerary: every field a caller can observe.
+  String pathKey(RoutingPath p) => [
+    p.originStop.id,
+    p.originWalkDistance.toStringAsFixed(4),
+    for (final s in p.segments)
+      '${s.route.id}/${s.pattern.id}/${s.fromIdx}-${s.toIdx}/'
+          '${s.fromStop.id}>${s.toStop.id}/${s.stopCount}/'
+          '${s.stops.map((x) => x.id).join(',')}/'
+          '${s.shapePoints.length}/${s.transitDistance.toStringAsFixed(4)}/'
+          '${s.headsign}',
+    p.destinationStop.id,
+    p.destinationWalkDistance.toStringAsFixed(4),
+    p.transferWalkDistance.toStringAsFixed(4),
+    p.score.toStringAsFixed(6),
+  ].join('|');
+
+  List<RoutingPath> plan(PlannerIndexBundle b, LatLng from, LatLng to) {
+    return GtfsRoutingService(
+      data: b.data,
+      spatialIndex: b.spatialIndex,
+      routeIndex: b.routeIndex,
+    ).findRoutes(
+      origin: from,
+      destination: to,
+      maxWalkDistance: 1500,
+      maxResults: 5,
+      maxStopCandidates: 150,
+      maxDirects: 5,
+      maxTransferPaths: 5,
+    );
+  }
+
+  group('round trip restores the parsed data field by field', () {
+    late PlannerIndexBundle loaded;
+    setUpAll(() => loaded = load(blob));
+
+    test('agencies', () {
+      expect(loaded.data.agencies.length, built.data.agencies.length);
+      for (var i = 0; i < built.data.agencies.length; i++) {
+        final a = built.data.agencies[i], b = loaded.data.agencies[i];
+        expect(
+          [
+            b.id,
+            b.name,
+            b.url,
+            b.timezone,
+            b.lang,
+            b.phone,
+            b.fareUrl,
+            b.email,
+          ],
+          [
+            a.id,
+            a.name,
+            a.url,
+            a.timezone,
+            a.lang,
+            a.phone,
+            a.fareUrl,
+            a.email,
+          ],
+        );
+      }
+    });
+
+    test('stops, in map order, every field', () {
+      expect(loaded.data.stops.keys, orderedEquals(built.data.stops.keys));
+      for (final a in built.data.stops.values) {
+        final b = loaded.data.stops[a.id]!;
+        expect(
+          [
+            b.id,
+            b.code,
+            b.name,
+            b.description,
+            b.lat,
+            b.lon,
+            b.zoneId,
+            b.url,
+            b.locationType,
+            b.parentStation,
+            b.timezone,
+            b.wheelchairBoarding,
+            b.platformCode,
+          ],
+          [
+            a.id,
+            a.code,
+            a.name,
+            a.description,
+            a.lat,
+            a.lon,
+            a.zoneId,
+            a.url,
+            a.locationType,
+            a.parentStation,
+            a.timezone,
+            a.wheelchairBoarding,
+            a.platformCode,
+          ],
+        );
+      }
+      // The fixture is Arabic: the string pool must round-trip UTF-8.
+      expect(
+        loaded.data.stops.values.any((s) => s.name.contains('شارع')),
+        isTrue,
+      );
+    });
+
+    test('routes, trips, calendars, frequencies', () {
+      expect(loaded.data.routes.keys, orderedEquals(built.data.routes.keys));
+      for (final a in built.data.routes.values) {
+        final b = loaded.data.routes[a.id]!;
+        expect(
+          [
+            b.agencyId,
+            b.shortName,
+            b.longName,
+            b.description,
+            b.type,
+            b.url,
+            b.colorHex,
+            b.textColorHex,
+            b.sortOrder,
+          ],
+          [
+            a.agencyId,
+            a.shortName,
+            a.longName,
+            a.description,
+            a.type,
+            a.url,
+            a.colorHex,
+            a.textColorHex,
+            a.sortOrder,
+          ],
+        );
+      }
+      expect(loaded.data.trips.keys, orderedEquals(built.data.trips.keys));
+      for (final a in built.data.trips.values) {
+        final b = loaded.data.trips[a.id]!;
+        expect(
+          [
+            b.routeId,
+            b.serviceId,
+            b.headsign,
+            b.shortName,
+            b.directionId,
+            b.blockId,
+            b.shapeId,
+            b.wheelchairAccessible,
+            b.bikesAllowed,
+          ],
+          [
+            a.routeId,
+            a.serviceId,
+            a.headsign,
+            a.shortName,
+            a.directionId,
+            a.blockId,
+            a.shapeId,
+            a.wheelchairAccessible,
+            a.bikesAllowed,
+          ],
+        );
+      }
+      expect(
+        loaded.data.calendars.keys,
+        orderedEquals(built.data.calendars.keys),
+      );
+      for (final a in built.data.calendars.values) {
+        final b = loaded.data.calendars[a.serviceId]!;
+        expect(
+          [
+            b.monday,
+            b.tuesday,
+            b.wednesday,
+            b.thursday,
+            b.friday,
+            b.saturday,
+            b.sunday,
+            b.startDate,
+            b.endDate,
+            b.startDate.isUtc,
+          ],
+          [
+            a.monday,
+            a.tuesday,
+            a.wednesday,
+            a.thursday,
+            a.friday,
+            a.saturday,
+            a.sunday,
+            a.startDate,
+            a.endDate,
+            a.startDate.isUtc,
+          ],
+        );
+      }
+      expect(loaded.data.calendarDates.length, built.data.calendarDates.length);
+      expect(loaded.data.frequencies.length, built.data.frequencies.length);
+      for (var i = 0; i < built.data.frequencies.length; i++) {
+        final a = built.data.frequencies[i], b = loaded.data.frequencies[i];
+        expect(
+          [b.tripId, b.startTime, b.endTime, b.headwaySecs, b.exactTimes],
+          [a.tripId, a.startTime, a.endTime, a.headwaySecs, a.exactTimes],
+        );
+      }
+    });
+
+    test('stop times, in file order', () {
+      expect(loaded.data.stopTimes.length, built.data.stopTimes.length);
+      for (var i = 0; i < built.data.stopTimes.length; i++) {
+        final a = built.data.stopTimes[i], b = loaded.data.stopTimes[i];
+        expect(
+          [
+            b.tripId,
+            b.arrivalTime,
+            b.departureTime,
+            b.stopId,
+            b.stopSequence,
+            b.stopHeadsign,
+            b.pickupType,
+            b.dropOffType,
+            b.shapeDistTraveled,
+            b.timepoint,
+          ],
+          [
+            a.tripId,
+            a.arrivalTime,
+            a.departureTime,
+            a.stopId,
+            a.stopSequence,
+            a.stopHeadsign,
+            a.pickupType,
+            a.dropOffType,
+            a.shapeDistTraveled,
+            a.timepoint,
+          ],
+        );
+      }
+    });
+
+    test('shapes with every point (Float64 coordinates, no rounding)', () {
+      expect(loaded.data.shapes.keys, orderedEquals(built.data.shapes.keys));
+      var points = 0;
+      for (final a in built.data.shapes.values) {
+        final b = loaded.data.shapes[a.id]!;
+        expect(b.points.length, a.points.length);
+        for (var i = 0; i < a.points.length; i++) {
+          final pa = a.points[i], pb = b.points[i];
+          expect(
+            [pb.shapeId, pb.lat, pb.lon, pb.sequence, pb.distTraveled],
+            [pa.shapeId, pa.lat, pa.lon, pa.sequence, pa.distTraveled],
+          );
+          points++;
+        }
+      }
+      expect(points, greaterThan(500));
+    });
+  });
+
+  group('round trip restores the indices', () {
+    late PlannerIndexBundle loaded;
+    setUpAll(() => loaded = load(blob));
+
+    test('patterns: ids, stops, cumDist, bbox, line keys', () {
+      final a = built.routeIndex, b = loaded.routeIndex;
+      expect(b.patternCount, a.patternCount);
+      expect(b.transferRadiusMeters, a.transferRadiusMeters);
+      expect(b.sameNameRouteLimit, a.sameNameRouteLimit);
+      for (var i = 0; i < a.patternCount; i++) {
+        final pa = a.patternById(i), pb = b.patternById(i);
+        expect(pb.id, pa.id);
+        expect(pb.routeId, pa.routeId);
+        expect(pb.stopIds, orderedEquals(pa.stopIds));
+        expect(pb.headsign, pa.headsign);
+        expect(pb.shapeId, pa.shapeId);
+        expect(pb.cumDist, orderedEquals(pa.cumDist));
+        expect(
+          [pb.minLat, pb.minLon, pb.maxLat, pb.maxLon],
+          [pa.minLat, pa.minLon, pa.maxLat, pa.maxLon],
+        );
+        for (final stopId in pa.stopIds) {
+          expect(pb.indexOfStop(stopId), pa.indexOfStop(stopId));
+        }
+      }
+      for (final route in built.data.routes.values) {
+        expect(b.lineKeyForRoute(route.id), a.lineKeyForRoute(route.id));
+        expect(
+          b.getPatternsForRoute(route.id).map((p) => p.id),
+          orderedEquals(a.getPatternsForRoute(route.id).map((p) => p.id)),
+        );
+      }
+    });
+
+    test('per-stop lookups in the same order (drives enumeration order)', () {
+      final a = built.routeIndex, b = loaded.routeIndex;
+      for (final stopId in built.data.stops.keys) {
+        expect(
+          b.getPatternsAtStop(stopId).map((p) => p.id),
+          orderedEquals(a.getPatternsAtStop(stopId).map((p) => p.id)),
+        );
+        expect(
+          b.getRoutesAtStop(stopId).toList(),
+          orderedEquals(a.getRoutesAtStop(stopId).toList()),
+        );
+      }
+    });
+
+    test('connection table: all four columns, every entry', () {
+      final a = built.routeIndex, b = loaded.routeIndex;
+      expect(b.connectionCount, a.connectionCount);
+      expect(a.connectionCount, greaterThan(100));
+      for (var p = 0; p < a.patternCount; p++) {
+        final ca = a.getConnectionsFor(p), cb = b.getConnectionsFor(p);
+        expect(cb.length, ca.length);
+        for (var k = 0; k < ca.length; k++) {
+          expect(cb.otherPatternIdAt(k), ca.otherPatternIdAt(k));
+          expect(cb.myStopIdxAt(k), ca.myStopIdxAt(k));
+          expect(cb.otherStopIdxAt(k), ca.otherStopIdxAt(k));
+          expect(cb.walkMetersAt(k), ca.walkMetersAt(k));
+        }
+      }
+      expect(walkZeroTable(b), orderedEquals(sharedStopTable(b)));
+      expect(walkZeroTable(b), orderedEquals(walkZeroTable(a)));
+    });
+
+    test('spatial index: same tree, same k-NN and range answers', () {
+      final a = built.spatialIndex, b = loaded.spatialIndex;
+      expect(
+        b.preorder.map((s) => s.id),
+        orderedEquals(a.preorder.map((s) => s.id)),
+      );
+      final rnd = Random(993);
+      final stops = built.data.stops.values.toList();
+      for (var i = 0; i < 200; i++) {
+        final s = stops[rnd.nextInt(stops.length)];
+        final at = LatLng(
+          s.lat + (rnd.nextDouble() - 0.5) / 100,
+          s.lon + (rnd.nextDouble() - 0.5) / 100,
+        );
+        String near(List<NearbyStop> l) =>
+            l.map((n) => '${n.stop.id}@${n.distance}').join(',');
+        expect(
+          near(b.findNearestStops(at, maxResults: 150, maxDistance: 1500)),
+          near(a.findNearestStops(at, maxResults: 150, maxDistance: 1500)),
+        );
+        expect(
+          near(b.findStopsInRadius(at, 300)),
+          near(a.findStopsInRadius(at, 300)),
+        );
+      }
+    });
+
+    test('schedule index: departures and frequencies', () {
+      final a = built.scheduleIndex, b = loaded.scheduleIndex;
+      expect(b.stopTimesByStop.keys, orderedEquals(a.stopTimesByStop.keys));
+      final at = DateTime(2026, 9, 9, 7, 30);
+      for (final stopId in built.data.stops.keys) {
+        String deps(List<StopDeparture> l) => l
+            .map(
+              (d) =>
+                  '${d.tripId}/${d.routeId}/${d.departureTime}/'
+                  '${d.stopSequence}/${d.headsign}',
+            )
+            .join(',');
+        expect(
+          deps(b.getNextDepartures(stopId, atTime: at, limit: 20)),
+          deps(a.getNextDepartures(stopId, atTime: at, limit: 20)),
+        );
+      }
+      for (final route in built.data.routes.values) {
+        final fa = a.getRouteFrequency(route.id);
+        final fb = b.getRouteFrequency(route.id);
+        expect(
+          [fb?.routeId, fb?.avgHeadway, fb?.tripCount],
+          [fa?.routeId, fa?.avgHeadway, fa?.tripCount],
+        );
+      }
+    });
+
+    test(
+      'the reporter\'s four trips and 200 random pairs plan identically',
+      () {
+        const origin = LatLng(15.29408, 44.26392);
+        const mall = LatLng(15.33736, 44.19833);
+        const shareFrom = LatLng(15.2952334, 44.2623529);
+        const university = LatLng(15.3536032, 44.1786948);
+        final trips = <(LatLng, LatLng)>[
+          (origin, mall),
+          (mall, origin),
+          (shareFrom, university),
+          (university, shareFrom),
+        ];
+        final rnd = Random(2);
+        final stops = built.data.stops.values.toList();
+        for (var i = 0; i < 200; i++) {
+          trips.add((
+            stops[rnd.nextInt(stops.length)].position,
+            stops[rnd.nextInt(stops.length)].position,
+          ));
+        }
+        var itineraries = 0;
+        for (final (from, to) in trips) {
+          final a = plan(built, from, to), b = plan(loaded, from, to);
+          expect(b.map(pathKey).toList(), orderedEquals(a.map(pathKey)));
+          itineraries += a.length;
+        }
+        expect(itineraries, greaterThan(50));
+        // The four reported trips still plan (#992) after the round trip.
+        for (final trip in trips.take(4)) {
+          expect(plan(loaded, trip.$1, trip.$2), isNotEmpty);
+        }
+      },
+    );
+
+    test(
+      'a client fed from the snapshot answers like one fed from the build',
+      () async {
+        final fromBuild = LocalPlannerClient()
+          ..loadFromParsed(
+            data: built.data,
+            spatialIndex: built.spatialIndex,
+            routeIndex: built.routeIndex,
+          );
+        final fromSnapshot = LocalPlannerClient()
+          ..loadFromParsed(
+            data: loaded.data,
+            spatialIndex: loaded.spatialIndex,
+            routeIndex: loaded.routeIndex,
+          );
+        final a = await fromBuild.findRoutes(
+          origin: const LatLng(15.33736, 44.19833),
+          destination: const LatLng(15.29408, 44.26392),
+          maxWalkDistance: 1500,
+        );
+        final b = await fromSnapshot.findRoutes(
+          origin: const LatLng(15.33736, 44.19833),
+          destination: const LatLng(15.29408, 44.26392),
+          maxWalkDistance: 1500,
+        );
+        expect(b.map(pathKey).toList(), orderedEquals(a.map(pathKey)));
+        final routeId = built.data.routes.keys.first;
+        final da = await fromBuild.getRouteDetail(routeId);
+        final db = await fromSnapshot.getRouteDetail(routeId);
+        expect(db!.geometry, orderedEquals(da!.geometry));
+        expect(
+          db.stops.map((s) => s.id),
+          orderedEquals(da.stops.map((s) => s.id)),
+        );
+      },
+    );
+  });
+
+  group('the blob itself', () {
+    test('re-encoding the restored bundle is byte-identical', () {
+      final again = PlannerIndexCodec.encode(
+        load(blob),
+        fingerprint: fingerprint,
+      );
+      expect(again.length, blob.length);
+      expect(again, orderedEquals(blob));
+    });
+
+    test('is compact next to the zip and starts with the magic', () {
+      expect(String.fromCharCodes(blob.sublist(0, 4)), 'TPIX');
+      expect(String.fromCharCodes(blob.sublist(blob.length - 4)), 'XIPT');
+      // The fixture zip is 30 KB of compressed text; the snapshot holds the
+      // parsed model plus three indices in ~80 KB.
+      expect(blob.length, lessThan(zip.length * 4));
+    });
+
+    test('decodes from an unaligned view of a larger buffer', () {
+      final padded = Uint8List(blob.length + 3)
+        ..setRange(3, blob.length + 3, blob);
+      final view = Uint8List.sublistView(padded, 3);
+      expect(view.offsetInBytes % 8, isNot(0));
+      expect(
+        load(view).routeIndex.connectionCount,
+        built.routeIndex.connectionCount,
+      );
+    });
+
+    test('an empty feed round-trips', () {
+      final bundle = PlannerIndexBundle(
+        data: GtfsData.empty,
+        spatialIndex: GtfsSpatialIndex(const {}),
+        routeIndex: GtfsRouteIndex(GtfsData.empty),
+        scheduleIndex: GtfsScheduleIndex(
+          trips: const {},
+          stopTimes: const [],
+          calendars: const {},
+          calendarDates: const [],
+          frequencies: const [],
+        ),
+      );
+      final bytes = PlannerIndexCodec.encode(bundle, fingerprint: 'x');
+      final back = PlannerIndexCodec.decode(
+        bytes,
+        fingerprint: 'x',
+        transferRadiusMeters: GtfsRouteIndex.defaultTransferRadiusMeters,
+        sameNameRouteLimit: GtfsRouteIndex.defaultSameNameRouteLimit,
+      );
+      expect(back, isNotNull);
+      expect(back!.data.stops, isEmpty);
+      expect(back.routeIndex.patternCount, 0);
+      expect(back.spatialIndex.findNearestStops(const LatLng(0, 0)), isEmpty);
+    });
+  });
+
+  group('refuses what is not a snapshot for this input', () {
+    test('another GTFS (fingerprint) → null', () {
+      expect(
+        rejectReason(blob, fp: PlannerIndexCodec.fingerprint(Uint8List(0))),
+        contains('fingerprint'),
+      );
+    });
+
+    test('other index knobs → null', () {
+      expect(rejectReason(blob, radius: 0), contains('transferRadiusMeters'));
+      expect(
+        rejectReason(blob, limit: 1 << 30),
+        contains('sameNameRouteLimit'),
+      );
+    });
+
+    test('unknown format version → null (forward compatibility)', () {
+      final other = Uint8List.fromList(blob);
+      ByteData.sublistView(
+        other,
+      ).setUint32(4, PlannerIndexCodec.formatVersion + 1, Endian.host);
+      expect(rejectReason(other), contains('format version'));
+    });
+
+    test('wrong magic, garbage, empty → null', () {
+      final other = Uint8List.fromList(blob)..[0] = 0x00;
+      expect(rejectReason(other), contains('not a planner snapshot'));
+      expect(rejectReason(Uint8List(0)), isNotNull);
+      expect(
+        rejectReason(Uint8List.fromList(List.filled(64, 0xab))),
+        isNotNull,
+      );
+      expect(rejectReason(zip), isNotNull, reason: 'the GTFS zip itself');
+    });
+
+    test('truncated anywhere → null, never an exception', () {
+      final cuts = <int>{
+        for (var i = 1; i < 64; i++) blob.length * i ~/ 64,
+        blob.length - 1,
+        blob.length - 4,
+        blob.length - 5,
+        16,
+        17,
+        63,
+        64,
+        65,
+      };
+      for (final cut in cuts) {
+        expect(
+          rejectReason(Uint8List.sublistView(blob, 0, cut)),
+          isNotNull,
+          reason: 'cut at $cut of ${blob.length}',
+        );
+      }
+    });
+
+    test('a single flipped byte anywhere in the payload → null', () {
+      final rnd = Random(7);
+      // Header + string pool live in the first KB; the rest is payload.
+      for (var i = 0; i < 300; i++) {
+        final at = rnd.nextInt(blob.length - 4);
+        final other = Uint8List.fromList(blob);
+        other[at] ^= 0x01 << rnd.nextInt(8);
+        expect(rejectReason(other), isNotNull, reason: 'flip at $at');
+      }
+    });
+
+    test('trailing or missing trailer → null', () {
+      final longer = Uint8List(blob.length + 8)..setRange(0, blob.length, blob);
+      expect(rejectReason(longer), isNotNull);
+      final noTrailer = Uint8List.fromList(blob)
+        ..fillRange(blob.length - 4, blob.length, 0);
+      expect(rejectReason(noTrailer), contains('trailer'));
+    });
+
+    test('encode refuses a bundle it cannot represent losslessly', () {
+      final data = GtfsData(
+        agencies: const [],
+        stops: const {},
+        routes: const {},
+        trips: const {},
+        stopTimes: [
+          const GtfsStopTime(
+            tripId: 't',
+            stopId: 's',
+            stopSequence: 1,
+            departureTime: Duration(milliseconds: 1500),
+          ),
+        ],
+        calendars: const {},
+        calendarDates: const [],
+        frequencies: const [],
+        shapes: const {},
+      );
+      final bundle = PlannerIndexBundle(
+        data: data,
+        spatialIndex: GtfsSpatialIndex(const {}),
+        routeIndex: GtfsRouteIndex(data),
+        scheduleIndex: GtfsScheduleIndex(
+          trips: const {},
+          stopTimes: data.stopTimes,
+          calendars: const {},
+          calendarDates: const [],
+          frequencies: const [],
+        ),
+      );
+      expect(
+        () => PlannerIndexCodec.encode(bundle, fingerprint: 'x'),
+        throwsA(isA<PlannerIndexEncodeException>()),
+      );
+    });
+  });
+
+  group('fingerprint', () {
+    test('is content-sensitive, length-sensitive and stable', () {
+      expect(fingerprint, hasLength(16));
+      expect(PlannerIndexCodec.fingerprint(zip), fingerprint);
+      final flipped = Uint8List.fromList(zip)..[zip.length ~/ 2] ^= 1;
+      expect(PlannerIndexCodec.fingerprint(flipped), isNot(fingerprint));
+      expect(
+        PlannerIndexCodec.fingerprint(
+          Uint8List.sublistView(zip, 0, zip.length - 1),
+        ),
+        isNot(fingerprint),
+      );
+      expect(
+        PlannerIndexCodec.fingerprint(Uint8List(0)),
+        isNot(PlannerIndexCodec.fingerprint(Uint8List(1))),
+      );
+    });
+
+    test(
+      'known answers (pin: the cache key must not drift between releases)',
+      () {
+        expect(PlannerIndexCodec.fingerprint(Uint8List(0)), '050c5d1ff2ecfaec');
+        expect(
+          PlannerIndexCodec.fingerprint(Uint8List.fromList([1, 2, 3, 4, 5])),
+          isNot('050c5d1ff2ecfaec'),
+        );
+      },
+    );
+  });
+
+  group('format version guard', () {
+    test('the integer skeleton of the fixture snapshot is pinned — if this '
+        'fails, the index build changed: bump PlannerIndexCodec.formatVersion '
+        'and update the digest', () {
+      final loaded = load(blob);
+      final sb = StringBuffer();
+      final index = loaded.routeIndex;
+      for (var p = 0; p < index.patternCount; p++) {
+        final pat = index.patternById(p);
+        sb.writeln('P $p ${pat.routeId} ${pat.stopIds.join(',')}');
+        final c = index.getConnectionsFor(p);
+        for (var k = 0; k < c.length; k++) {
+          sb.writeln(
+            'C ${c.otherPatternIdAt(k)} ${c.myStopIdxAt(k)} '
+            '${c.otherStopIdxAt(k)}',
+          );
+        }
+      }
+      sb.writeln(
+        'S ${loaded.spatialIndex.preorder.map((s) => s.id).join(',')}',
+      );
+      for (final e in loaded.scheduleIndex.stopTimesByStop.entries) {
+        sb.writeln('T ${e.key} ${e.value.map((st) => st.tripId).join(',')}');
+      }
+      final digest = PlannerIndexCodec.fingerprint(
+        Uint8List.fromList(sb.toString().codeUnits),
+      );
+      expect(PlannerIndexCodec.formatVersion, 1);
+      expect(digest, '94eb0e89a69b5fd9');
+    });
+  });
+}

--- a/packages/trufi_core_planner/test/support/bundle_dump.dart
+++ b/packages/trufi_core_planner/test/support/bundle_dump.dart
@@ -1,0 +1,126 @@
+import 'package:trufi_core_planner/trufi_core_planner.dart';
+
+/// Canonical text of everything a [PlannerIndexBundle] holds: every field of
+/// the parsed [GtfsData] and of the three indices, in enumeration order.
+///
+/// Calendar instants are written as `year-month-day` plus the UTC flag: the
+/// parser builds them with `DateTime(y, m, d)` in local time, so the instant
+/// depends on the machine's timezone while the day does not. Everything
+/// else is exact (`double.toString()` round-trips).
+///
+/// Used by the `format version guard` test — its digest is pinned, so any
+/// change in what the parser or an index produces from the same GTFS fails
+/// the suite until `PlannerIndexCodec.formatVersion` is bumped — and by the
+/// review tools to compare a built bundle with a restored one.
+String describeBundle(PlannerIndexBundle b) {
+  final sb = StringBuffer();
+  final d = b.data;
+  String day(DateTime t) =>
+      '${t.year}-${t.month}-${t.day}${t.isUtc ? 'Z' : ''}';
+  String dur(Duration? x) => x == null ? '-' : '${x.inMicroseconds}';
+
+  sb.writeln(
+    'knobs ${b.routeIndex.transferRadiusMeters} '
+    '${b.routeIndex.sameNameRouteLimit}',
+  );
+  for (final a in d.agencies) {
+    sb.writeln(
+      'A ${a.id}|${a.name}|${a.url}|${a.timezone}|${a.lang}|'
+      '${a.phone}|${a.fareUrl}|${a.email}',
+    );
+  }
+  for (final s in d.stops.values) {
+    sb.writeln(
+      'S ${s.id}|${s.code}|${s.name}|${s.description}|${s.lat}|'
+      '${s.lon}|${s.zoneId}|${s.url}|${s.locationType}|${s.parentStation}|'
+      '${s.timezone}|${s.wheelchairBoarding}|${s.platformCode}',
+    );
+  }
+  for (final r in d.routes.values) {
+    sb.writeln(
+      'R ${r.id}|${r.agencyId}|${r.shortName}|${r.longName}|'
+      '${r.description}|${r.type}|${r.url}|${r.colorHex}|${r.textColorHex}|'
+      '${r.sortOrder}',
+    );
+  }
+  for (final t in d.trips.values) {
+    sb.writeln(
+      'T ${t.id}|${t.routeId}|${t.serviceId}|${t.headsign}|'
+      '${t.shortName}|${t.directionId}|${t.blockId}|${t.shapeId}|'
+      '${t.wheelchairAccessible}|${t.bikesAllowed}',
+    );
+  }
+  for (final st in d.stopTimes) {
+    sb.writeln(
+      'ST ${st.tripId}|${dur(st.arrivalTime)}|${dur(st.departureTime)}|'
+      '${st.stopId}|${st.stopSequence}|${st.stopHeadsign}|${st.pickupType}|'
+      '${st.dropOffType}|${st.shapeDistTraveled}|${st.timepoint}',
+    );
+  }
+  for (final c in d.calendars.values) {
+    sb.writeln(
+      'CAL ${c.serviceId}|${c.monday}${c.tuesday}${c.wednesday}'
+      '${c.thursday}${c.friday}${c.saturday}${c.sunday}|${day(c.startDate)}|'
+      '${day(c.endDate)}',
+    );
+  }
+  for (final cd in d.calendarDates) {
+    sb.writeln('CD ${cd.serviceId}|${day(cd.date)}|${cd.exceptionType}');
+  }
+  for (final f in d.frequencies) {
+    sb.writeln(
+      'F ${f.tripId}|${dur(f.startTime)}|${dur(f.endTime)}|'
+      '${f.headwaySecs}|${f.exactTimes}',
+    );
+  }
+  for (final sh in d.shapes.values) {
+    sb.writeln('SH ${sh.id} ${sh.points.length}');
+    for (final p in sh.points) {
+      sb.writeln(
+        '  ${p.shapeId}|${p.lat}|${p.lon}|${p.sequence}|'
+        '${p.distTraveled}',
+      );
+    }
+  }
+
+  final index = b.routeIndex;
+  for (var i = 0; i < index.patternCount; i++) {
+    final p = index.patternById(i);
+    sb.writeln(
+      'P ${p.id}|${p.routeId}|${p.headsign}|${p.shapeId}|'
+      '${p.stopIds.join(',')}|${p.cumDist.join(',')}|'
+      '${p.minLat},${p.minLon},${p.maxLat},${p.maxLon}',
+    );
+    final c = index.getConnectionsFor(i);
+    for (var k = 0; k < c.length; k++) {
+      sb.writeln(
+        '  C ${c.otherPatternIdAt(k)} ${c.myStopIdxAt(k)} '
+        '${c.otherStopIdxAt(k)} ${c.walkMetersAt(k)}',
+      );
+    }
+  }
+  for (final r in d.routes.values) {
+    sb.writeln(
+      'L ${r.id}|${index.lineKeyForRoute(r.id)}|'
+      '${index.getPatternsForRoute(r.id).map((p) => p.id).join(',')}',
+    );
+  }
+  for (final s in d.stops.values) {
+    sb.writeln(
+      'AT ${s.id}|'
+      '${index.getPatternsAtStop(s.id).map((p) => p.id).join(',')}|'
+      '${index.getRoutesAtStop(s.id).join(',')}',
+    );
+  }
+
+  sb.writeln('KD ${b.spatialIndex.preorder.map((s) => s.id).join(',')}');
+
+  for (final e in b.scheduleIndex.stopTimesByStop.entries) {
+    sb.writeln(
+      'SCH ${e.key}|${e.value.map((st) => '${st.tripId}/'
+          '${st.stopSequence}/${dur(st.arrivalTime)}/'
+          '${dur(st.departureTime)}').join(',')}',
+    );
+  }
+  return sb.toString();
+}

--- a/packages/trufi_core_routing/lib/src/providers/trufi_planner/planner_index_store.dart
+++ b/packages/trufi_core_routing/lib/src/providers/trufi_planner/planner_index_store.dart
@@ -22,8 +22,9 @@ Future<String?> plannerIndexCachePath(String gtfsAsset) =>
 /// read. Synchronous on purpose: it runs inside the loading isolate.
 Uint8List? readPlannerIndexSync(String path) => impl.readPlannerIndexSync(path);
 
-/// Writes [bytes] atomically (temp file + rename) so a crash mid-write can
-/// never leave a half snapshot in place. Throws on I/O failure.
+/// Writes [bytes] atomically (unique temp file + rename) so a crash
+/// mid-write can never leave a half snapshot in place; a failed write
+/// removes its temp file. Throws on I/O failure.
 Future<void> writePlannerIndex(String path, Uint8List bytes) =>
     impl.writePlannerIndex(path, bytes);
 

--- a/packages/trufi_core_routing/lib/src/providers/trufi_planner/planner_index_store.dart
+++ b/packages/trufi_core_routing/lib/src/providers/trufi_planner/planner_index_store.dart
@@ -1,0 +1,31 @@
+/// Where the local planner caches its built index between cold starts
+/// (#993). The platform implementation (`dart:io` + `path_provider`) is
+/// selected at compile time; on web — where the local planner is not used —
+/// the stub reports "no cache" and `TrufiPlannerDataSource` builds as
+/// before. Keeping `dart:io` behind this import is what lets
+/// `trufi_core_routing` keep compiling for `flutter build web`.
+library;
+
+import 'dart:typed_data';
+
+import 'planner_index_store_stub.dart'
+    if (dart.library.io) 'planner_index_store_io.dart'
+    as impl;
+
+/// Absolute path of the snapshot file for [gtfsAsset], or null when the
+/// platform has nowhere to put it. Must run on the root isolate
+/// (`path_provider` is a platform channel).
+Future<String?> plannerIndexCachePath(String gtfsAsset) =>
+    impl.plannerIndexCachePath(gtfsAsset);
+
+/// The whole snapshot file, or null when it does not exist or cannot be
+/// read. Synchronous on purpose: it runs inside the loading isolate.
+Uint8List? readPlannerIndexSync(String path) => impl.readPlannerIndexSync(path);
+
+/// Writes [bytes] atomically (temp file + rename) so a crash mid-write can
+/// never leave a half snapshot in place. Throws on I/O failure.
+Future<void> writePlannerIndex(String path, Uint8List bytes) =>
+    impl.writePlannerIndex(path, bytes);
+
+/// Removes the snapshot if present. Never throws.
+Future<void> deletePlannerIndex(String path) => impl.deletePlannerIndex(path);

--- a/packages/trufi_core_routing/lib/src/providers/trufi_planner/planner_index_store_io.dart
+++ b/packages/trufi_core_routing/lib/src/providers/trufi_planner/planner_index_store_io.dart
@@ -1,6 +1,8 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path_provider/path_provider.dart';
 import 'package:trufi_core_planner/trufi_core_planner.dart';
 
@@ -19,9 +21,7 @@ Future<String?> plannerIndexCachePath(String gtfsAsset) async {
       .split('/')
       .last
       .replaceAll(RegExp('[^A-Za-z0-9._-]'), '_');
-  final key = PlannerIndexCodec.fingerprint(
-    Uint8List.fromList(gtfsAsset.codeUnits),
-  );
+  final key = PlannerIndexCodec.fingerprint(utf8.encode(gtfsAsset));
   return '${dir.path}/trufi_planner/$base-$key.idx';
 }
 
@@ -35,12 +35,57 @@ Uint8List? readPlannerIndexSync(String path) {
   }
 }
 
+/// Test seam: awaited once the temp file is fully written and before it is
+/// renamed into place, so a test can pin the atomic sequence and hold the
+/// write to check that the planner was ready before it. Null in production.
+@visibleForTesting
+Future<void> Function(String tmpPath, String path)?
+debugBeforePlannerIndexRename;
+
 Future<void> writePlannerIndex(String path, Uint8List bytes) async {
   final file = File(path);
   await file.parent.create(recursive: true);
-  final tmp = File('$path.tmp');
-  await tmp.writeAsBytes(bytes, flush: true);
-  await tmp.rename(path);
+  await _deleteStaleTemps(file);
+  // Unique temp name: two writers of the same snapshot (two providers over
+  // one asset) must not truncate each other's file mid-write.
+  final tmp = File('$path.$pid.${DateTime.now().microsecondsSinceEpoch}.tmp');
+  try {
+    await tmp.writeAsBytes(bytes, flush: true);
+    await debugBeforePlannerIndexRename?.call(tmp.path, path);
+    await tmp.rename(path);
+  } catch (_) {
+    // Disk full, permissions, a concurrent writer that swept our temp file…
+    // never leave a partial snapshot behind on an already tight disk.
+    try {
+      if (await tmp.exists()) await tmp.delete();
+    } catch (_) {
+      // Nothing more to do; the caller logs the original failure.
+    }
+    rethrow;
+  }
+}
+
+/// Temp files of this very snapshot left by a run killed mid-write (unique
+/// names would otherwise accumulate). A concurrent writer's file in flight
+/// is swept too: its rename then fails and is logged, and the snapshot on
+/// disk is the other writer's — still complete and valid.
+Future<void> _deleteStaleTemps(File file) async {
+  final prefix = '${file.path}.';
+  try {
+    await for (final entry in file.parent.list()) {
+      if (entry is File &&
+          entry.path.startsWith(prefix) &&
+          entry.path.endsWith('.tmp')) {
+        try {
+          await entry.delete();
+        } catch (_) {
+          // Best effort.
+        }
+      }
+    }
+  } catch (_) {
+    // Best effort: an unreadable directory fails the write itself later.
+  }
 }
 
 Future<void> deletePlannerIndex(String path) async {

--- a/packages/trufi_core_routing/lib/src/providers/trufi_planner/planner_index_store_io.dart
+++ b/packages/trufi_core_routing/lib/src/providers/trufi_planner/planner_index_store_io.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path_provider/path_provider.dart';
+import 'package:trufi_core_planner/trufi_core_planner.dart';
+
+/// `<app cache dir>/trufi_planner/<asset basename>-<hash>.idx`.
+///
+/// The **cache** directory, not application support: Android Auto Backup
+/// excludes `getCacheDir()` and caps an app's backup at 25 MB — the
+/// Cochabamba snapshot alone is ~38 MB, and a file that size under
+/// `getFilesDir()` would make the whole app backup fail (preferences, saved
+/// places). iOS likewise leaves `Library/Caches` out of iCloud backups and
+/// may purge it under disk pressure, which is fine: the snapshot is rebuilt
+/// from the bundled GTFS. Same location the offline map extraction uses.
+Future<String?> plannerIndexCachePath(String gtfsAsset) async {
+  final dir = await getApplicationCacheDirectory();
+  final base = gtfsAsset
+      .split('/')
+      .last
+      .replaceAll(RegExp('[^A-Za-z0-9._-]'), '_');
+  final key = PlannerIndexCodec.fingerprint(
+    Uint8List.fromList(gtfsAsset.codeUnits),
+  );
+  return '${dir.path}/trufi_planner/$base-$key.idx';
+}
+
+Uint8List? readPlannerIndexSync(String path) {
+  try {
+    final file = File(path);
+    if (!file.existsSync()) return null;
+    return file.readAsBytesSync();
+  } catch (_) {
+    return null;
+  }
+}
+
+Future<void> writePlannerIndex(String path, Uint8List bytes) async {
+  final file = File(path);
+  await file.parent.create(recursive: true);
+  final tmp = File('$path.tmp');
+  await tmp.writeAsBytes(bytes, flush: true);
+  await tmp.rename(path);
+}
+
+Future<void> deletePlannerIndex(String path) async {
+  try {
+    final file = File(path);
+    if (await file.exists()) await file.delete();
+  } catch (_) {
+    // Best effort: a stale file is rejected by its header on the next read.
+  }
+}

--- a/packages/trufi_core_routing/lib/src/providers/trufi_planner/planner_index_store_stub.dart
+++ b/packages/trufi_core_routing/lib/src/providers/trufi_planner/planner_index_store_stub.dart
@@ -1,0 +1,11 @@
+// Web (no `dart:io`): the local planner does not run here, and there is no
+// file system to cache into — every call reports "no cache".
+import 'dart:typed_data';
+
+Future<String?> plannerIndexCachePath(String gtfsAsset) async => null;
+
+Uint8List? readPlannerIndexSync(String path) => null;
+
+Future<void> writePlannerIndex(String path, Uint8List bytes) async {}
+
+Future<void> deletePlannerIndex(String path) async {}

--- a/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_config.dart
+++ b/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_config.dart
@@ -89,6 +89,21 @@ class TrufiPlannerConfig {
   /// the same line" rule.
   final int sameNameRouteLimit;
 
+  /// Keep the built planner index on disk between cold starts (default:
+  /// true; local mode only).
+  ///
+  /// Parsing the bundled GTFS and building the indices runs on every cold
+  /// start otherwise — ~1.6 s on a desktop VM for the Cochabamba feed,
+  /// several times that on a low-end phone — and the planner is not ready
+  /// until it finishes (#993). With this on, the first start after an
+  /// install or update still builds once and writes a snapshot to the app's
+  /// cache directory; later starts load it in a fraction of the time. The
+  /// snapshot is keyed by the GTFS content, [transferRadiusMeters],
+  /// [sameNameRouteLimit] and the snapshot format version, so a changed
+  /// feed or engine rebuilds; anything unreadable is silently rebuilt too.
+  /// Turn it off if a deployment must not write to the cache directory.
+  final bool persistIndex;
+
   /// Create a local (offline) configuration using GTFS asset.
   const TrufiPlannerConfig.local({
     required String this.gtfsAsset,
@@ -101,6 +116,7 @@ class TrufiPlannerConfig {
     this.maxStopCandidates = 150,
     this.transferRadiusMeters = 100,
     this.sameNameRouteLimit = 3,
+    this.persistIndex = true,
   }) : serverUrl = null;
 
   /// Create a remote (online) configuration using server URL.
@@ -118,5 +134,6 @@ class TrufiPlannerConfig {
     this.maxStopCandidates = 150,
   }) : gtfsAsset = null,
        transferRadiusMeters = 100,
-       sameNameRouteLimit = 3;
+       sameNameRouteLimit = 3,
+       persistIndex = false;
 }

--- a/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_data_source.dart
+++ b/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_data_source.dart
@@ -8,36 +8,117 @@ import 'package:trufi_core_planner/trufi_core_planner.dart';
 
 import '../../models/service_hours.dart';
 import '../../models/service_hours_lookup.dart';
+import 'planner_index_store.dart';
 import 'trufi_planner_config.dart';
 
 /// Status of the data source.
 enum TrufiPlannerDataStatus { unloaded, loading, loaded, error }
 
-/// Input for [_loadAndBuildInIsolate] (for isolate communication).
+/// Where the last local preload got its planner index from (#993).
+enum PlannerIndexSource {
+  /// Parsed the GTFS and built every index (first start, changed feed,
+  /// unreadable or stale snapshot, or persistence disabled).
+  built,
+
+  /// Restored the snapshot written by an earlier start.
+  cache,
+}
+
+/// Diagnostics of the last local preload — what the one-line log prints
+/// and what tests assert on.
+class PlannerIndexLoadInfo {
+  final PlannerIndexSource source;
+
+  /// Content fingerprint of the GTFS asset (the cache key).
+  final String fingerprint;
+
+  /// Wall-clock milliseconds inside the loading isolate.
+  final int totalMs;
+
+  /// [PlannerIndexBundle.build] split; null when loaded from the cache.
+  final PlannerBuildTimings? buildTimings;
+
+  /// Reading the snapshot file; 0 when there was none to read.
+  final int readMs;
+
+  /// Decoding the snapshot; 0 when none was decoded.
+  final int decodeMs;
+
+  /// Encoding the fresh build for the cache; 0 when nothing was encoded.
+  final int encodeMs;
+
+  /// Size of the snapshot read or written, bytes; 0 when neither happened.
+  final int snapshotBytes;
+
+  /// Why an existing snapshot was not used (stale fingerprint, other
+  /// version, corrupt…); null when there was none or it was used.
+  final String? rejectedBecause;
+
+  const PlannerIndexLoadInfo({
+    required this.source,
+    required this.fingerprint,
+    required this.totalMs,
+    this.buildTimings,
+    this.readMs = 0,
+    this.decodeMs = 0,
+    this.encodeMs = 0,
+    this.snapshotBytes = 0,
+    this.rejectedBecause,
+  });
+
+  String get _mb => (snapshotBytes / 1e6).toStringAsFixed(1);
+
+  @override
+  String toString() {
+    switch (source) {
+      case PlannerIndexSource.cache:
+        return 'planner index loaded from cache in ${totalMs}ms '
+            '(read ${readMs}ms, decode ${decodeMs}ms; snapshot $_mb MB, '
+            'fingerprint $fingerprint)';
+      case PlannerIndexSource.built:
+        final why = rejectedBecause == null
+            ? ''
+            : '; cache rejected: $rejectedBecause';
+        final cached = snapshotBytes == 0
+            ? ''
+            : '; snapshot $_mb MB encoded in ${encodeMs}ms';
+        return 'planner index built in ${totalMs}ms '
+            '($buildTimings$cached$why; fingerprint $fingerprint)';
+    }
+  }
+}
+
+/// Input for [_loadOrBuildInIsolate] (for isolate communication).
 class _GtfsLoadRequest {
   final Uint8List bytes;
   final double transferRadiusMeters;
   final int sameNameRouteLimit;
 
+  /// Snapshot file to read and, after a build, to refresh; null disables
+  /// persistence (config opt-out, web, or no cache directory).
+  final String? snapshotPath;
+
   const _GtfsLoadRequest({
     required this.bytes,
     required this.transferRadiusMeters,
     required this.sameNameRouteLimit,
+    required this.snapshotPath,
   });
 }
 
 /// Result of loading GTFS data with indices (for isolate communication).
 class _GtfsLoadResult {
-  final GtfsData data;
-  final GtfsSpatialIndex spatialIndex;
-  final GtfsRouteIndex routeIndex;
-  final GtfsScheduleIndex scheduleIndex;
+  final PlannerIndexBundle bundle;
+  final PlannerIndexLoadInfo info;
+
+  /// Fresh snapshot to write to [_GtfsLoadRequest.snapshotPath]; null when
+  /// the index came from the cache or is not persisted.
+  final Uint8List? snapshot;
 
   const _GtfsLoadResult({
-    required this.data,
-    required this.spatialIndex,
-    required this.routeIndex,
-    required this.scheduleIndex,
+    required this.bundle,
+    required this.info,
+    this.snapshot,
   });
 }
 
@@ -56,6 +137,8 @@ class TrufiPlannerDataSource implements ServiceHoursLookup {
   TrufiPlannerDataStatus _status = TrufiPlannerDataStatus.unloaded;
   String? _errorMessage;
   Completer<void>? _preloadCompleter;
+  PlannerIndexLoadInfo? _lastIndexLoad;
+  Future<void>? _pendingSnapshotWrite;
 
   TrufiPlannerDataSource({required this.config}) {
     if (config.isRemote) {
@@ -79,6 +162,16 @@ class TrufiPlannerDataSource implements ServiceHoursLookup {
 
   /// Error message if loading failed.
   String? get errorMessage => _errorMessage;
+
+  /// How the last local preload obtained its index (built or from the
+  /// persisted snapshot) and how long each step took; null before the first
+  /// local preload and in remote mode.
+  PlannerIndexLoadInfo? get lastIndexLoad => _lastIndexLoad;
+
+  /// The snapshot write started by the last preload, if any. The planner is
+  /// ready before the write finishes; await this to know the file is on
+  /// disk (tests, or a caller that wants to measure).
+  Future<void>? get pendingSnapshotWrite => _pendingSnapshotWrite;
 
   /// Schedule index (local mode only).
   GtfsScheduleIndex? get scheduleIndex => _scheduleIndex;
@@ -193,31 +286,78 @@ class TrufiPlannerDataSource implements ServiceHoursLookup {
     final sw = Stopwatch()..start();
 
     final bytes = await rootBundle.load(config.gtfsAsset!);
-    final assetData = bytes.buffer.asUint8List();
+    final assetData = bytes.buffer.asUint8List(
+      bytes.offsetInBytes,
+      bytes.lengthInBytes,
+    );
+
+    // The snapshot lives in the app's cache directory (#993). Resolving the
+    // path is a platform-channel call, so it happens here on the root
+    // isolate and travels to the worker as a plain string.
+    String? snapshotPath;
+    if (config.persistIndex) {
+      try {
+        snapshotPath = await plannerIndexCachePath(config.gtfsAsset!);
+      } catch (e) {
+        debugPrint(
+          'TrufiPlannerDataSource: no cache directory for the planner '
+          'index ($e); building without persistence',
+        );
+      }
+    }
 
     final result = await compute(
-      _loadAndBuildInIsolate,
+      _loadOrBuildInIsolate,
       _GtfsLoadRequest(
         bytes: assetData,
         transferRadiusMeters: config.transferRadiusMeters,
         sameNameRouteLimit: config.sameNameRouteLimit,
+        snapshotPath: snapshotPath,
       ),
     );
 
-    _localData = result.data;
-    _scheduleIndex = result.scheduleIndex;
+    final bundle = result.bundle;
+    _localData = bundle.data;
+    _scheduleIndex = bundle.scheduleIndex;
+    _lastIndexLoad = result.info;
 
     final localClient = _client as LocalPlannerClient;
     localClient.loadFromParsed(
-      data: result.data,
-      spatialIndex: result.spatialIndex,
-      routeIndex: result.routeIndex,
+      data: bundle.data,
+      spatialIndex: bundle.spatialIndex,
+      routeIndex: bundle.routeIndex,
     );
 
     sw.stop();
     debugPrint(
-      'TrufiPlannerDataSource: Preloaded in ${sw.elapsedMilliseconds}ms',
+      'TrufiPlannerDataSource: Preloaded in ${sw.elapsedMilliseconds}ms — '
+      '${result.info}',
     );
+
+    // Persist the fresh build without holding the planner back: the write
+    // is asynchronous file I/O and its failure only costs the next start a
+    // rebuild.
+    final snapshot = result.snapshot;
+    if (snapshot != null && snapshotPath != null) {
+      _pendingSnapshotWrite = _writeSnapshot(snapshotPath, snapshot);
+    }
+  }
+
+  Future<void> _writeSnapshot(String path, Uint8List snapshot) async {
+    final sw = Stopwatch()..start();
+    try {
+      await writePlannerIndex(path, snapshot);
+      debugPrint(
+        'TrufiPlannerDataSource: planner index snapshot written '
+        '(${(snapshot.length / 1e6).toStringAsFixed(1)} MB in '
+        '${sw.elapsedMilliseconds}ms) to $path',
+      );
+    } catch (e) {
+      debugPrint(
+        'TrufiPlannerDataSource: could not write the planner index snapshot '
+        '($e); the next start will build again',
+      );
+    }
   }
 
   Future<void> _preloadRemote() async {
@@ -226,28 +366,77 @@ class TrufiPlannerDataSource implements ServiceHoursLookup {
     debugPrint('TrufiPlannerDataSource: Remote server ready');
   }
 
-  static _GtfsLoadResult _loadAndBuildInIsolate(_GtfsLoadRequest request) {
-    final data = GtfsParser.parseFromBytes(request.bytes);
-    final spatialIndex = GtfsSpatialIndex(data.stops);
-    final routeIndex = GtfsRouteIndex(
-      data,
-      spatialIndex: spatialIndex,
+  /// Worker-isolate body: restore the snapshot when it matches this GTFS
+  /// and these knobs, otherwise parse + build (and encode the result so the
+  /// root isolate can persist it). Never throws because of the cache.
+  static _GtfsLoadResult _loadOrBuildInIsolate(_GtfsLoadRequest request) {
+    final sw = Stopwatch()..start();
+    final fingerprint = PlannerIndexCodec.fingerprint(request.bytes);
+    final path = request.snapshotPath;
+
+    var readMs = 0;
+    String? rejectedBecause;
+    if (path != null) {
+      final readSw = Stopwatch()..start();
+      final snapshot = readPlannerIndexSync(path);
+      readMs = readSw.elapsedMilliseconds;
+      if (snapshot != null) {
+        final decodeSw = Stopwatch()..start();
+        final bundle = PlannerIndexCodec.decode(
+          snapshot,
+          fingerprint: fingerprint,
+          transferRadiusMeters: request.transferRadiusMeters,
+          sameNameRouteLimit: request.sameNameRouteLimit,
+          onReject: (reason) => rejectedBecause = reason,
+        );
+        if (bundle != null) {
+          return _GtfsLoadResult(
+            bundle: bundle,
+            info: PlannerIndexLoadInfo(
+              source: PlannerIndexSource.cache,
+              fingerprint: fingerprint,
+              totalMs: sw.elapsedMilliseconds,
+              readMs: readMs,
+              decodeMs: decodeSw.elapsedMilliseconds,
+              snapshotBytes: snapshot.length,
+            ),
+          );
+        }
+      }
+    }
+
+    final bundle = PlannerIndexBundle.build(
+      request.bytes,
       transferRadiusMeters: request.transferRadiusMeters,
       sameNameRouteLimit: request.sameNameRouteLimit,
     );
-    final scheduleIndex = GtfsScheduleIndex(
-      trips: data.trips,
-      stopTimes: data.stopTimes,
-      calendars: data.calendars,
-      calendarDates: data.calendarDates,
-      frequencies: data.frequencies,
-    );
+
+    Uint8List? snapshot;
+    var encodeMs = 0;
+    if (path != null) {
+      final encodeSw = Stopwatch()..start();
+      try {
+        snapshot = PlannerIndexCodec.encode(bundle, fingerprint: fingerprint);
+      } on PlannerIndexEncodeException catch (e) {
+        // Not representable — keep the in-memory build, skip the cache.
+        rejectedBecause = 'not cacheable: ${e.message}';
+      }
+      encodeMs = encodeSw.elapsedMilliseconds;
+    }
 
     return _GtfsLoadResult(
-      data: data,
-      spatialIndex: spatialIndex,
-      routeIndex: routeIndex,
-      scheduleIndex: scheduleIndex,
+      bundle: bundle,
+      snapshot: snapshot,
+      info: PlannerIndexLoadInfo(
+        source: PlannerIndexSource.built,
+        fingerprint: fingerprint,
+        totalMs: sw.elapsedMilliseconds,
+        buildTimings: bundle.buildTimings,
+        readMs: readMs,
+        encodeMs: encodeMs,
+        snapshotBytes: snapshot?.length ?? 0,
+        rejectedBecause: rejectedBecause,
+      ),
     );
   }
 
@@ -299,5 +488,6 @@ class TrufiPlannerDataSource implements ServiceHoursLookup {
     _scheduleIndex = null;
     _status = TrufiPlannerDataStatus.unloaded;
     _errorMessage = null;
+    _lastIndexLoad = null;
   }
 }

--- a/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_data_source.dart
+++ b/packages/trufi_core_routing/lib/src/providers/trufi_planner/trufi_planner_data_source.dart
@@ -489,5 +489,6 @@ class TrufiPlannerDataSource implements ServiceHoursLookup {
     _status = TrufiPlannerDataStatus.unloaded;
     _errorMessage = null;
     _lastIndexLoad = null;
+    _pendingSnapshotWrite = null;
   }
 }

--- a/packages/trufi_core_routing/pubspec.yaml
+++ b/packages/trufi_core_routing/pubspec.yaml
@@ -30,9 +30,11 @@ dependencies:
   provider: ^6.1.5+1
   shared_preferences: ^2.5.4
   archive: ^4.0.4
+  path_provider: ^2.1.5
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
   mocktail: ^1.0.4
+  path_provider_platform_interface: ^2.1.0

--- a/packages/trufi_core_routing/test/unit/trufi_planner_config_test.dart
+++ b/packages/trufi_core_routing/test/unit/trufi_planner_config_test.dart
@@ -30,4 +30,21 @@ void main() {
       expect(config.sameNameRouteLimit, 3);
     });
   });
+
+  group('TrufiPlannerConfig persisted index (#993)', () {
+    test('local mode persists by default and can opt out', () {
+      const on = TrufiPlannerConfig.local(gtfsAsset: 'assets/gtfs.zip');
+      expect(on.persistIndex, isTrue);
+      const off = TrufiPlannerConfig.local(
+        gtfsAsset: 'assets/gtfs.zip',
+        persistIndex: false,
+      );
+      expect(off.persistIndex, isFalse);
+    });
+
+    test('remote mode has nothing to persist', () {
+      const config = TrufiPlannerConfig.remote(serverUrl: 'https://p.example');
+      expect(config.persistIndex, isFalse);
+    });
+  });
 }

--- a/packages/trufi_core_routing/test/unit/trufi_planner_index_cache_test.dart
+++ b/packages/trufi_core_routing/test/unit/trufi_planner_index_cache_test.dart
@@ -1,0 +1,314 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:trufi_core_planner/trufi_core_planner.dart';
+import 'package:trufi_core_routing/trufi_core_routing.dart';
+
+/// The persisted planner index end to end through [TrufiPlannerDataSource]
+/// (#993): real files in a temp cache directory, the GTFS served through a
+/// mocked asset bundle, the worker isolate as in production.
+class _FakePathProvider extends PathProviderPlatform {
+  final String root;
+
+  _FakePathProvider(this.root);
+
+  @override
+  Future<String?> getApplicationCachePath() async => root;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const asset = 'assets/routing/test.gtfs.zip';
+  // The planner package's fixture: a cut of the real Sana'a feed. Tests run
+  // from the package root (melos / CI do), hence the relative path.
+  final fixture = File(
+    '../trufi_core_planner/test/fixtures/sanaa_issue2_mini.gtfs.zip',
+  );
+  late Uint8List zip;
+  late Directory tempDir;
+  late Map<String, Uint8List> assets;
+
+  setUpAll(() {
+    expect(
+      fixture.existsSync(),
+      isTrue,
+      reason: 'run from packages/trufi_core_routing: ${fixture.absolute.path}',
+    );
+    zip = fixture.readAsBytesSync();
+  });
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('planner-index-');
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+    assets = {asset: zip};
+    TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockMessageHandler('flutter/assets', (message) async {
+          final key = utf8.decode(
+            message!.buffer.asUint8List(
+              message.offsetInBytes,
+              message.lengthInBytes,
+            ),
+          );
+          final bytes = assets[key];
+          return bytes == null ? null : ByteData.sublistView(bytes);
+        });
+  });
+
+  tearDown(() async {
+    TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+        .setMockMessageHandler('flutter/assets', null);
+    await tempDir.delete(recursive: true);
+  });
+
+  Directory cacheDir() => Directory('${tempDir.path}/trufi_planner');
+
+  List<File> snapshotFiles() => cacheDir().existsSync()
+      ? cacheDir().listSync().whereType<File>().toList()
+      : const [];
+
+  File snapshotFile() {
+    final files = snapshotFiles().where((f) => f.path.endsWith('.idx'));
+    expect(files, hasLength(1), reason: 'exactly one snapshot per asset');
+    return files.single;
+  }
+
+  Future<TrufiPlannerDataSource> preload({bool persist = true}) async {
+    final source = TrufiPlannerDataSource(
+      config: TrufiPlannerConfig.local(
+        gtfsAsset: asset,
+        maxWalkingDistance: 1500,
+        persistIndex: persist,
+      ),
+    );
+    await source.preload();
+    expect(source.isLoaded, isTrue, reason: source.errorMessage);
+    await source.pendingSnapshotWrite;
+    return source;
+  }
+
+  /// The reporter's trips from trufi-sanaa#2, planned through the client.
+  Future<List<String>> plan(TrufiPlannerDataSource source) async {
+    const pairs = <(LatLng, LatLng)>[
+      (LatLng(15.29408, 44.26392), LatLng(15.33736, 44.19833)),
+      (LatLng(15.33736, 44.19833), LatLng(15.29408, 44.26392)),
+      (LatLng(15.2952334, 44.2623529), LatLng(15.3536032, 44.1786948)),
+      (LatLng(15.3536032, 44.1786948), LatLng(15.2952334, 44.2623529)),
+    ];
+    final out = <String>[];
+    for (final (from, to) in pairs) {
+      final paths = await source.client.findRoutes(
+        origin: from,
+        destination: to,
+        maxWalkDistance: 1500,
+      );
+      out.add(
+        paths
+            .map(
+              (p) =>
+                  '${p.originStop.id}>'
+                  '${p.segments.map((s) => '${s.route.id}/${s.pattern.id}/${s.fromIdx}-${s.toIdx}').join('+')}'
+                  '>${p.destinationStop.id}@${p.score.toStringAsFixed(6)}',
+            )
+            .join(','),
+      );
+    }
+    return out;
+  }
+
+  /// A different but valid GTFS: the fixture without its last route.
+  Uint8List withoutLastRoute(Uint8List original) {
+    final archive = ZipDecoder().decodeBytes(original);
+    final out = Archive();
+    for (final file in archive) {
+      if (!file.isFile) continue;
+      var content = file.content as List<int>;
+      if (file.name.endsWith('routes.txt')) {
+        final lines = utf8
+            .decode(content)
+            .split('\n')
+            .where((l) => l.trim().isNotEmpty)
+            .toList();
+        lines.removeLast();
+        content = utf8.encode('${lines.join('\n')}\n');
+      }
+      out.addFile(ArchiveFile(file.name, content.length, content));
+    }
+    return Uint8List.fromList(ZipEncoder().encode(out));
+  }
+
+  test(
+    'first start builds and persists; the next cold start loads the snapshot '
+    'and plans identically',
+    () async {
+      final first = await preload();
+      final info1 = first.lastIndexLoad!;
+      expect(info1.source, PlannerIndexSource.built);
+      expect(info1.buildTimings, isNotNull);
+      expect(info1.snapshotBytes, greaterThan(10000));
+      expect(info1.rejectedBecause, isNull, reason: 'no snapshot yet');
+      final file = snapshotFile();
+      expect(file.lengthSync(), info1.snapshotBytes);
+      expect(
+        snapshotFiles().where((f) => f.path.endsWith('.tmp')),
+        isEmpty,
+        reason: 'temp file renamed into place',
+      );
+      expect(file.path, contains('test.gtfs.zip-'));
+
+      final second = await preload();
+      final info2 = second.lastIndexLoad!;
+      expect(info2.source, PlannerIndexSource.cache);
+      expect(info2.buildTimings, isNull);
+      expect(info2.snapshotBytes, info1.snapshotBytes);
+      expect(info2.fingerprint, info1.fingerprint);
+      expect(second.pendingSnapshotWrite, isNull, reason: 'nothing to write');
+      expect(file.lengthSync(), info1.snapshotBytes, reason: 'not rewritten');
+
+      expect(
+        second.routeIndex!.connectionCount,
+        first.routeIndex!.connectionCount,
+      );
+      expect(second.data!.stops.length, first.data!.stops.length);
+      final plannedFromBuild = await plan(first);
+      expect(plannedFromBuild.where((s) => s.isNotEmpty), hasLength(4));
+      expect(await plan(second), orderedEquals(plannedFromBuild));
+      expect(
+        second.getNextDepartures(first.data!.stops.keys.first, limit: 3).length,
+        first.getNextDepartures(first.data!.stops.keys.first, limit: 3).length,
+      );
+      expect('${info2}', contains('loaded from cache'));
+    },
+  );
+
+  test('a changed GTFS asset is detected and the snapshot replaced', () async {
+    final first = await preload();
+    final before = snapshotFile().lengthSync();
+    final routesBefore = first.data!.routes.length;
+
+    assets[asset] = withoutLastRoute(zip);
+    final second = await preload();
+    final info = second.lastIndexLoad!;
+    expect(info.source, PlannerIndexSource.built);
+    expect(info.rejectedBecause, contains('fingerprint'));
+    expect(info.fingerprint, isNot(first.lastIndexLoad!.fingerprint));
+    expect(
+      second.data!.routes.length,
+      routesBefore - 1,
+      reason: 'the planner uses the new feed, not the stale snapshot',
+    );
+    expect(snapshotFile().lengthSync(), isNot(before));
+
+    final third = await preload();
+    expect(third.lastIndexLoad!.source, PlannerIndexSource.cache);
+    expect(third.data!.routes.length, routesBefore - 1);
+  });
+
+  test('a corrupt snapshot is rebuilt silently and overwritten', () async {
+    await preload();
+    final file = snapshotFile();
+    final bytes = file.readAsBytesSync();
+    // Flip one byte deep in the payload, keep the size.
+    bytes[bytes.length ~/ 2] ^= 0x40;
+    file.writeAsBytesSync(bytes, flush: true);
+
+    final rebuilt = await preload();
+    expect(rebuilt.lastIndexLoad!.source, PlannerIndexSource.built);
+    expect(rebuilt.lastIndexLoad!.rejectedBecause, contains('checksum'));
+    expect(rebuilt.status, TrufiPlannerDataStatus.loaded);
+    expect((await plan(rebuilt)).where((s) => s.isNotEmpty), hasLength(4));
+
+    final again = await preload();
+    expect(again.lastIndexLoad!.source, PlannerIndexSource.cache);
+  });
+
+  test('a truncated snapshot and garbage are rebuilt too', () async {
+    await preload();
+    final file = snapshotFile();
+    final bytes = file.readAsBytesSync();
+    file.writeAsBytesSync(bytes.sublist(0, bytes.length ~/ 3), flush: true);
+    expect((await preload()).lastIndexLoad!.source, PlannerIndexSource.built);
+    expect((await preload()).lastIndexLoad!.source, PlannerIndexSource.cache);
+
+    file.writeAsBytesSync(List.filled(4096, 0x5a), flush: true);
+    final rebuilt = await preload();
+    expect(rebuilt.lastIndexLoad!.source, PlannerIndexSource.built);
+    expect(rebuilt.lastIndexLoad!.rejectedBecause, isNotNull);
+  });
+
+  test('a snapshot from another format version is rebuilt', () async {
+    await preload();
+    final file = snapshotFile();
+    final bytes = file.readAsBytesSync();
+    ByteData.sublistView(
+      bytes,
+    ).setUint32(4, PlannerIndexCodec.formatVersion + 1, Endian.host);
+    file.writeAsBytesSync(bytes, flush: true);
+    final rebuilt = await preload();
+    expect(rebuilt.lastIndexLoad!.source, PlannerIndexSource.built);
+    expect(rebuilt.lastIndexLoad!.rejectedBecause, contains('format version'));
+    expect((await preload()).lastIndexLoad!.source, PlannerIndexSource.cache);
+  });
+
+  test(
+    'other index knobs mean another snapshot (rebuilt, then reused)',
+    () async {
+      await preload();
+      final source = TrufiPlannerDataSource(
+        config: const TrufiPlannerConfig.local(
+          gtfsAsset: asset,
+          transferRadiusMeters: 0,
+        ),
+      );
+      await source.preload();
+      await source.pendingSnapshotWrite;
+      expect(source.lastIndexLoad!.source, PlannerIndexSource.built);
+      expect(
+        source.lastIndexLoad!.rejectedBecause,
+        contains('transferRadiusMeters'),
+      );
+      expect(source.routeIndex!.transferRadiusMeters, 0);
+    },
+  );
+
+  test('persistIndex: false never touches the disk', () async {
+    final source = await preload(persist: false);
+    expect(source.lastIndexLoad!.source, PlannerIndexSource.built);
+    expect(source.lastIndexLoad!.snapshotBytes, 0);
+    expect(source.pendingSnapshotWrite, isNull);
+    expect(cacheDir().existsSync(), isFalse);
+    expect(
+      (await preload(persist: false)).lastIndexLoad!.source,
+      PlannerIndexSource.built,
+    );
+  });
+
+  test('no cache directory available: builds without persisting', () async {
+    PathProviderPlatform.instance = _ThrowingPathProvider();
+    final source = await preload();
+    expect(source.isLoaded, isTrue);
+    expect(source.lastIndexLoad!.source, PlannerIndexSource.built);
+    expect(source.lastIndexLoad!.snapshotBytes, 0);
+    expect(cacheDir().existsSync(), isFalse);
+  });
+
+  test('clear() forgets the load diagnostics', () async {
+    final source = await preload();
+    expect(source.lastIndexLoad, isNotNull);
+    source.clear();
+    expect(source.lastIndexLoad, isNull);
+    expect(source.status, TrufiPlannerDataStatus.unloaded);
+  });
+}
+
+class _ThrowingPathProvider extends PathProviderPlatform {
+  @override
+  Future<String?> getApplicationCachePath() async =>
+      throw MissingPluginException('no path_provider here');
+}

--- a/packages/trufi_core_routing/test/unit/trufi_planner_index_cache_test.dart
+++ b/packages/trufi_core_routing/test/unit/trufi_planner_index_cache_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
@@ -8,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:trufi_core_planner/trufi_core_planner.dart';
+import 'package:trufi_core_routing/src/providers/trufi_planner/planner_index_store_io.dart';
 import 'package:trufi_core_routing/trufi_core_routing.dart';
 
 /// The persisted planner index end to end through [TrufiPlannerDataSource]
@@ -62,6 +64,7 @@ void main() {
   });
 
   tearDown(() async {
+    debugBeforePlannerIndexRename = null;
     TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
         .setMockMessageHandler('flutter/assets', null);
     await tempDir.delete(recursive: true);
@@ -183,7 +186,7 @@ void main() {
         second.getNextDepartures(first.data!.stops.keys.first, limit: 3).length,
         first.getNextDepartures(first.data!.stops.keys.first, limit: 3).length,
       );
-      expect('${info2}', contains('loaded from cache'));
+      expect('$info2', contains('loaded from cache'));
     },
   );
 
@@ -301,9 +304,121 @@ void main() {
   test('clear() forgets the load diagnostics', () async {
     final source = await preload();
     expect(source.lastIndexLoad, isNotNull);
+    expect(source.pendingSnapshotWrite, isNotNull);
     source.clear();
     expect(source.lastIndexLoad, isNull);
+    expect(source.pendingSnapshotWrite, isNull);
     expect(source.status, TrufiPlannerDataStatus.unloaded);
+  });
+
+  test('the planner is ready before the snapshot write starts, and the write '
+      'goes through a temp file renamed into place', () async {
+    // Hold the write between "temp file complete" and "rename": the
+    // preload must have finished by then, and nothing named .idx may exist.
+    final gate = Completer<void>();
+    addTearDown(() {
+      if (!gate.isCompleted) gate.complete();
+    });
+    late TrufiPlannerDataSource source;
+    TrufiPlannerDataStatus? statusAtRename;
+    String? tmpAtRename;
+    int? tmpLengthAtRename;
+    var finalExistedAtRename = true;
+    debugBeforePlannerIndexRename = (tmp, path) async {
+      statusAtRename = source.status;
+      tmpAtRename = tmp;
+      tmpLengthAtRename = File(tmp).lengthSync();
+      finalExistedAtRename = File(path).existsSync();
+      await gate.future;
+    };
+    source = TrufiPlannerDataSource(
+      config: const TrufiPlannerConfig.local(
+        gtfsAsset: asset,
+        maxWalkingDistance: 1500,
+      ),
+    );
+    // A preload that waited for the write would hang on the gate.
+    await source.preload().timeout(const Duration(seconds: 20));
+    expect(source.isLoaded, isTrue, reason: source.errorMessage);
+    expect(source.lastIndexLoad!.source, PlannerIndexSource.built);
+    expect(source.pendingSnapshotWrite, isNotNull);
+    expect(
+      snapshotFiles().where((f) => f.path.endsWith('.idx')),
+      isEmpty,
+      reason: 'planner ready while the snapshot is not on disk yet',
+    );
+    expect((await plan(source)).where((s) => s.isNotEmpty), hasLength(4));
+
+    gate.complete();
+    await source.pendingSnapshotWrite;
+    expect(statusAtRename, TrufiPlannerDataStatus.loaded);
+    expect(finalExistedAtRename, isFalse);
+    expect(tmpAtRename, endsWith('.tmp'));
+    expect(tmpLengthAtRename, source.lastIndexLoad!.snapshotBytes);
+    final file = snapshotFile();
+    expect(tmpAtRename, startsWith('${file.path}.'));
+    expect(file.lengthSync(), source.lastIndexLoad!.snapshotBytes);
+    expect(snapshotFiles().where((f) => f.path.endsWith('.tmp')), isEmpty);
+  });
+
+  group('writePlannerIndex', () {
+    late Directory dir;
+    late String path;
+    setUp(() async {
+      dir = await Directory('${tempDir.path}/store').create();
+      path = '${dir.path}/a.idx';
+    });
+
+    test(
+      'writes a temp file next to the target and renames it over the '
+      'previous snapshot; stale temp files are swept, nothing else is left',
+      () async {
+        final old = Uint8List.fromList([1, 2, 3]);
+        await File(path).writeAsBytes(old, flush: true);
+        await File('$path.999.1.tmp').writeAsBytes([9], flush: true);
+        final bytes = Uint8List.fromList(
+          List.generate(200000, (i) => (i * 31) & 0xff),
+        );
+        // A reader that opened the old snapshot keeps seeing the old bytes
+        // after a rename (the inode is untouched); a rewrite in place or a
+        // copy over the file would change what it reads.
+        final oldHandle = await File(path).open();
+        addTearDown(oldHandle.close);
+
+        var calls = 0;
+        debugBeforePlannerIndexRename = (tmp, target) async {
+          calls++;
+          expect(target, path);
+          expect(tmp, startsWith('$path.'));
+          expect(tmp, endsWith('.tmp'));
+          expect(File(tmp).readAsBytesSync(), bytes, reason: 'temp complete');
+          expect(
+            File(path).readAsBytesSync(),
+            old,
+            reason: 'the previous snapshot is intact until the rename',
+          );
+          expect(File('$path.999.1.tmp').existsSync(), isFalse);
+        };
+        await writePlannerIndex(path, bytes);
+        expect(calls, 1, reason: 'the write must go through the seam');
+        expect(File(path).readAsBytesSync(), bytes);
+        expect(dir.listSync().map((e) => e.path), [path]);
+        if (!Platform.isWindows) {
+          expect(await oldHandle.read(3), old, reason: 'renamed, not copied');
+        }
+      },
+    );
+
+    test('a failed write leaves no temp file behind and rethrows', () async {
+      // Renaming a file over an existing directory fails (EISDIR), after the
+      // temp file has been fully written.
+      final target = await Directory('${dir.path}/taken.idx').create();
+      await expectLater(
+        writePlannerIndex(target.path, Uint8List.fromList([1, 2, 3])),
+        throwsA(isA<FileSystemException>()),
+      );
+      expect(dir.listSync().map((e) => e.path), [target.path]);
+    });
   });
 }
 


### PR DESCRIPTION
Closes #993. The offline planner parsed the bundled GTFS and built every index (`GtfsRouteIndex` with the #992 transfer table, `GtfsSpatialIndex`, `GtfsScheduleIndex`) on **every** cold start, and the planner stayed in `loading` until it finished. The built state is now persisted as a binary snapshot in the app's cache directory and restored on the next start; the GTFS is only parsed and the indices only built when there is no valid snapshot for exactly this feed, these knobs and this engine version. All in `trufi_core_planner` (pure Dart) plus the store and the wiring in `trufi_core_routing`.

## What is rebuilt today, and what it costs

Instrumented run on the desktop VM (JIT), the feeds the apps ship (`harness-output/phases_desktop_jit.txt`):

| Phase | Cochabamba (trufi-app: 23 679 stops, 657 patterns, 104 592 stop_times, 357 597 shape points) | Sana'a (6 179 stops, 194 patterns) |
|---|---|---|
| Parse `shapes.txt` | **0.69–0.78 s** | 31–34 ms |
| Parse `stop_times.txt` | 0.24–0.27 s | 17–21 ms |
| Parse the rest + inflate | 0.13–0.17 s | 26–34 ms |
| `GtfsSpatialIndex` | 52–56 ms | 14–18 ms |
| `GtfsRouteIndex` patterns | 50–71 ms | 4–8 ms |
| `GtfsRouteIndex` connections (#992) | 0.32–0.45 s | 14 ms |
| `GtfsScheduleIndex` | 36–45 ms | 1 ms |
| **Cold start** | **1.58–1.73 s** | 115–120 ms |

Parsing is 68 % of the cold start (`shapes.txt` alone 45 %); the transfer table #992 made visible is 25 %. Persisting only the indices would have left 1.1 s of 1.6 s on the table, so the snapshot holds the **parsed data too**.

## Design

- **`PlannerIndexBundle`** (`trufi_core_planner/lib/src/snapshot/`): the four objects the planner keeps in memory, with `build(gtfsZip)` — the old isolate body — reporting a per-phase timing split.
- **`PlannerIndexCodec`**: `encode(bundle, fingerprint:)` / `decode(bytes, fingerprint:, transferRadiusMeters:, sameNameRouteLimit:)` / `fingerprint(bytes)`. One blob, host byte order, 8-byte-aligned sections with a tag and a length, over a deduplicated string pool written as the **last** section (its offset sits in the header), so the encoder streams the whole blob into a single buffer:
  - `GtfsData` **lossless**: coordinates, `cumDist` and `shape_dist_traveled` as `Float64`, GTFS times as `Int32` seconds, dates as microseconds-since-epoch `Float64` + UTC flag, enums by value, every `Map` in iteration order (the order drives the engine's enumeration order). Integer columns take the narrowest width their maximum fits (1/2/4 bytes) and are widened to `Int32List` on load.
  - Indices as their own working tables: the CSR connection columns of `GtfsRouteIndex` verbatim, the KD-tree of `GtfsSpatialIndex` as its **pre-order** (the tree shape is a function of the stop count — median split — so it is rebuilt in O(n) with no sort and is the same tree), the sorted stop-time groups of `GtfsScheduleIndex`. Each index gains a `restore(...)` constructor; the cheap per-stop / per-route maps are re-derived from the patterns in id order, which inserts every pair in the same order the build did (the round-trip test checks that order for every stop).
  - **Key**: GTFS content fingerprint (two 32-bit FNV-1a streams over 32-bit words + length, 5–7 ms for the 4.9 MB Cochabamba zip, JS-safe arithmetic as in #980), `transferRadiusMeters`, `sameNameRouteLimit`, and `PlannerIndexCodec.formatVersion` — the version of the schema **and** of the index-building rules — and of the parser: the snapshot stores the parsed `GtfsData` too, so any change in `GtfsParser` / `CsvParser` / `*.fromCsv` that yields different data from the same zip must bump it as well (the rule is documented on `formatVersion` and on the parser and the three indices). The guard test digests **every field** of the fixture bundle — parsed data including names, colours, times and shape points; pattern `cumDist`, bbox, headsign, shape; all four connection columns; line keys; per-stop lookup order; KD-tree pre-order; schedule groups — except calendar instants (timezone-dependent, dumped as year-month-day), and pins the digest, so a forgotten bump fails the suite (the #973/#975 failure mode: a cache that survives an update).
  - **Refusal**: wrong magic/trailer, other version, other knobs, other fingerprint, string-pool offset out of range, payload checksum mismatch, truncation, any reference out of range while restoring → `decode` returns `null` with a reason; it never throws for malformed input. Every header bit is validated by its own check (a test flips each one); record counts read ahead of per-record loops are bounded against the remaining bytes before anything is allocated.
- **`TrufiPlannerDataSource.preload()`**: resolves the snapshot path on the root isolate (`path_provider` is a platform channel), then in the worker isolate fingerprints the asset, reads + decodes the snapshot and returns it, or builds as before and also encodes; the root isolate hands the bundle to `LocalPlannerClient` first and writes the snapshot afterwards (async file I/O, unique temp file + rename, the temp file removed on failure, failures only logged). One `debugPrint` line reports source and timings — `planner index loaded from cache in 12ms (read 1ms, decode 8ms; snapshot 1.1 MB, …)` / `planner index built in 1650ms (parse 1091ms, spatial 56ms, index 461ms, schedule 35ms; snapshot 38.2 MB encoded in 369ms; …)` — and `lastIndexLoad` exposes the same for callers and tests.
- **Where**: `<app cache dir>/trufi_planner/<asset>-<hash>.idx`, one file per asset, overwritten when the key differs (no stale accumulation). The **cache** directory rather than application support on purpose: Android Auto Backup caps an app at 25 MB and excludes `getCacheDir()` — a 38 MB file under `getFilesDir()` would make the whole app backup fail (preferences, saved places); iOS keeps `Library/Caches` out of iCloud and may purge it under disk pressure, which is exactly the semantics of a rebuildable cache. Same location as the offline map extraction.
- **Web unaffected**: the store is a conditional import (`planner_index_store_io.dart` / `_stub.dart`), no `dart:io` reaches the web build, `flutter build web --release` of `apps/example` passes. The codec compiles for dart2js (32-bit arithmetic only).
- **Opt-out**: `TrufiPlannerConfig.local(persistIndex: true)` (default); `.remote` has nothing to persist.

## Measured (desktop VM, `harness-output/snapshot_bench_desktop.txt`, `harness-output/fix-0909/`)

| Feed | Build (parse + indices) | Encode (first start only) | Snapshot | Decode | Zip |
|---|---|---|---|---|---|
| Cochabamba (trufi-app) | 1.63–1.70 s | 0.24–0.37 s | **38.25 MB** | **0.17–0.32 s** | 4.92 MB |
| Sana'a | 0.11–0.19 s | 10–57 ms | **1.12 MB** | **8–31 ms** | 0.35 MB |

Re-encoding the restored bundle is **byte-identical** to the original snapshot on both feeds; every field of the restored bundle equals the built one (canonical dump of 3.1 M lines on Cochabamba, 0 differing lines); 300 random stop pairs × 2 walk radii per feed (plus the four trufi-sanaa#2 trips) plan **identical itineraries** from the built and the restored indices (stops, patterns, positions, walks, scores, geometry). Query time is unchanged (Cochabamba 8.3 ms built / 7.8 ms restored).

**Memory on the first start.** The encoder writes into one buffer (string pool last). On the desktop the Cochabamba build alone peaks at 620–628 MB maxRss; build + encode peaks at **687–697 MB** (an earlier draft with a second writer and two copies peaked at 763–775 MB); decoding the snapshot in a fresh process peaks at 444 MB. Numbers from `harness-output/fix-0909/mem_after.txt` (one process per mode).

**Snapshot size vs zip.** Cochabamba's snapshot is 7.8× its GTFS zip. The zip is compressed text and contains no index; 26 MB of the 38 MB are the 2.6 M transfer connections of #992 (6 B each stored — the same table takes 40 MB in memory), 7 MB the 357 597 shape points at full `Float64` precision, the parsed rest ~5 MB (less than the 22 MB of text it replaces). `gzip -1` would bring it to 10 MB (0.22 s to compress, 0.03 s to inflate on the desktop); left as a follow-up because it would trade file size for a decompression pass on every start and blur the measurement here.

## Emulator (trufi-sanaa app, Android 16 arm64 emulator, profile/AOT build)

The real Sana'a app with `dependency_overrides` to `main` (`3ac4838d`) and to this branch; times from logcat — `Preloaded in` is planner-ready measured from the start of `_preloadLocal`, the isolate's own report in parentheses. Full logs and screenshots in the review comment. The "corrupted" and "truncated" rows ran on the variant of the feed without route `18800934` (fingerprint `446118af…`), not on the shipped feed; the conclusion is the same.

| Scenario | Planner ready | Inside the isolate |
|---|---|---|
| `main`, cold start 1 / 2 | **476 / 642 ms** | parse + build, every start |
| branch, first start (no snapshot) | 610 ms | built in 584 ms (parse 311, spatial 33, index 220, schedule 1; **encode 16 ms**) + async write 1.1 MB in 126 ms |
| branch, cold start 2 / 3 | **107 / 81 ms** | loaded from cache in 29 / 43 ms (decode 28 / 39) |
| GTFS without any line "14" (29 route_ids carry that name) installed over it, cache kept | 523 ms | `cache rejected: GTFS fingerprint changed` → built in 496 ms (parse 319, spatial 79, index 20; encode 68); snapshot 1.0 MB (967 012 B, was 1 121 572), snapshot rewritten; the university trip (7 → 14 before) now finds no route on that feed |
| next cold start on the new feed | 72 ms | loaded from cache in 52 ms (decode 50) |
| snapshot corrupted (4 KB overwritten) | 581 ms | `cache rejected: checksum mismatch` → built, rewritten; next start 42 ms from cache |
| snapshot truncated to 300 KB | 463 ms | `cache rejected: truncated snapshot (no trailer)` → built, rewritten |

Debug (JIT) builds keep the ratio but are slower: `main` 1 594 / 1 259 ms; branch 1 516 ms first start (built 1 206 + encode 228), then **598 / 631 ms** from the cache. No unhandled exceptions in any run. Cochabamba could not be run in the emulator (trufi-app's toolchain, same as in #992); it is covered by the harness on the feed trufi-app ships.

## Tests

`trufi_core_planner` **85/85** (56 before), `trufi_core_routing` unit **140/140** (126 before); `flutter analyze` clean in `trufi_core_planner` and `apps/example`, `trufi_core_routing` keeps its two pre-existing infos; `flutter build web --release` of `apps/example` passes.

- `planner_index_codec_test.dart` (29): round trip of every `GtfsData` field (agencies, stops incl. Arabic names, routes, trips, calendars, frequencies, stop times, every shape point), patterns (ids, stops, `cumDist`, bbox, `indexOfStop`, line keys), `getPatternsAtStop` / `getRoutesAtStop` in the same order for every stop, all four connection columns for every entry and the brute-force `sharedStopTable` (#992), the spatial pre-order plus k-NN and range answers at 200 random points, departures at every stop and route frequencies, identical itineraries for the reporter's four trips + 200 random pairs, a `LocalPlannerClient` fed from each; `encode(decode(x)) == x`; decoding from an unaligned view; empty feed; refusal of another fingerprint, other knobs, another format version, wrong magic, garbage, the zip itself, 72 truncation points, 300 random single-bit flips anywhere, every bit of the header, forged record counts (2^31 − 1 agencies / calendars / calendar dates with the checksum recomputed → rejected by the byte bound before anything is allocated) and forged string-pool offsets, trailing bytes and a missing trailer; encode refuses non-whole-second durations; fingerprint sensitivity and known answers; the format-version guard over the canonical dump of every field (`test/support/bundle_dump.dart`).
- `trufi_planner_index_cache_test.dart` (12, routing): real files in a temp cache directory, the fixture served through a mocked asset bundle, the worker isolate as in production — first start builds and writes (temp file renamed, one file per asset), second start loads from cache and plans identically; a changed GTFS asset (fixture minus one route) is detected by fingerprint, rebuilt, snapshot replaced and the new data used; corrupt (flipped byte → checksum), truncated, garbage and other-version snapshots are rebuilt silently and overwritten; other knobs rebuild; `persistIndex: false` never touches the disk; a failing `path_provider` builds without persisting; `clear()` resets the diagnostics and the pending write; **the planner is ready before the snapshot write starts** (the write is held at a test seam between "temp file complete" and "rename": the preload has returned, plans, and no `.idx` exists yet); **`writePlannerIndex` is atomic** (temp file next to the target with the full content while the previous snapshot is still intact, renamed — not copied — over it, stale temp files swept, nothing else left; a failed rename removes the temp file and rethrows).
- `trufi_planner_config_test.dart` (+2): the knob in both modes.

## Notes for the reviewer

- First start after install or update pays build + encode (Cochabamba: +0.24–0.37 s on the desktop) before the planner is ready; the write itself does not hold the planner back (pinned by a test). On the desktop the first start's peak RSS is ~65–75 MB above the build alone for Cochabamba (687–697 vs 620–628 MB maxRss) while the snapshot is encoded into its single buffer. Acceptable by the issue, and identical to the asset-extraction behaviour of #973/#975.
- `GtfsRouteIndex.restore` re-derives `_stopToPatternIds` / `_stopToRoutes` / `_routePatterns` from the patterns instead of persisting them; the equivalence (including insertion order) is argued in its doc comment and checked by the round-trip test on the fixture.
- `GtfsScheduleIndex` is built and now persisted although nothing in the UI reads it yet; dropping it from the snapshot would save ~0.5 MB on Cochabamba — not done, to keep the bundle equal to what the data source exposes.
- Calendar dates are persisted as the local-time instants the parser creates; nothing reads them yet (`getNextDepartures` ignores calendars). When the schedule starts using them, persist year-month-day or add the timezone to the key.
- Follow-ups: gzip the snapshot (numbers above); remove a stale `.idx` when an app renames its GTFS asset (one file per asset name today); overlap `rootBundle.load` and the cache-path lookup at start; a lazy `GtfsShape.points` view over the typed columns would cut decode time and memory further (357 k objects are allocated today, as the parser does).
