### PR TITLE
Home: draw and fit a plan restored from the previous session (#995)

### DIFF
--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -1026,15 +1026,12 @@ class _HomeScreenState extends State<HomeScreen>
 
   /// Compute and apply camera position to fit the given points.
   ///
-  /// The fit only takes bearing and tilt from the base camera — target and
-  /// zoom come from the points — so before the map has reported a camera the
-  /// initial one is used instead of dropping the fit. That is the cold-start
-  /// case with a plan restored from the previous session: the plan is back a
-  /// few milliseconds after the first frame, hundreds of milliseconds before
-  /// the map's first camera report, and nothing replayed the fit afterwards,
-  /// so the restored route was drawn outside the default viewport (#995).
-  /// The controlled camera set here is held by [TrufiMap] until its style has
-  /// loaded (#946), so nothing needs to wait for the map.
+  /// The fit only takes the bearing from the base camera — target and zoom
+  /// come from the points and the viewport — so before the map has reported a
+  /// camera the initial one is used instead of dropping the fit: a plan
+  /// restored on a cold start lands before the map's first camera report and
+  /// nothing replayed the fit afterwards (#995). The controlled camera set
+  /// here is held by [TrufiMap] until its style has loaded (#946).
   void _fitCameraToPoints(List<LatLng> points) {
     final baseCamera = _currentCamera ?? _initialCamera;
     if (_fitCameraUtil == null || baseCamera == null) return;
@@ -1081,9 +1078,14 @@ class _HomeScreenState extends State<HomeScreen>
   /// Programmatic moves suppress the map's onCameraChanged callback, so
   /// without this the recorded viewport goes stale and an engine switch
   /// right after (e.g. my-location → change map style) snaps back to the
-  /// previous view (#902).
+  /// previous view (#902). For the same reason the controlled camera is
+  /// dropped here: [_onCameraChanged] never runs for this move, so it would
+  /// stay set to the route fit and the next rebuild (a GPS tick, the
+  /// keyboard, a rotation) would hand it back to [TrufiMap], snapping the
+  /// view away from the location the user asked for (#995).
   void _moveCameraTracked(TrufiCameraPosition position) {
     _currentCamera = position;
+    _cameraTarget = null;
     _mapController?.moveCamera(position);
   }
 

--- a/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
+++ b/packages/screens/trufi_core_home_screen/lib/src/widgets/home_screen.dart
@@ -1025,9 +1025,20 @@ class _HomeScreenState extends State<HomeScreen>
   }
 
   /// Compute and apply camera position to fit the given points.
+  ///
+  /// The fit only takes bearing and tilt from the base camera — target and
+  /// zoom come from the points — so before the map has reported a camera the
+  /// initial one is used instead of dropping the fit. That is the cold-start
+  /// case with a plan restored from the previous session: the plan is back a
+  /// few milliseconds after the first frame, hundreds of milliseconds before
+  /// the map's first camera report, and nothing replayed the fit afterwards,
+  /// so the restored route was drawn outside the default viewport (#995).
+  /// The controlled camera set here is held by [TrufiMap] until its style has
+  /// loaded (#946), so nothing needs to wait for the map.
   void _fitCameraToPoints(List<LatLng> points) {
-    if (_fitCameraUtil == null || _currentCamera == null) return;
-    final newCam = _fitCameraUtil!.cameraForPoints(points, _currentCamera!);
+    final baseCamera = _currentCamera ?? _initialCamera;
+    if (_fitCameraUtil == null || baseCamera == null) return;
+    final newCam = _fitCameraUtil!.cameraForPoints(points, baseCamera);
     if (newCam != null) {
       setState(() {
         _cameraTarget = newCam;

--- a/packages/screens/trufi_core_home_screen/test/restored_plan_map_test.dart
+++ b/packages/screens/trufi_core_home_screen/test/restored_plan_map_test.dart
@@ -1,0 +1,532 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:trufi_core_home_screen/trufi_core_home_screen.dart';
+import 'package:trufi_core_interfaces/trufi_core_interfaces.dart'
+    show TrufiLocation;
+import 'package:trufi_core_maps/trufi_core_maps.dart';
+import 'package:trufi_core_routing/trufi_core_routing.dart' as routing;
+import 'package:trufi_core_search_locations/trufi_core_search_locations.dart'
+    show SearchLocationsLocalizations;
+
+/// #995: a plan restored from the previous session has to reach the map the
+/// way a fresh one does — route layers AND a fitted camera — although the
+/// restore completes before the map has reported any camera. Drives the real
+/// [HomeScreen] over a fake map engine that records what it is handed.
+
+// Sana'a: the app's default viewport vs the university trip (trufi-sanaa#2),
+// which lies entirely outside that viewport.
+const _defaultCenter = LatLng(15.3470, 44.2050);
+const _defaultZoom = 14.0;
+const _origin = LatLng(15.2952334, 44.2623529);
+const _boarding = LatLng(15.2990, 44.2580);
+const _transfer = LatLng(15.3150, 44.2250);
+const _alighting = LatLng(15.3500, 44.1830);
+const _destination = LatLng(15.3536032, 44.1786948);
+
+routing.Place _place(String id, LatLng p) =>
+    routing.Place(name: id, lat: p.latitude, lon: p.longitude, stopId: id);
+
+routing.Leg _leg(
+  List<LatLng> points, {
+  String? route,
+  required int startMinute,
+  required int minutes,
+}) {
+  final start = DateTime(2026, 9, 10, 12, startMinute);
+  return routing.Leg(
+    mode: route == null ? 'WALK' : 'BUS',
+    startTime: start,
+    endTime: start.add(Duration(minutes: minutes)),
+    duration: Duration(minutes: minutes),
+    distance: 1000,
+    transitLeg: route != null,
+    encodedPoints: routing.PolylineCodec.encode(points),
+    decodedPoints: points,
+    route: route == null
+        ? null
+        : routing.Route(gtfsId: route, shortName: route),
+    shortName: route,
+    fromPlace: _place('from-$startMinute', points.first),
+    toPlace: _place('to-$startMinute', points.last),
+  );
+}
+
+/// walk → bus 7 → bus 14 → walk (the "7 → 14, 57 min" trip of the report).
+routing.Plan _universityPlan() => routing.Plan(
+  itineraries: [
+    routing.Itinerary(
+      legs: [
+        _leg([_origin, _boarding], startMinute: 0, minutes: 5),
+        _leg([_boarding, _transfer], route: '7', startMinute: 5, minutes: 20),
+        _leg(
+          [_transfer, _alighting],
+          route: '14',
+          startMinute: 25,
+          minutes: 27,
+        ),
+        _leg([_alighting, _destination], startMinute: 52, minutes: 5),
+      ],
+      startTime: DateTime(2026, 9, 10, 12),
+      endTime: DateTime(2026, 9, 10, 12, 57),
+      walkTime: const Duration(minutes: 10),
+      duration: const Duration(minutes: 57),
+      walkDistance: 833,
+    ),
+  ],
+);
+
+const _from = TrufiLocation(
+  description: 'Origen',
+  latitude: 15.2952334,
+  longitude: 44.2623529,
+);
+const _to = TrufiLocation(
+  description: 'Universidad',
+  latitude: 15.3536032,
+  longitude: 44.1786948,
+);
+
+/// Stores JSON like [HomeScreenRepositoryImpl] does, so the restored plan
+/// went through the same round trip as on a device. [gate] lets a test hold
+/// the restore until after the home screen's first frame.
+class _JsonRepository implements HomeScreenRepository {
+  String? planJson;
+  String? selectedJson;
+  TrufiLocation? from;
+  TrufiLocation? to;
+  Completer<void>? gate;
+
+  void seed(routing.Plan plan) {
+    planJson = jsonEncode(plan.toJson());
+    selectedJson = jsonEncode(plan.itineraries!.first.toJson());
+    from = _from;
+    to = _to;
+  }
+
+  @override
+  Future<void> initialize() async {}
+  @override
+  Future<void> dispose() async {}
+  @override
+  Future<void> saveFromPlace(TrufiLocation? data) async => from = data;
+  @override
+  Future<TrufiLocation?> getFromPlace() async => from;
+  @override
+  Future<void> saveToPlace(TrufiLocation? data) async => to = data;
+  @override
+  Future<TrufiLocation?> getToPlace() async => to;
+  @override
+  Future<void> savePlan(routing.Plan? data) async =>
+      planJson = data == null ? null : jsonEncode(data.toJson());
+  @override
+  Future<routing.Plan?> getPlan() async {
+    await gate?.future;
+    return planJson == null
+        ? null
+        : routing.Plan.fromJson(jsonDecode(planJson!) as Map<String, dynamic>);
+  }
+
+  @override
+  Future<void> saveSelectedItinerary(routing.Itinerary? data) async =>
+      selectedJson = data == null ? null : jsonEncode(data.toJson());
+  @override
+  Future<routing.Itinerary?> getSelectedItinerary() async =>
+      selectedJson == null
+      ? null
+      : routing.Itinerary.fromJson(
+          jsonDecode(selectedJson!) as Map<String, dynamic>,
+        );
+  @override
+  Future<void> clear() async {
+    planJson = null;
+    selectedJson = null;
+    from = null;
+    to = null;
+  }
+}
+
+class _FakePlanService implements RequestPlanService {
+  _FakePlanService(this.plan);
+  final routing.Plan plan;
+  int calls = 0;
+
+  @override
+  Future<routing.Plan> fetchPlan({
+    required TrufiLocation from,
+    required TrufiLocation to,
+    String? locale,
+    required DateTime dateTime,
+    bool arriveBy = false,
+  }) async {
+    calls++;
+    return plan;
+  }
+}
+
+/// What the home screen handed to the map on its latest build, plus a way to
+/// play the map's own camera report (the moment the real map becomes "ready"
+/// from the screen's point of view).
+class _MapCalls {
+  List<TrufiLayer> layers = const [];
+  TrufiCameraPosition? camera;
+  TrufiCameraPosition? initialCamera;
+  ValueChanged<TrufiCameraPosition>? _onCameraChanged;
+  int reports = 0;
+
+  TrufiLayer? layer(String id) {
+    final hits = layers.where((l) => l.id == id).toList();
+    return hits.isEmpty ? null : hits.single;
+  }
+
+  void report(TrufiCameraPosition position) {
+    reports++;
+    _onCameraChanged?.call(position);
+  }
+}
+
+class _FakeEngine extends ITrufiMapEngine {
+  _FakeEngine(this.calls);
+  final _MapCalls calls;
+
+  @override
+  String get id => 'fake';
+  @override
+  String get name => 'Fake';
+  @override
+  String get description => 'Fake map';
+
+  @override
+  Widget buildMap({
+    TrufiMapController? controller,
+    required TrufiCameraPosition initialCamera,
+    TrufiCameraPosition? camera,
+    ValueChanged<TrufiCameraPosition>? onCameraChanged,
+    void Function(LatLng)? onMapClick,
+    void Function(LatLng)? onMapLongClick,
+    List<TrufiLayer> layers = const [],
+    List<WidgetMarker> widgetMarkers = const [],
+  }) {
+    calls.layers = layers;
+    calls.camera = camera;
+    calls.initialCamera = initialCamera;
+    calls._onCameraChanged = onCameraChanged;
+    return _FakeMap(
+      controller: controller,
+      initialCamera: initialCamera,
+      camera: camera,
+    );
+  }
+}
+
+/// Mirrors TrufiMap's controller lifecycle and keeps the controlled camera
+/// it was last given, like the real map does until its style has loaded.
+class _FakeMap extends StatefulWidget {
+  const _FakeMap({
+    required this.controller,
+    required this.initialCamera,
+    required this.camera,
+  });
+  final TrufiMapController? controller;
+  final TrufiCameraPosition initialCamera;
+  final TrufiCameraPosition? camera;
+
+  @override
+  State<_FakeMap> createState() => _FakeMapState();
+}
+
+class _FakeMapState extends State<_FakeMap> implements TrufiMapDelegate {
+  late TrufiCameraPosition _camera;
+
+  @override
+  void initState() {
+    super.initState();
+    _camera = widget.camera ?? widget.initialCamera;
+    widget.controller?.attach(this);
+  }
+
+  @override
+  void didUpdateWidget(_FakeMap oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.camera != null && widget.camera != _camera) {
+      _camera = widget.camera!;
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller?.detach(this);
+    super.dispose();
+  }
+
+  @override
+  TrufiCameraPosition get cameraPosition => _camera;
+  @override
+  void moveCamera(TrufiCameraPosition position) => _camera = position;
+  @override
+  void fitBounds(
+    LatLngBounds bounds, {
+    EdgeInsets padding = EdgeInsets.zero,
+    double minZoom = 2.0,
+    double maxZoom = 20.0,
+  }) {}
+  @override
+  List<TrufiMarker> pickMarkersAt(
+    LatLng tap, {
+    double hitboxPx = 24.0,
+    int? perLayerLimit,
+    int? globalLimit,
+  }) => const [];
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.expand();
+}
+
+Future<_MapCalls> _pumpHome(
+  WidgetTester tester,
+  RoutePlannerCubit cubit, {
+  bool phone = true,
+}) async {
+  if (phone) {
+    // The report's device: 1080×2424 @ 2.625 → narrow layout, bottom sheet.
+    tester.view.physicalSize = const Size(1080, 2424);
+    tester.view.devicePixelRatio = 2.625;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+  }
+  final calls = _MapCalls();
+  final manager = MapEngineManager(
+    engines: [_FakeEngine(calls)],
+    defaultCenter: _defaultCenter,
+    defaultZoom: _defaultZoom,
+  );
+  await tester.pumpWidget(
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider<MapEngineManager>.value(value: manager),
+        BlocProvider<RoutePlannerCubit>.value(value: cubit),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: [
+          ...HomeScreenLocalizations.localizationsDelegates,
+          MapsLocalizations.delegate,
+          SearchLocationsLocalizations.delegate,
+          routing.RoutingLocalizations.delegate,
+        ],
+        supportedLocales: HomeScreenLocalizations.supportedLocales,
+        home: HomeScreen(
+          onMenuPressed: () {},
+          config: const HomeScreenConfig(),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return calls;
+}
+
+void _expectRouteDrawnAndFitted(_MapCalls calls) {
+  final lines = calls.layer('route-lines-layer');
+  expect(lines, isNotNull, reason: 'the itinerary polyline layer is missing');
+  expect(lines!.lines, hasLength(4), reason: 'one line per leg');
+
+  final markers = calls.layer('route-markers-layer');
+  expect(markers, isNotNull, reason: 'the route markers layer is missing');
+  expect(
+    markers!.markers.map((m) => m.id),
+    containsAll([
+      'start-marker',
+      'end-marker',
+      'transit-label-1',
+      'transit-label-2',
+      'boarding-1',
+      'alighting-2',
+    ]),
+  );
+  expect(
+    calls.layer('location-markers-layer'),
+    isNull,
+    reason: 'origin/destination previews give way to the route markers',
+  );
+
+  final camera = calls.camera;
+  expect(camera, isNotNull, reason: 'no camera fit was handed to the map');
+  expect(camera!.target.latitude, inInclusiveRange(15.29, 15.36));
+  expect(camera.target.longitude, inInclusiveRange(44.17, 44.27));
+  expect(
+    camera.zoom,
+    lessThan(_defaultZoom),
+    reason: 'the trip spans ~11 km: fitting it must zoom out from 14',
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    // LocationService's auto-start asks geolocator whether the service is
+    // enabled; without a plugin that call would throw. Answer "no".
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('flutter.baseflow.com/geolocator'),
+          (call) async => false,
+        );
+  });
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('flutter.baseflow.com/geolocator'),
+          null,
+        );
+  });
+
+  group('plan restored from the previous session (#995)', () {
+    testWidgets('restored after the first frame, before any camera report: '
+        'route drawn and camera fitted', (tester) async {
+      // The device timeline: first frame → restore emits ~3 ms later →
+      // the map's first camera report ~500 ms after that.
+      final repository = _JsonRepository()
+        ..seed(_universityPlan())
+        ..gate = Completer<void>();
+      final cubit = RoutePlannerCubit(
+        repository: repository,
+        requestService: _FakePlanService(_universityPlan()),
+      );
+      addTearDown(cubit.close);
+      unawaited(cubit.initialize());
+
+      final calls = await _pumpHome(tester, cubit);
+      expect(calls.layer('route-lines-layer'), isNull);
+      expect(calls.camera, isNull);
+
+      repository.gate!.complete();
+      await tester.pumpAndSettle();
+
+      expect(calls.reports, 0, reason: 'the map is not "ready" yet');
+      _expectRouteDrawnAndFitted(calls);
+      expect(find.textContaining('57'), findsWidgets);
+    });
+
+    testWidgets('restored before the screen exists (state already set when the '
+        'listener subscribes): route drawn and camera fitted', (tester) async {
+      final repository = _JsonRepository()..seed(_universityPlan());
+      final cubit = RoutePlannerCubit(
+        repository: repository,
+        requestService: _FakePlanService(_universityPlan()),
+      );
+      addTearDown(cubit.close);
+      await cubit.initialize();
+      expect(cubit.state.selectedItinerary, isNotNull);
+
+      final calls = await _pumpHome(tester, cubit);
+
+      expect(calls.reports, 0);
+      _expectRouteDrawnAndFitted(calls);
+    });
+
+    testWidgets('wide layout (side panel) fits the restored plan too', (
+      tester,
+    ) async {
+      final repository = _JsonRepository()..seed(_universityPlan());
+      final cubit = RoutePlannerCubit(
+        repository: repository,
+        requestService: _FakePlanService(_universityPlan()),
+      );
+      addTearDown(cubit.close);
+      await cubit.initialize();
+
+      final calls = await _pumpHome(tester, cubit, phone: false);
+      _expectRouteDrawnAndFitted(calls);
+    });
+
+    testWidgets('the map reporting its camera afterwards keeps the fitted view '
+        '(the screen does not re-drive it to the default)', (tester) async {
+      final repository = _JsonRepository()..seed(_universityPlan());
+      final cubit = RoutePlannerCubit(
+        repository: repository,
+        requestService: _FakePlanService(_universityPlan()),
+      );
+      addTearDown(cubit.close);
+      await cubit.initialize();
+      final calls = await _pumpHome(tester, cubit);
+      final fitted = calls.camera!;
+
+      // The real map applies the controlled camera once its style loads and
+      // then reports it (its own idle for the initial position is ignored
+      // while the controlled camera is pending — see TrufiMap).
+      calls.report(fitted);
+      await tester.pumpAndSettle();
+
+      final held =
+          (tester.state(find.byType(_FakeMap)) as _FakeMapState).cameraPosition;
+      expect(held, equals(fitted));
+      expect(calls.layer('route-lines-layer'), isNotNull);
+    });
+
+    testWidgets('clearing the plan clears the route from the map as well', (
+      tester,
+    ) async {
+      final repository = _JsonRepository()..seed(_universityPlan());
+      final cubit = RoutePlannerCubit(
+        repository: repository,
+        requestService: _FakePlanService(_universityPlan()),
+      );
+      addTearDown(cubit.close);
+      await cubit.initialize();
+      final calls = await _pumpHome(tester, cubit);
+      _expectRouteDrawnAndFitted(calls);
+
+      await cubit.clearPlan();
+      await tester.pumpAndSettle();
+
+      expect(calls.layer('route-lines-layer'), isNull);
+      expect(calls.layer('route-markers-layer'), isNull);
+      expect(calls.camera, isNull, reason: 'nothing left to fit');
+      // The places stay, so the map shows their previews — panel and map agree.
+      final previews = calls.layer('location-markers-layer');
+      expect(previews, isNotNull);
+      expect(
+        previews!.markers.map((m) => m.id),
+        containsAll(['origin-preview', 'destination-preview']),
+      );
+      expect(find.textContaining('57'), findsNothing);
+    });
+  });
+
+  group('fresh search (unchanged)', () {
+    testWidgets('planning after the map reported its camera draws and fits', (
+      tester,
+    ) async {
+      final service = _FakePlanService(_universityPlan());
+      final cubit = RoutePlannerCubit(
+        repository: _JsonRepository(),
+        requestService: service,
+      );
+      addTearDown(cubit.close);
+      await cubit.initialize();
+      final calls = await _pumpHome(tester, cubit);
+      expect(calls.layer('route-lines-layer'), isNull);
+
+      calls.report(
+        const TrufiCameraPosition(target: _defaultCenter, zoom: _defaultZoom),
+      );
+      await cubit.setFromPlace(_from);
+      await cubit.setToPlace(_to);
+      await tester.pumpAndSettle();
+      expect(calls.layer('location-markers-layer'), isNotNull);
+      expect(calls.camera, isNull, reason: 'no fit for previews alone');
+
+      await cubit.fetchPlan();
+      await tester.pumpAndSettle();
+
+      expect(service.calls, 1);
+      _expectRouteDrawnAndFitted(calls);
+    });
+  });
+}

--- a/packages/screens/trufi_core_home_screen/test/restored_plan_map_test.dart
+++ b/packages/screens/trufi_core_home_screen/test/restored_plan_map_test.dart
@@ -59,27 +59,29 @@ routing.Leg _leg(
   );
 }
 
-/// walk → bus 7 → bus 14 → walk (the "7 → 14, 57 min" trip of the report).
-routing.Plan _universityPlan() => routing.Plan(
+/// walk → bus [first] → bus [second] → walk (the "7 → 14, 57 min" trip of the
+/// report; other route names give an alternative over the same stops).
+routing.Itinerary _universityItinerary({
+  String first = '7',
+  String second = '14',
+}) => routing.Itinerary(
+  legs: [
+    _leg([_origin, _boarding], startMinute: 0, minutes: 5),
+    _leg([_boarding, _transfer], route: first, startMinute: 5, minutes: 20),
+    _leg([_transfer, _alighting], route: second, startMinute: 25, minutes: 27),
+    _leg([_alighting, _destination], startMinute: 52, minutes: 5),
+  ],
+  startTime: DateTime(2026, 9, 10, 12),
+  endTime: DateTime(2026, 9, 10, 12, 57),
+  walkTime: const Duration(minutes: 10),
+  duration: const Duration(minutes: 57),
+  walkDistance: 833,
+);
+
+routing.Plan _universityPlan({bool withAlternative = false}) => routing.Plan(
   itineraries: [
-    routing.Itinerary(
-      legs: [
-        _leg([_origin, _boarding], startMinute: 0, minutes: 5),
-        _leg([_boarding, _transfer], route: '7', startMinute: 5, minutes: 20),
-        _leg(
-          [_transfer, _alighting],
-          route: '14',
-          startMinute: 25,
-          minutes: 27,
-        ),
-        _leg([_alighting, _destination], startMinute: 52, minutes: 5),
-      ],
-      startTime: DateTime(2026, 9, 10, 12),
-      endTime: DateTime(2026, 9, 10, 12, 57),
-      walkTime: const Duration(minutes: 10),
-      duration: const Duration(minutes: 57),
-      walkDistance: 833,
-    ),
+    _universityItinerary(),
+    if (withAlternative) _universityItinerary(first: '9', second: '21'),
   ],
 );
 
@@ -365,6 +367,76 @@ void _expectRouteDrawnAndFitted(_MapCalls calls) {
     lessThan(_defaultZoom),
     reason: 'the trip spans ~11 km: fitting it must zoom out from 14',
   );
+  expect(
+    camera.bearing,
+    0,
+    reason: 'the fit keeps the base camera bearing: the map is not rotated',
+  );
+}
+
+/// Any HomeScreen rebuild — here a viewport change (keyboard, rotation); on a
+/// device also every GPS tick, which calls setState.
+Future<void> _rebuildHome(WidgetTester tester) async {
+  tester.view.physicalSize = const Size(1080, 2000);
+  await tester.pumpAndSettle();
+}
+
+/// The recentre button is faded out while the route is in focus.
+double _recentreOpacity(WidgetTester tester) => tester
+    .widget<AnimatedOpacity>(
+      find.ancestor(
+        of: find.byIcon(Icons.crop_free_rounded),
+        matching: find.byType(AnimatedOpacity),
+      ),
+    )
+    .opacity;
+
+/// Geolocator answering "service on, permission granted, here is a fix", so
+/// LocationService auto-starts tracking and the my-location button takes the
+/// real path.
+void _mockGeolocatorWithFix(LatLng fix) {
+  final position = <String, dynamic>{
+    'latitude': fix.latitude,
+    'longitude': fix.longitude,
+    'timestamp': DateTime(2026, 9, 10, 12).millisecondsSinceEpoch,
+    'accuracy': 5.0,
+    'altitude': 0.0,
+    'altitude_accuracy': 0.0,
+    'heading': 0.0,
+    'heading_accuracy': 0.0,
+    'speed': 0.0,
+    'speed_accuracy': 0.0,
+    'is_mocked': true,
+  };
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  messenger.setMockMethodCallHandler(
+    const MethodChannel('flutter.baseflow.com/geolocator'),
+    (call) async {
+      switch (call.method) {
+        case 'isLocationServiceEnabled':
+          return true;
+        case 'checkPermission':
+        case 'requestPermission':
+          return 3; // LocationPermission.always
+        case 'getLastKnownPosition':
+        case 'getCurrentPosition':
+          return position;
+        case 'getLocationAccuracy':
+          return 0;
+      }
+      return null;
+    },
+  );
+  const updates = EventChannel('flutter.baseflow.com/geolocator_updates');
+  messenger.setMockStreamHandler(
+    updates,
+    MockStreamHandler.inline(
+      onListen: (args, events) => events.success(position),
+      onCancel: (args) {},
+    ),
+  );
+  addTearDown(() => messenger.setMockStreamHandler(updates, null));
 }
 
 void main() {
@@ -462,7 +534,15 @@ void main() {
       // while the controlled camera is pending — see TrufiMap).
       calls.report(fitted);
       await tester.pumpAndSettle();
+      // Once the map has reported the fit the screen releases it: a later
+      // rebuild hands no controlled camera, and the map keeps its view.
+      await _rebuildHome(tester);
 
+      expect(
+        calls.camera,
+        isNull,
+        reason: 'the screen keeps re-driving the fit',
+      );
       final held =
           (tester.state(find.byType(_FakeMap)) as _FakeMapState).cameraPosition;
       expect(held, equals(fitted));
@@ -496,6 +576,79 @@ void main() {
         containsAll(['origin-preview', 'destination-preview']),
       );
       expect(find.textContaining('57'), findsNothing);
+    });
+  });
+
+  group('after the fit', () {
+    testWidgets(
+      'my-location, then a rebuild (a GPS tick): the map stays on the '
+      'user, the screen does not hand the fit back',
+      (tester) async {
+        const fix = LatLng(15.40, 44.24);
+        _mockGeolocatorWithFix(fix);
+        final repository = _JsonRepository()..seed(_universityPlan());
+        final cubit = RoutePlannerCubit(
+          repository: repository,
+          requestService: _FakePlanService(_universityPlan()),
+        );
+        addTearDown(cubit.close);
+        await cubit.initialize();
+        final calls = await _pumpHome(tester, cubit);
+        _expectRouteDrawnAndFitted(calls);
+        final map = tester.state(find.byType(_FakeMap)) as _FakeMapState;
+
+        // Tracking auto-started with the granted permission: filled icon, and
+        // the tap takes the "already tracking" path of _onMyLocationPressed.
+        final myLocation = find.byIcon(Icons.my_location_rounded);
+        expect(myLocation, findsOneWidget, reason: 'tracking should be on');
+        await tester.tap(myLocation);
+        await tester.pumpAndSettle();
+        expect(map.cameraPosition.target, equals(fix));
+        expect(map.cameraPosition.zoom, 16);
+
+        await _rebuildHome(tester);
+
+        expect(
+          calls.camera,
+          isNull,
+          reason: 'a programmatic move must drop the controlled camera',
+        );
+        expect(
+          map.cameraPosition.target,
+          equals(fix),
+          reason: 'a rebuild must not yank the camera back to the route fit',
+        );
+        expect(map.cameraPosition.zoom, 16);
+      },
+    );
+
+    testWidgets('panning away shows the recentre button; fitting another '
+        'itinerary hides it again', (tester) async {
+      final plan = _universityPlan(withAlternative: true);
+      final repository = _JsonRepository()..seed(plan);
+      final cubit = RoutePlannerCubit(
+        repository: repository,
+        requestService: _FakePlanService(plan),
+      );
+      addTearDown(cubit.close);
+      await cubit.initialize();
+      final calls = await _pumpHome(tester, cubit);
+      _expectRouteDrawnAndFitted(calls);
+      expect(_recentreOpacity(tester), 0.0);
+
+      // The user pans ~50 km away: the map reports a camera off the fit.
+      calls.report(
+        const TrufiCameraPosition(target: LatLng(15.80, 44.60), zoom: 16),
+      );
+      await tester.pumpAndSettle();
+      expect(_recentreOpacity(tester), 1.0, reason: 'route out of focus');
+
+      // Selecting the other itinerary fits it from the reported camera (no
+      // intermediate loading state): the route is in focus again.
+      await cubit.selectItinerary(cubit.state.plan!.itineraries![1]);
+      await tester.pumpAndSettle();
+      _expectRouteDrawnAndFitted(calls);
+      expect(_recentreOpacity(tester), 0.0, reason: 'the fit resets focus');
     });
   });
 

--- a/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
+++ b/packages/trufi_core_maps/lib/src/presentation/map/trufi_map.dart
@@ -282,6 +282,13 @@ class _TrufiMapState extends State<TrufiMap> implements TrufiMapDelegate {
       _suppressCameraCallback = false;
       return;
     }
+    // A controlled camera is waiting for the style to load. The idle events
+    // the native map emits meanwhile describe its initial position (Android
+    // fires one before the style has loaded), not a move anyone asked for:
+    // recording it as the current camera would turn the replay in
+    // onStyleLoadedCallback into an "already there" no-op and silently drop
+    // the camera the parent set (#995).
+    if (_pendingCameraApply) return;
     final ctl = _mapCtl;
     if (ctl == null) return;
     final cam = ctl.cameraPosition;

--- a/packages/trufi_core_maps/test/trufi_map_idle_guard_test.dart
+++ b/packages/trufi_core_maps/test/trufi_map_idle_guard_test.dart
@@ -1,0 +1,270 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart' as latlng;
+import 'package:maplibre_gl/maplibre_gl.dart';
+import 'package:trufi_core_maps/trufi_core_maps.dart' hide LatLngBounds;
+
+/// #995 / #946: a controlled camera set before the map's style has loaded is
+/// held and replayed on `onStyleLoaded`. Android fires a `camera#onIdle` for
+/// the initial position before the style is ready; recording it as the
+/// current camera turned that replay into an "already there" no-op.
+///
+/// Drives the real [TrufiMap] over a fake [MapLibrePlatform] (the plugin's
+/// `MapLibrePlatform.createInstance` seam, no platform view) and plays the
+/// native event order by hand: `onCameraIdlePlatform` is `camera#onIdle`,
+/// `onMapStyleLoadedPlatform` is `map#onStyleLoaded`.
+class _FakePlatform extends MapLibrePlatform {
+  bool _created = false;
+  final moves = <CameraPosition>[];
+  final visible = LatLngBounds(
+    southwest: const LatLng(15.30, 44.15),
+    northeast: const LatLng(15.40, 44.25),
+  );
+
+  @override
+  Widget buildView(
+    Map<String, dynamic> creationParams,
+    OnPlatformViewCreatedCallback onPlatformViewCreated,
+    Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers,
+  ) {
+    // Exactly once: a second call would complete the plugin's controller
+    // future twice and attach duplicate controllers.
+    if (!_created) {
+      _created = true;
+      scheduleMicrotask(() => onPlatformViewCreated(0));
+    }
+    return const SizedBox.expand();
+  }
+
+  @override
+  Future<void> initPlatform(int id) async {}
+
+  @override
+  Future<bool?> moveCamera(CameraUpdate cameraUpdate) async {
+    final json = cameraUpdate.toJson() as List<dynamic>;
+    if (json.first != 'newCameraPosition') {
+      throw StateError('unexpected camera update $json');
+    }
+    final map = json[1] as Map<String, dynamic>;
+    final target = map['target'] as List<dynamic>;
+    moves.add(
+      CameraPosition(
+        target: LatLng(
+          (target[0] as num).toDouble(),
+          (target[1] as num).toDouble(),
+        ),
+        zoom: (map['zoom'] as num).toDouble(),
+        bearing: (map['bearing'] as num).toDouble(),
+        tilt: (map['tilt'] as num).toDouble(),
+      ),
+    );
+    return true;
+  }
+
+  @override
+  Future<LatLngBounds> getVisibleRegion() async => visible;
+
+  @override
+  Future<CameraPosition?> updateMapOptions(
+    Map<String, dynamic> optionsUpdate,
+  ) async => null;
+
+  // Every other platform call made while syncing layers or initialising the
+  // annotation managers returns a completed Future<void>.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => Future<void>.value();
+}
+
+const _initial = TrufiCameraPosition(
+  target: latlng.LatLng(15.347, 44.205),
+  zoom: 14,
+);
+// TrufiMap converts Leaflet zoom levels to MapLibre ones (one level apart).
+const _initialNative = CameraPosition(target: LatLng(15.347, 44.205), zoom: 13);
+const _fitted = TrufiCameraPosition(
+  target: latlng.LatLng(15.3244, 44.2205),
+  zoom: 12.31,
+);
+const _fittedNative = CameraPosition(
+  target: LatLng(15.3244, 44.2205),
+  zoom: 11.31,
+);
+const _panned = CameraPosition(target: LatLng(15.30, 44.26), zoom: 15.5);
+
+class _Harness {
+  _Harness(this.tester) {
+    MapLibrePlatform.createInstance = () => platform;
+  }
+
+  final WidgetTester tester;
+  final platform = _FakePlatform();
+  final reports = <TrufiCameraPosition>[];
+
+  Widget _build(TrufiCameraPosition? camera) => MaterialApp(
+    home: TrufiMap(
+      styleString: 'asset://style.json',
+      initialCamera: _initial,
+      camera: camera,
+      onCameraChanged: reports.add,
+    ),
+  );
+
+  Future<void> mount() async {
+    await tester.pumpWidget(_build(null));
+    await tester.pump(); // platform view "created" → controller handed over
+  }
+
+  Future<void> setControlledCamera(TrufiCameraPosition camera) async {
+    await tester.pumpWidget(_build(camera));
+  }
+
+  /// camera#onIdle from the native side.
+  Future<void> nativeIdle(CameraPosition position) async {
+    platform.onCameraIdlePlatform(position);
+    await tester.pump();
+    await tester.pump();
+  }
+
+  /// map#onStyleLoaded from the native side.
+  Future<void> styleLoaded() async {
+    platform.onMapStyleLoadedPlatform(null);
+    await tester.pumpAndSettle();
+    // TrufiMap schedules a 1 s retry of the layer sync after the style load.
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+  }
+}
+
+void main() {
+  tearDown(() {
+    MapLibrePlatform.createInstance = () => MapLibreMethodChannel();
+  });
+
+  group('TrufiMap controlled camera vs the pre-style camera idle', () {
+    testWidgets('#995 order: controlled camera → initial idle → style loaded: '
+        'the idle is ignored and the camera is replayed on style load', (
+      tester,
+    ) async {
+      final h = _Harness(tester);
+      await h.mount();
+      await h.setControlledCamera(_fitted);
+      expect(h.platform.moves, isEmpty, reason: 'style not loaded yet');
+
+      // Android: camera#onIdle for the initial position before the style.
+      await h.nativeIdle(_initialNative);
+      expect(
+        h.reports,
+        isEmpty,
+        reason:
+            'the initial idle must not be reported while a controlled '
+            'camera is pending (it would also overwrite the pending camera)',
+      );
+
+      await h.styleLoaded();
+      expect(h.platform.moves, hasLength(1), reason: 'replay on style load');
+      final move = h.platform.moves.single;
+      expect(
+        move.target.latitude,
+        closeTo(_fittedNative.target.latitude, 1e-9),
+      );
+      expect(
+        move.target.longitude,
+        closeTo(_fittedNative.target.longitude, 1e-9),
+      );
+      expect(move.zoom, closeTo(_fittedNative.zoom, 1e-9));
+
+      // The idle produced by that programmatic move is swallowed (callback
+      // suppression, as on the normal path)…
+      await h.nativeIdle(_fittedNative);
+      expect(h.reports, isEmpty);
+      // …and the guard is not stuck: the next gesture is reported.
+      await h.nativeIdle(_panned);
+      expect(h.reports, hasLength(1));
+      expect(h.reports.single.target.latitude, closeTo(15.30, 1e-9));
+      expect(h.reports.single.zoom, closeTo(16.5, 1e-9)); // 15.5 + 1
+    });
+
+    testWidgets('#946 order: initial idle → controlled camera → style loaded: '
+        'still replayed (unchanged)', (tester) async {
+      final h = _Harness(tester);
+      await h.mount();
+      await h.nativeIdle(_initialNative);
+      expect(h.reports, hasLength(1), reason: 'nothing pending: reported');
+
+      await h.setControlledCamera(_fitted);
+      await h.styleLoaded();
+      expect(h.platform.moves, hasLength(1));
+      expect(h.platform.moves.single.zoom, closeTo(_fittedNative.zoom, 1e-9));
+    });
+
+    testWidgets(
+      'a pan during the style load loses against the pending controlled '
+      'camera (documented semantics of the guard)',
+      (tester) async {
+        final h = _Harness(tester);
+        await h.mount();
+        await h.setControlledCamera(_fitted);
+        await h.nativeIdle(_initialNative);
+        await h.nativeIdle(_panned); // user pans the blank map
+        expect(h.reports, isEmpty);
+
+        await h.styleLoaded();
+        expect(h.platform.moves, hasLength(1));
+        expect(h.platform.moves.single.zoom, closeTo(_fittedNative.zoom, 1e-9));
+      },
+    );
+
+    testWidgets(
+      'pending camera and the map already there (user panned to it during '
+      'the style load): no move, no suppression, the next gesture is reported',
+      (tester) async {
+        final h = _Harness(tester);
+        await h.mount();
+        await h.setControlledCamera(_fitted);
+        await h.nativeIdle(_initialNative);
+        await h.nativeIdle(_fittedNative); // the user happens to pan there
+        expect(h.reports, isEmpty);
+        await h.styleLoaded();
+        expect(h.platform.moves, isEmpty, reason: 'already there');
+
+        await h.nativeIdle(_panned);
+        expect(h.reports, hasLength(1), reason: 'no suppression armed');
+      },
+    );
+
+    testWidgets(
+      'no controlled camera: idles are reported before and after the style '
+      'load (the guard is inert)',
+      (tester) async {
+        final h = _Harness(tester);
+        await h.mount();
+        await h.nativeIdle(_initialNative);
+        await h.styleLoaded();
+        await h.nativeIdle(_panned);
+        expect(h.reports, hasLength(2));
+        expect(h.platform.moves, isEmpty);
+      },
+    );
+
+    testWidgets(
+      'a controlled camera set AFTER the style loaded moves immediately and '
+      'its own idle is swallowed',
+      (tester) async {
+        final h = _Harness(tester);
+        await h.mount();
+        await h.nativeIdle(_initialNative);
+        await h.styleLoaded();
+        await h.setControlledCamera(_fitted);
+        expect(h.platform.moves, hasLength(1));
+        await h.nativeIdle(_fittedNative);
+        expect(h.reports, hasLength(1), reason: 'only the first idle');
+        await h.nativeIdle(_panned);
+        expect(h.reports, hasLength(2));
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #995. On a cold start with a plan from the previous session the home screen restored the itinerary panel but the map stayed at the default city view. The route **was** on the map — `TrufiMap` synchronised the polyline and marker layers as soon as its style loaded — but the camera never fitted it, and the university trip of trufi-sanaa#2 lies entirely outside Sana'a's default viewport (centre 15.347/44.205, zoom 14), so the screen looked empty. Two swipes south on the "empty" map showed the "14" line and its badge.

The issue title says "no polyline, no markers"; the instrumented run shows both layers were synced to the native map (`route-lines-layer` 4 lines, `route-markers-layer` 8 markers, including the origin/destination markers) — the only missing piece was the camera fit. The issue title and body should be read as "the restored route is drawn outside the default viewport and the camera does not fit it".

## Root cause (timeline from an instrumented profile build of the Sana'a app, Android 16)

```
09.129  first frame: _viewportReady = true, no pending fit points
09.132  RoutePlannerCubit.initialize → plan restored (4 legs, 167 points) → listener → route layers built
09.132  _fitCameraToPoints: _currentCamera == null → return           ← fit dropped
09.581  native camera idle for the initial position (before the style)
09.597  first onCameraChanged (default centre), pendingFit = 167       ← nothing replays the fit
09.754  onStyleLoaded → layers synced (route-lines-layer 4 lines, route-markers-layer 8 markers)
```

- `_fitCameraToPoints` returned early when the map had not reported a camera yet (`_currentCamera` is only set by `onCameraChanged` / `_moveCameraTracked`). On a cold start the restore lands ~3 ms after the first frame and ~465 ms before the map's first camera report.
- The only replay of `_pendingFitPoints` runs once, in the first `LayoutBuilder` build — 3 ms *before* the restore, with nothing to replay — and never again. A fresh search never hits this because the user searches after the map has reported its camera.
- The #946 replay in `TrufiMap` could not help: no controlled camera was ever produced.
- The JSON round trip is not involved: the local planner stores `encodedPoints` on every leg and the restored legs decode to their full geometry (checked in the log and pinned by the tests).

## Fix

- **`home_screen.dart` — `_fitCameraToPoints`**: use `_initialCamera` as the base camera while the map has not reported one. `FitCameraUtil.cameraForPoints` takes only the bearing from the base camera (`TrufiCameraPosition` has no tilt, and the base zoom cancels out of the fit maths: target and zoom come from the points and the viewport, known since the first frame), so the fit is computed as soon as the plan is there and reaches `TrufiMap` as a controlled camera — reusing the #946 mechanism, which holds it until the style has loaded. No new replay path, no waiting on events.
- **`trufi_map.dart` — `_handleCameraIdle`**: ignore camera-idle events while a controlled camera is pending for the style load. Android fires `camera#onIdle` for the initial position before `onStyleLoaded` (registered in `onMapReady`, before `setStyle`); without this guard that idle overwrote `_currentCamera` with the default centre and the replay in `onStyleLoadedCallback` became an "already there" no-op — the fit would have been lost a second way. This closes a gap in #946 for any controlled camera set before the style loads; a pan made during the (sub-second) style load is overridden by the requested camera, which is what a controlled camera means.
- **`home_screen.dart` — `_moveCameraTracked`** (found in review): drop `_cameraTarget` when the camera is moved programmatically (my-location). The map suppresses its callback for programmatic moves, so `_onCameraChanged` never cleared the driven camera and the next rebuild (a GPS tick, the keyboard, a rotation) handed the route fit back to the map, snapping the view away from the user's location. Pre-existing on the fresh-search path (search → my-location without panning first); with the restored fit it would have hit the first my-location tap of every cold start, and it also defeated #950 (an engine switch after my-location would have reopened on the route).

The fresh-search path is unchanged: with a reported camera the code takes exactly the branch it took before. Clearing the plan still clears layers and camera together (`_updateRouteOnMap(null)` / `_updateFitCameraPoints`).

Stale plans are drawn as-is and fitted, as before this PR nothing re-planned or dropped a restored plan; a "from the previous session / re-plan" hint would be a product follow-up, not part of this bug.

## Tests (Flutter 3.44.1, the CI version)

`trufi_core_home_screen` **39/39** (31 before this PR), `trufi_core_maps` **56/56** (50 before), `flutter analyze` clean in both packages apart from a pre-existing info in an untouched file.

`test/restored_plan_map_test.dart` (+8, `trufi_core_home_screen`) drives the **real `HomeScreen`** over a fake map engine that records the `layers` / `camera` / `initialCamera` it is handed and can play the map's camera report; the repository stores JSON like the real one:

- restored **after the first frame and before any camera report** (the device timeline): 4 lines, start/end/transit-label/boarding/alighting markers, camera fitted inside the trip's bounding box, zoomed out from 14, bearing kept at 0;
- restored **before the screen exists** (state already set when the `BlocConsumer` subscribes — the `needsRouteRender` fallback);
- wide layout (side panel) fits too;
- the map reporting the fitted camera afterwards: the screen releases the controlled camera (a later rebuild hands none) and the map keeps the fitted view;
- `clearPlan()` removes lines and markers, drops the camera target and leaves the origin/destination previews;
- **my-location after the fit**: a real tap on the my-location button over a mocked geolocator (tracking auto-started), then a rebuild — the map stays on the user and the screen hands no camera back;
- panning away shows the recentre button; fitting another itinerary hides it again;
- fresh search after the map reported its camera draws and fits (unchanged).

The same file on `main`: ****7 of the 8 fail** (every restore-based scenario — `camera` is null, so the my-location and recentre steps never get a fit either); the fresh-search guard passes**. Each guard has a mutation check: dropping the `_cameraTarget = null` line of `_moveCameraTracked` fails exactly the my-location test (`+38 −1`); reverting `_handleCameraIdle` to `main` leaves this suite green and fails exactly 3 of the 6 tests below (`+53 −3` in `trufi_core_maps`).

`test/trufi_map_idle_guard_test.dart` (+6, `trufi_core_maps`) drives the **real `TrufiMap`** over a fake `MapLibrePlatform` (the plugin's `MapLibrePlatform.createInstance` seam, no platform view) and plays the native event order by hand: controlled camera → initial `camera#onIdle` → `map#onStyleLoaded`. On `main` 3 of the 6 fail (the initial idle is reported and the replay becomes a no-op). The other three pin what must not change: the #946 order (idle → camera → style), an inert guard without a controlled camera, and a controlled camera set after the style (immediate move, own idle swallowed, next gesture reported).

## Emulator (Sana'a app, Android 16 arm64, profile builds, `dependency_overrides` to `main` `61eac621` and to this branch)

Sequence in both builds: deep link of the university trip (route drawn) → force-stop → cold start with data kept → screenshots at 3 s and 15 s.

| | after the deep link (fresh path) | cold start + 3 s | + 15 s |
|---|---|---|---|
| `main` | route drawn | panel "1 route found · 57 min" restored, map at the default centre, no route in view | identical bytes |
| this branch | route drawn | panel restored, **route drawn and camera fitted** (7 → 14, origin and destination markers) | identical bytes |

On the branch, additionally: rotate to landscape (wide layout, side panel) → route still fitted in the map area; back to portrait → kept; tap the panel's ✕ → route and markers gone together with the panel; cold start after that → nothing restored, default view. 0 crash lines in logcat across all runs.

**My-location snap-back (the `_moveCameraTracked` fix), same emulator, restored plan on both builds**: cold start with the restored plan → a GPS fix delivered → tap the my-location button → 2 s later a screenshot → one more GPS fix (a `HomeScreen` rebuild) → 5 s later a screenshot. On `a7ba58be` the map is on the user (zoom 16) at 2 s and **back on the fitted route** at 5 s; with the fix it is on the user at 2 s and **still on the user** at 5 s (the dot moved with the new fix, so the tick was delivered). 0 crash lines.

| `a7ba58be` — 2 s after my-location | `a7ba58be` — 5 s later, after a GPS tick: snapped back to the route | this branch — 2 s after my-location | this branch — 5 s later, after a GPS tick: stays on the user |
|---|---|---|---|
| <img src="https://raw.githubusercontent.com/trufi-association/trufi-core/759d9f48a3ebbf4f3fdc07a49a136eb1dd7b4e7d/pr-996/12-before-a7ba58be-restored-then-mylocation-2s.png" width="180"> | <img src="https://raw.githubusercontent.com/trufi-association/trufi-core/759d9f48a3ebbf4f3fdc07a49a136eb1dd7b4e7d/pr-996/13-before-a7ba58be-mylocation-plus-gps-tick-5s-snapped-back-to-route.png" width="180"> | <img src="https://raw.githubusercontent.com/trufi-association/trufi-core/759d9f48a3ebbf4f3fdc07a49a136eb1dd7b4e7d/pr-996/14-after-fix-restored-then-mylocation-2s.png" width="180"> | <img src="https://raw.githubusercontent.com/trufi-association/trufi-core/759d9f48a3ebbf4f3fdc07a49a136eb1dd7b4e7d/pr-996/15-after-fix-mylocation-plus-gps-tick-5s-stays-on-user.png" width="180"> |

| `main` — cold start + 15 s (panel restored, map at the default centre) | `main` — same screen after panning south: the route was there, off-screen | this branch — cold start + 3 s: restored route drawn and fitted |
|---|---|---|
| <img src="https://raw.githubusercontent.com/trufi-association/trufi-core/0183d306ed2d2b72da866561a9ff04da96b708c8/pr-996/03-before-main-coldstart-15s-unchanged.png" width="240"> | <img src="https://raw.githubusercontent.com/trufi-association/trufi-core/0183d306ed2d2b72da866561a9ff04da96b708c8/pr-996/04-main-instrumented-pan-south-route-was-offscreen.png" width="240"> | <img src="https://raw.githubusercontent.com/trufi-association/trufi-core/0183d306ed2d2b72da866561a9ff04da96b708c8/pr-996/06-after-fix-coldstart-3s-restored-route-fitted.png" width="240"> |

The full set (deep link on both builds, 15 s, rotation, clearing, cold start after clearing) is in the review comment.

## Notes for the reviewer

- `home_screen.dart` changes 4 lines of logic plus two doc comments (`_fitCameraToPoints`, `_moveCameraTracked`); #991 (open) touches the same file only around the POI panel (`_buildPOIDetailPanel`, imports) — no overlapping hunks, either can merge first.
- `_currentCamera` in `HomeScreen` stays null until the map's first report, as before; `_buildMap` already starts a rebuilt map (engine or theme switch) from `camera: _cameraTarget`, which after this PR is the fitted camera, so the view survives an engine switch; the rotation check above exercises a rebuild of the same map, not an engine switch.
- `dart format` on `trufi_map.dart` would reflow lines `main` never formatted; only the touched lines are formatted, as in previous PRs.
